### PR TITLE
Implement plot deletion and toast notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>Działkofert - Dodaj darmowe ogłoszenie</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.8.0/proj4.js"></script>
   
       <!-- Favicon dla przeglądarek -->
@@ -377,6 +379,7 @@
 
 
 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <!-- Firebase + logika aplikacji -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
@@ -387,7 +390,7 @@
       setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
     import {
-      getFirestore, collection, query, where, getDocs, doc, setDoc
+      getFirestore, collection, query, where, getDocs, doc, setDoc, getDoc, deleteDoc
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
     // --- Konfiguracja ---
@@ -405,6 +408,47 @@
     const auth = getAuth(app);
     const db   = getFirestore(app);
     auth.languageCode = 'pl';
+
+    function ensureToastContainer() {
+      let cont = document.querySelector('.toast-container');
+      if (!cont) {
+        cont = document.createElement('div');
+        cont.className = 'toast-container position-fixed top-0 end-0 p-3';
+        cont.style.zIndex = '1100';
+        document.body.appendChild(cont);
+      }
+      return cont;
+    }
+
+    function showToast(message, type = 'info') {
+      const cont = ensureToastContainer();
+
+      let bgClass = 'bg-primary';
+      if (type === 'success') bgClass = 'bg-success';
+      if (type === 'warning') bgClass = 'bg-warning text-dark';
+      if (type === 'error')   bgClass = 'bg-danger';
+
+      const wrapper = document.createElement('div');
+      wrapper.className = `toast align-items-center text-white ${bgClass} border-0`;
+      wrapper.setAttribute('role', 'alert');
+      wrapper.setAttribute('aria-live', 'assertive');
+      wrapper.setAttribute('aria-atomic', 'true');
+
+      wrapper.innerHTML = `
+        <div class="d-flex">
+          <div class="toast-body">${message}</div>
+          <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
+        </div>
+      `;
+
+      cont.appendChild(wrapper);
+
+      const bsToast = new bootstrap.Toast(wrapper, { delay: 4000 });
+      bsToast.show();
+      wrapper.addEventListener('hidden.bs.toast', () => wrapper.remove());
+    }
+
+    window.showToast = showToast;
 
     // Persystencja
     async function useBestPersistence() {
@@ -711,6 +755,38 @@
         userOffers.innerHTML = '<p>Wystąpił błąd podczas ładowania ofert.</p>';
       }
     }
+
+    async function deletePlot(offerId, plotIndex, title) {
+      if (!confirm(`Czy na pewno chcesz usunąć działkę "${title}"?`)) return;
+      try {
+        const offerRef = doc(db, 'propertyListings', offerId);
+        const snap = await getDoc(offerRef);
+        if (!snap.exists()) {
+          showToast('Ogłoszenie nie istnieje.', 'error');
+          return;
+        }
+        const data = snap.data();
+        if (!Array.isArray(data.plots)) {
+          showToast('Brak działek do usunięcia.', 'error');
+          return;
+        }
+        const plots = data.plots;
+        plots.splice(plotIndex, 1);
+        if (plots.length === 0) {
+          await deleteDoc(offerRef);
+        } else {
+          await setDoc(offerRef, { plots }, { merge: true });
+        }
+        showToast('Działka usunięta', 'success');
+        if (auth.currentUser) {
+          loadUserOffers(auth.currentUser.email || null, auth.currentUser.uid || null);
+        }
+      } catch (err) {
+        console.error('deletePlot', err);
+        showToast('Nie udało się usunąć działki.', 'error');
+      }
+    }
+    window.deletePlot = deletePlot;
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Bootstrap assets and toast helpers
- implement global `deletePlot` for removing plots from Firestore with toast feedback

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5622d28ac832b906b21d7c2ba634d