### PR TITLE
Align Szczegóły button with popup close icon

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -162,10 +162,14 @@
   .toast-lite { padding:10px 12px; }
 }
 
-.map-info-window { font-size:.95rem; max-width:320px; }
+.map-info-window {
+  font-size:.95rem;
+  max-width:320px;
+  position:relative;
+  padding-top:28px;
+}
 .map-info-window h3 { font-size:1.05rem; margin:0 0 .4rem; }
 .map-info-window p { margin:.2rem 0; font-size:.9rem; }
-.map-info-window .mini-actions { margin-top:.55rem; display:flex; gap:.5rem; justify-content:center; }
 .map-info-window .btn-mini {
   display:inline-block;
   padding:.35rem .6rem;
@@ -176,6 +180,11 @@
   font-size:.8rem;
   cursor:pointer;
   text-decoration:none;
+}
+.map-info-window .details-btn {
+  position:absolute;
+  top:4px;
+  right:32px;
 }
 
 /* zmniejszony przycisk zamknięcia w oknie mapy */
@@ -193,7 +202,7 @@
   .map-info-window { font-size:.9rem; max-width:400px; }
   .map-info-window h3 { font-size:1rem; white-space:nowrap; }
   .map-info-window p { font-size:.85rem; white-space:nowrap; }
-  .map-info-window .mini-actions { flex-wrap:wrap; }
+  .map-info-window .details-btn { top:2px; right:30px; }
   .gm-ui-hover-effect {
     transform:scale(.7) !important;
     transform-origin:top right;

--- a/oferty.html
+++ b/oferty.html
@@ -383,15 +383,13 @@ window.showConfirmModal = showConfirmModal;
 
     return `
       <div class="map-info-window">
+        <a class="btn-mini details-btn" target="_blank" href="${detailsUrl}">Szczegóły</a>
         <h3>${plot.Id || "Brak identyfikatora"}</h3>
         <p><b>Miejscowość:</b> ${city}</p>
-        ${price ? `<p><b>Cena:</b> ${price.toLocaleString('pl-PL')} zł${ppm2 ? ` <span style="color:#718096;">(${ppm2} zł/m²)</span>` : ''}</p>` : ''}
+        ${price ? `<p><b>Cena:</b> ${price.toLocaleString('pl-PL')} zł${ppm2 ? ` <span style=\"color:#718096;\">(${ppm2} zł/m²)</span>` : ''}</p>` : ''}
         ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
         ${data.firstName ? `<p><b>Imię:</b> ${data.firstName}</p>` : ''}
         <p><b>Telefon:</b> ${phone || 'brak'}</p>
-        <div class="mini-actions center">
-          <a class="btn-mini" target="_blank" href="${detailsUrl}">Szczegóły</a>
-        </div>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
- Move "Szczegóły" link in map info popup beside the close icon
- Add CSS to absolutely position the link and adjust mobile layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e317740832b850fe1a8ac072d4a