### PR TITLE
Display contact name in offer listings

### DIFF
--- a/oferty.html
+++ b/oferty.html
@@ -387,7 +387,7 @@ window.showConfirmModal = showConfirmModal;
         <p><b>Miejscowość:</b> ${city}</p>
         ${price ? `<p><b>Cena:</b> ${price.toLocaleString('pl-PL')} zł${ppm2 ? ` <span style="color:#718096;">(${ppm2} zł/m²)</span>` : ''}</p>` : ''}
         ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
-        ${data.firstName ? `<p>${data.firstName}</p>` : ''}
+        ${data.firstName ? `<p><b>Imię:</b> ${data.firstName}</p>` : ''}
         <p><b>Telefon:</b> ${phone || 'brak'}</p>
         <div class="mini-actions center">
           <a class="btn-mini" target="_blank" href="${detailsUrl}">Szczegóły</a>
@@ -554,7 +554,7 @@ window.showConfirmModal = showConfirmModal;
       card.innerHTML = `
         <h5>${o.plot.Id || "Brak identyfikatora"}</h5>
         ${o.data.city ? `<p><b>Miejscowość:</b> ${o.data.city}</p>` : ""}
-        ${o.data.firstName ? `<p>${o.data.firstName}</p>` : ""}
+        ${o.data.firstName ? `<p><b>Imię:</b> ${o.data.firstName}</p>` : ""}
         <p><b>Telefon:</b> ${formatPhone(o.data.phone) || "-"}</p>
         ${price ? `<p><b>Cena całkowita:</b> ${price.toLocaleString('pl-PL')} zł <span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2} zł/m²</span></p>` : ""}
         ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ""}

--- a/oferty.html
+++ b/oferty.html
@@ -387,6 +387,7 @@ window.showConfirmModal = showConfirmModal;
         <p><b>Miejscowość:</b> ${city}</p>
         ${price ? `<p><b>Cena:</b> ${price.toLocaleString('pl-PL')} zł${ppm2 ? ` <span style="color:#718096;">(${ppm2} zł/m²)</span>` : ''}</p>` : ''}
         ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
+        ${data.firstName ? `<p>${data.firstName}</p>` : ''}
         <p><b>Telefon:</b> ${phone || 'brak'}</p>
         <div class="mini-actions center">
           <a class="btn-mini" target="_blank" href="${detailsUrl}">Szczegóły</a>
@@ -553,6 +554,7 @@ window.showConfirmModal = showConfirmModal;
       card.innerHTML = `
         <h5>${o.plot.Id || "Brak identyfikatora"}</h5>
         ${o.data.city ? `<p><b>Miejscowość:</b> ${o.data.city}</p>` : ""}
+        ${o.data.firstName ? `<p>${o.data.firstName}</p>` : ""}
         <p><b>Telefon:</b> ${formatPhone(o.data.phone) || "-"}</p>
         ${price ? `<p><b>Cena całkowita:</b> ${price.toLocaleString('pl-PL')} zł <span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2} zł/m²</span></p>` : ""}
         ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ""}


### PR DESCRIPTION
## Summary
- Show the owner's first name above the phone number in map info windows
- Include the owner's first name above the phone number in the “Oferty działek” list

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c72eb79e3c832ba2efe1bee0fb8eda