### PR TITLE
Remove footer from offers page and fix user offers layout

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -35,7 +35,6 @@
   box-shadow:0 4px 10px rgba(0,0,0,0.1);
   padding:20px;
   margin-bottom:20px;
-  height:800px;
 }
 
 .offers-section .section-title { margin-bottom:1rem; }
@@ -43,8 +42,9 @@
 
 .offers-list,
 .offers-grid {
-  max-height:800px;
-  overflow-y:auto;
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
 }
 
 .user-dashboard {

--- a/oferty.html
+++ b/oferty.html
@@ -320,43 +320,6 @@ window.showConfirmModal = showConfirmModal;
       </form>
     </div>
   </div>
-
-
-<footer id="contact">
-  <div class="container">
-    <div class="footer-container">
-      <div class="footer-about">
-        <a href="index.html" class="footer-logo">
-          <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Dzialkofert_logo.png" alt="Działkofert">
-          <span>Działkofert</span>
-        </a>
-        <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
-      </div>
-
-      <div class="footer-links">
-        <h3>Przydatne linki</h3>
-        <ul>
-          <li><a href="index.html">Strona główna</a></li>
-          <li><a href="oferty.html">Oferty</a></li>
-          <li><a href="dodaj.html">Dodaj ofertę</a></li>
-          <li><a href="#contact">Kontakt</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-contact">
-        <h3>Kontakt</h3>
-        <p><i class="fas fa-envelope"></i> info@dzialkofert.pl</p>
-        <p><i class="fas fa-phone"></i> +48 123 456 789</p>
-      </div>
-    </div>
-
-    <div class="footer-bottom">
-      © 2025 Działkofert. Wszelkie prawa zastrzeżone.
-    </div>
-  </div>
-</footer>
-
-
   <!-- Firebase -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js";


### PR DESCRIPTION
## Summary
- remove footer from `oferty.html`
- adjust offers layout to prevent offer cards overlapping "Moje Oferty"

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7286a2eb0832bb102ca8edb9f08b3