### PR TITLE
Show full nickname after login on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@ window.showConfirmModal = showConfirmModal;
         authButtons && (authButtons.style.display = 'none');
         userMenu    && (userMenu.style.display = 'flex');
         if (accountBtn) {
-          const label = user.displayName ? user.displayName.split(' ')[0] : (user.email || 'Moje konto');
+          const label = user.displayName || user.email || 'Moje konto';
           accountBtn.innerHTML = `<i class="fas fa-user me-1"></i> ${label}`;
         }
         userDashboard && (userDashboard.style.display = 'block');


### PR DESCRIPTION
## Summary
- Display full `displayName` or email in the account button on index page after user login.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c70d3645c8832b8e91371c73ad50db