### PR TITLE
Expose getDoc globally in offers page

### DIFF
--- a/oferty.html
+++ b/oferty.html
@@ -1073,6 +1073,7 @@ async function loadUserOffers(email, uid) {
   window.where = where;
   window.doc       = doc;
   window.updateDoc = updateDoc;
+  window.getDoc    = getDoc;
 </script>
 
 


### PR DESCRIPTION
## Summary
- Fix delete function failing by exporting Firestore `getDoc` to the global window scope on `oferty.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e4a7636c832ba4024cc0c1b208d4