### PR TITLE
Format phone numbers and adjust map info popup

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -165,7 +165,7 @@
 .map-info-window { font-size:.95rem; max-width:320px; }
 .map-info-window h3 { font-size:1.05rem; margin:0 0 .4rem; }
 .map-info-window p { margin:.2rem 0; font-size:.9rem; }
-.map-info-window .mini-actions { margin-top:.55rem; display:flex; gap:.5rem; }
+.map-info-window .mini-actions { margin-top:.55rem; display:flex; gap:.5rem; justify-content:center; }
 .map-info-window .btn-mini {
   display:inline-block;
   padding:.35rem .6rem;
@@ -177,6 +177,9 @@
   cursor:pointer;
   text-decoration:none;
 }
+
+/* zmniejszony przycisk zamknięcia w oknie mapy */
+.gm-ui-hover-effect { transform:scale(.8) !important; }
 
 @media (max-width:768px){
   .map-info-window { font-size:.9rem; max-width:260px; }

--- a/oferty.html
+++ b/oferty.html
@@ -364,12 +364,21 @@ window.showConfirmModal = showConfirmModal;
   window.infoWin = null;
 
   // ====== HELPERS ======
+  function formatPhone(phone) {
+    const digits = String(phone || "").replace(/\D/g, "");
+    const core = digits.length >= 9 ? digits.slice(-9) : digits;
+    if (core.length === 9) {
+      return `+48 ${core.slice(0,3)}-${core.slice(3,6)}-${core.slice(6)}`;
+    }
+    return "";
+  }
+
   function infoHTML(plot, data, offerId, plotIndex) {
     const price = Number(plot.price || 0);
     const area  = Number(plot.pow_dzialki_m2_uldk || 0);
     const ppm2  = price && area ? (price/area).toFixed(0) : null;
     const city  = data.city || "brak";
-    const phone = data.phone || "brak";
+    const phone = formatPhone(data.phone);
     const detailsUrl = `oferta.html?id=${offerId}&plot=${plotIndex}`;
 
     return `
@@ -378,7 +387,7 @@ window.showConfirmModal = showConfirmModal;
         <p><b>Miejscowość:</b> ${city}</p>
         ${price ? `<p><b>Cena:</b> ${price.toLocaleString('pl-PL')} zł${ppm2 ? ` <span style="color:#718096;">(${ppm2} zł/m²)</span>` : ''}</p>` : ''}
         ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
-        <p><b>Telefon:</b> ${phone}</p>
+        <p><b>Telefon:</b> ${phone || 'brak'}</p>
         <div class="mini-actions center">
           <a class="btn-mini" target="_blank" href="${detailsUrl}">Szczegóły</a>
         </div>
@@ -544,7 +553,7 @@ window.showConfirmModal = showConfirmModal;
       card.innerHTML = `
         <h5>${o.plot.Id || "Brak identyfikatora"}</h5>
         ${o.data.city ? `<p><b>Miejscowość:</b> ${o.data.city}</p>` : ""}
-        <p><b>Telefon:</b> ${o.data.phone || "-"}</p>
+        <p><b>Telefon:</b> ${formatPhone(o.data.phone) || "-"}</p>
         ${price ? `<p><b>Cena całkowita:</b> ${price.toLocaleString('pl-PL')} zł <span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2} zł/m²</span></p>` : ""}
         ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ""}
         <div class="offer-actions center">


### PR DESCRIPTION
## Summary
- normalize phone numbers in map popups and offer list
- center the "Szczegóły" button and shrink the popup close icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c72be0d5fc832b87b6bda7ec60e3e0