### PR TITLE
Add custom confirmation modal for plot deletion

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -197,6 +197,8 @@
   padding:16px;
 }
 
+.confirm-modal.show { display:flex; }
+
 .confirm-box {
   width:100%;
   max-width:420px;

--- a/index.html
+++ b/index.html
@@ -112,6 +112,17 @@
   </header>
 <!-- Toasts -->
 <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
+<!-- Confirm Modal -->
+<div class="confirm-modal" id="confirmModal" role="dialog" aria-modal="true">
+  <div class="confirm-box">
+    <h3 class="confirm-title">Potwierdzenie</h3>
+    <p class="confirm-message"></p>
+    <div class="confirm-actions">
+      <button class="confirm-btn confirm-cancel">Anuluj</button>
+      <button class="confirm-btn confirm-yes">Usuń</button>
+    </div>
+  </div>
+</div>
 <script>
 /* ===== UI: TOAST (vanilla) =====
    showToast('Oferta „...” została usunięta.', 'success')
@@ -151,6 +162,38 @@ function showToast(message, type = 'info') {
   const t = setTimeout(close, 4000);
   wrap.addEventListener('mouseenter', () => clearTimeout(t), { once: true });
 }
+</script>
+
+<!-- Confirm Modal Script -->
+<script>
+function showConfirmModal(message) {
+  return new Promise(resolve => {
+    const modal = document.getElementById('confirmModal');
+    if (!modal) return resolve(false);
+
+    modal.querySelector('.confirm-message').textContent = message;
+    modal.classList.add('show');
+
+    const yesBtn = modal.querySelector('.confirm-yes');
+    const cancelBtn = modal.querySelector('.confirm-cancel');
+
+    const cleanup = () => {
+      modal.classList.remove('show');
+      yesBtn.removeEventListener('click', onYes);
+      cancelBtn.removeEventListener('click', onCancel);
+      modal.removeEventListener('click', onOutside);
+    };
+
+    const onYes = () => { cleanup(); resolve(true); };
+    const onCancel = () => { cleanup(); resolve(false); };
+    const onOutside = (e) => { if (e.target === modal) { cleanup(); resolve(false); } };
+
+    yesBtn.addEventListener('click', onYes, { once: true });
+    cancelBtn.addEventListener('click', onCancel, { once: true });
+    modal.addEventListener('click', onOutside, { once: true });
+  });
+}
+window.showConfirmModal = showConfirmModal;
 </script>
 
   <!-- Skrypt: menu mobilne (toggle + zamykanie przy zmianie rozmiaru) -->
@@ -755,7 +798,7 @@ function showToast(message, type = 'info') {
       }
     }
     async function deletePlot(offerId, plotIndex, title) {
-      if (!confirm(`Czy na pewno chcesz usunąć działkę "${title}"?`)) return;
+      if (!(await showConfirmModal(`Czy na pewno chcesz usunąć działkę "${title}"?`))) return;
       try {
         const offerRef = doc(db, 'propertyListings', offerId);
         const snap = await getDoc(offerRef);

--- a/oferty.html
+++ b/oferty.html
@@ -89,6 +89,17 @@
 
 <!-- Toasts -->
 <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
+<!-- Confirm Modal -->
+<div class="confirm-modal" id="confirmModal" role="dialog" aria-modal="true">
+  <div class="confirm-box">
+    <h3 class="confirm-title">Potwierdzenie</h3>
+    <p class="confirm-message"></p>
+    <div class="confirm-actions">
+      <button class="confirm-btn confirm-cancel">Anuluj</button>
+      <button class="confirm-btn confirm-yes">Usuń</button>
+    </div>
+  </div>
+</div>
 <script>
 /* ===== UI: TOAST (vanilla) =====
    showToast('Oferta „...” została usunięta.', 'success')
@@ -133,6 +144,38 @@ function showToast(message, type = 'info') {
   // jeśli użytkownik najedzie, nie chowaj
   wrap.addEventListener('mouseenter', () => clearTimeout(t), { once: true });
 }
+</script>
+
+<!-- Confirm Modal Script -->
+<script>
+function showConfirmModal(message) {
+  return new Promise(resolve => {
+    const modal = document.getElementById('confirmModal');
+    if (!modal) return resolve(false);
+
+    modal.querySelector('.confirm-message').textContent = message;
+    modal.classList.add('show');
+
+    const yesBtn = modal.querySelector('.confirm-yes');
+    const cancelBtn = modal.querySelector('.confirm-cancel');
+
+    const cleanup = () => {
+      modal.classList.remove('show');
+      yesBtn.removeEventListener('click', onYes);
+      cancelBtn.removeEventListener('click', onCancel);
+      modal.removeEventListener('click', onOutside);
+    };
+
+    const onYes = () => { cleanup(); resolve(true); };
+    const onCancel = () => { cleanup(); resolve(false); };
+    const onOutside = (e) => { if (e.target === modal) { cleanup(); resolve(false); } };
+
+    yesBtn.addEventListener('click', onYes, { once: true });
+    cancelBtn.addEventListener('click', onCancel, { once: true });
+    modal.addEventListener('click', onOutside, { once: true });
+  });
+}
+window.showConfirmModal = showConfirmModal;
 </script>
 
 
@@ -958,7 +1001,7 @@ async function loadUserOffers(email, uid) {
 }
 
 async function deletePlot(offerId, plotIndex, title) {
-  if (!confirm(`Czy na pewno chcesz usunąć działkę "${title}"?`)) return;
+  if (!(await showConfirmModal(`Czy na pewno chcesz usunąć działkę "${title}"?`))) return;
   try {
     const offerRef = doc(db, 'propertyListings', offerId);
     const snap = await getDoc(offerRef);


### PR DESCRIPTION
## Summary
- add reusable confirm modal markup and script for plot deletion
- replace native confirm with styled modal on index and oferty pages
- support confirm modal display with new CSS rule

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fc741bb8832b9ff0a3233a68f23d