### PR TITLE
Add login header to dodaj page without add-offer link

### DIFF
--- a/assets/dodaj.css
+++ b/assets/dodaj.css
@@ -3,19 +3,92 @@ body {
 }
 
 .toast-container {
-  z-index: 1100;
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1400;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
 }
 
-.container-main { display: flex; min-height: 100vh; }
-.map-container { flex: 1; position: sticky; top: 0; height: 100vh; }
+.toast-lite {
+  min-width: 280px;
+  max-width: 92vw;
+  background: #fff;
+  color: #0f172a;
+  border-radius: 10px;
+  box-shadow: 0 10px 20px rgba(0,0,0,.12),0 3px 6px rgba(0,0,0,.08);
+  padding: 12px 14px 12px 12px;
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  transform: translateY(-8px);
+  opacity: 0;
+  transition: transform .18s ease, opacity .18s ease;
+  pointer-events: auto;
+}
+
+.toast-lite.show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.toast-lite .toast-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 14px;
+  color: #fff;
+}
+
+.toast-lite .toast-msg { line-height: 1.45; font-size: .95rem; }
+
+.toast-lite .toast-close {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  color: #64748b;
+  padding: 4px;
+}
+
+.toast-lite .toast-close:hover { color: #0f172a; }
+
+.toast-success .toast-icon { background: #16a34a; }
+.toast-info    .toast-icon { background: #1e6fba; }
+.toast-warning .toast-icon { background: #f59e0b; }
+.toast-error   .toast-icon { background: #dc2626; }
+
+@media (max-width:576px){
+  .toast-container { top:10px; right:10px; gap:8px; }
+  .toast-lite { padding:10px 12px; }
+}
+
 #map { height: 100%; width: 100%; }
 
+.container-main {
+  display: flex;
+  margin-top: var(--nav-top);
+  min-height: calc(100vh - var(--nav-top));
+}
+.map-container {
+  flex: 1;
+  position: sticky;
+  top: var(--nav-top);
+  height: calc(100vh - var(--nav-top));
+}
 .form-container {
   width: 400px;
   background: #fff;
   padding: 20px;
   overflow-y: auto;
-  height: 100vh;
+  height: calc(100vh - var(--nav-top));
   box-shadow: -5px 0 15px rgba(0, 0, 0, 0.1);
 }
 
@@ -47,8 +120,8 @@ body {
 .btn-primary:hover { background: linear-gradient(135deg, var(--secondary), var(--primary)); transform: none; box-shadow: none; }
 
 @media (max-width: 992px) {
-  .container-main { flex-direction: column; }
-  .map-container { height: 50vh; order: 2; }
+  .container-main { flex-direction: column; min-height: auto; }
+  .map-container { height: 50vh; order: 2; position: relative; top: 0; }
   .form-container { width: 100%; height: auto; order: 1; }
 }
 

--- a/dodaj.html
+++ b/dodaj.html
@@ -10,8 +10,6 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   <link rel="icon" type="image/png" sizes="32x32" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" />
 
-  <!-- Bootstrap -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 
   <!-- Firebase SDK (APP, Firestore, Analytics, Auth) -->
   <script type="module">
@@ -54,7 +52,56 @@
 </head>
 
 <body onload="loadGoogleMaps()">
-  <div class="toast-container position-fixed top-0 end-0 p-3"></div>
+  <div class="top-navbar">
+    <div class="contact-info">
+      <i class="fas fa-clock"></i> Poniedziałek - Piątek 9:00 - 18:00
+      <span><i class="fas fa-phone"></i> +48 505 849 404</span>
+    </div>
+
+    <div class="auth-buttons" id="authButtons">
+      <button class="btn btn-outline-primary btn-sm me-2" id="loginBtn">
+        <i class="fas fa-sign-in-alt me-1"></i> Zaloguj się
+      </button>
+      <button class="btn btn-primary btn-sm" id="registerBtn">
+        <i class="fas fa-user-plus me-1"></i> Zarejestruj się
+      </button>
+    </div>
+
+    <div class="user-menu" id="userMenu" style="display:none;">
+      <button class="btn btn-outline-primary btn-sm me-2" id="accountBtn">
+        <i class="fas fa-user me-1"></i> Moje konto
+      </button>
+      <button class="btn btn-secondary btn-sm ms-2" id="logoutBtn">
+        <i class="fas fa-sign-out-alt me-1"></i> Wyloguj
+      </button>
+    </div>
+  </div>
+
+  <header>
+    <a href="index.html" class="logo">
+      <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+      <span>Grunteo</span>
+    </a>
+
+    <nav class="desktop-nav">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+    </nav>
+
+    <button class="mobile-menu-btn" aria-label="Otwórz menu">
+      <i class="fas fa-bars"></i>
+    </button>
+
+    <nav class="nav-menu">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+      <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
+    </nav>
+  </header>
+
+  <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
 
   <div class="container-main">
     <!-- Mapa desktop -->
@@ -138,12 +185,82 @@
       <div class="privacy-text">
         Za przetwarzanie danych osobowych podanych w formularzu odpowiada Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Współadministratorem pozostaje Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Zasady przetwarzania opisaliśmy tutaj: <a href="https://www.grunteo.pl/polityka-prywatnosci" target="_blank">www.grunteo.pl/polityka-prywatnosci</a>. Masz prawo odwołać zgody w dowolnym momencie.
       </div>
+  </div>
+  </div>
+
+  <!-- Login Modal -->
+  <div class="modal" id="loginModal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Zaloguj się</h3>
+        <button class="modal-close">&times;</button>
+      </div>
+      <form id="loginForm">
+        <div class="form-group">
+          <label for="loginEmail">Email</label>
+          <input type="email" id="loginEmail" required>
+        </div>
+        <div class="form-group">
+          <label for="loginPassword">Hasło</label>
+          <input type="password" id="loginPassword" required>
+        </div>
+        <button type="submit" class="btn btn-primary" style="width: 100%;">Zaloguj się</button>
+      </form>
+      <div class="social-login">
+        <button type="button" class="btn btn-google" id="googleLoginBtnLogin">
+          <i class="fab fa-google"></i> Kontynuuj z Google
+        </button>
+      </div>
+      <div class="form-footer">
+        <p>Nie masz konta? <a href="#" id="switchToRegister">Zarejestruj się</a></p>
+      </div>
     </div>
   </div>
 
-  <!-- Bootstrap + jQuery -->
+  <!-- Register Modal -->
+  <div class="modal" id="registerModal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Utwórz konto</h3>
+        <button class="modal-close">&times;</button>
+      </div>
+      <form id="registerForm">
+        <div class="form-group">
+          <label for="registerName">Imię i nazwisko</label>
+          <input type="text" id="registerName" required>
+        </div>
+        <div class="form-group">
+          <label for="registerEmail">Email</label>
+          <input type="email" id="registerEmail" required>
+        </div>
+        <div class="form-group">
+          <label for="registerPassword">Hasło</label>
+          <input type="password" id="registerPassword" required>
+        </div>
+        <div class="form-group">
+          <label for="registerConfirmPassword">Potwierdź hasło</label>
+          <input type="password" id="registerConfirmPassword" required>
+        </div>
+        <button type="submit" class="btn btn-primary" style="width: 100%;">Zarejestruj się</button>
+      </form>
+      <div class="social-login mt-3 text-center">
+        <button type="button" class="btn btn-google w-100 mb-2" id="googleLoginBtn">
+          <i class="fab fa-google me-1"></i> Zaloguj przez Google
+        </button>
+      </div>
+      <div class="domain-warning" id="domainWarning">
+        <i class="fas fa-exclamation-triangle"></i>
+        Uwaga: Logowanie przez Google może nie działać na tej domenie.
+        Aby rozwiązać ten problem, dodaj swoją domenę w ustawieniach Firebase.
+      </div>
+      <div class="form-footer">
+        <p>Masz już konto? <a href="#" id="switchToLogin">Zaloguj się</a></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- jQuery -->
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
 
   <script>
     /* ===== PERSISTENCJA FORMULARZA I PUNKTÓW ===== */
@@ -200,26 +317,43 @@
       });
     }
 
-    /* ===== UI: TOAST ===== */
-    function showToast(message, type = "info") {
-      let bgClass = "bg-primary";
-      if (type === "success") bgClass = "bg-success";
-      if (type === "warning") bgClass = "bg-warning text-dark";
-      if (type === "error")   bgClass = "bg-danger";
+    /* ===== UI: TOAST (vanilla) =====
+       showToast('message', 'success')
+       type: 'info' | 'success' | 'warning' | 'error'
+    */
+    function showToast(message, type = 'info') {
+      const container = document.getElementById('toastContainer');
+      if (!container) return;
 
-      const toast = $(`
-        <div class="toast align-items-center text-white ${bgClass} border-0" role="showToast" aria-live="assertive" aria-atomic="true">
-          <div class="d-flex">
-            <div class="toast-body">${message}</div>
-            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
-          </div>
-        </div>
-      `);
+      const wrap = document.createElement('div');
+      wrap.className = `toast-lite toast-${type}`;
+      wrap.setAttribute('role', 'status');
+      wrap.setAttribute('aria-live', 'polite');
 
-      $(".toast-container").append(toast);
-      const bsToast = new bootstrap.Toast(toast[0], { delay: 4000 });
-      bsToast.show();
-      toast.on("hidden.bs.toast", () => toast.remove());
+      const icon = {
+        success: '✓',
+        info: 'ℹ',
+        warning: '!',
+        error: '✕'
+      }[type] || 'ℹ';
+
+      wrap.innerHTML = `
+        <div class="toast-icon" aria-hidden="true">${icon}</div>
+        <div class="toast-msg">${message}</div>
+        <button class="toast-close" aria-label="Zamknij">&times;</button>
+      `;
+
+      const close = () => {
+        wrap.classList.remove('show');
+        setTimeout(() => wrap.remove(), 160);
+      };
+      wrap.querySelector('.toast-close').addEventListener('click', close);
+
+      container.appendChild(wrap);
+      requestAnimationFrame(() => wrap.classList.add('show'));
+
+      const t = setTimeout(close, 4000);
+      wrap.addEventListener('mouseenter', () => clearTimeout(t), { once: true });
     }
 
     /* ===== WALIDACJA FORMULARZA ===== */
@@ -567,13 +701,222 @@
         }
       });
 
-      $("#clearPlotsBtn, #clearPlotsBtnMobile").on("click", function(){ clearAllPoints(); });
+  $("#clearPlotsBtn, #clearPlotsBtnMobile").on("click", function(){ clearAllPoints(); });
 
       toggleFieldsForAuth(window.currentUser || null);
     });
-	
-	
-	
+
+
+
+  </script>
+  <script type="module">
+    import { initializeApp, getApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+    import {
+      getAuth, onAuthStateChanged, signOut,
+      signInWithEmailAndPassword, createUserWithEmailAndPassword, updateProfile,
+      GoogleAuthProvider, signInWithPopup, signInWithRedirect,
+      setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
+    } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyBdhMIiqetOfDGP85ERxtgwn3AXR50pBcE",
+      authDomain: "base-468e0.firebaseapp.com",
+      projectId: "base-468e0",
+      storageBucket: "base-468e0.firebasestorage.app",
+      messagingSenderId: "829161895559",
+      appId: "1:829161895559:web:d832541aac05b35847ea22"
+    };
+
+    const app  = getApps().length ? getApp() : initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+    const db   = getFirestore(app);
+    auth.languageCode = 'pl';
+
+    try { await setPersistence(auth, browserLocalPersistence); }
+    catch { try { await setPersistence(auth, browserSessionPersistence); }
+    catch { await setPersistence(auth, inMemoryPersistence); } }
+
+    const googleProvider = new GoogleAuthProvider();
+    googleProvider.setCustomParameters({ prompt: 'select_account' });
+
+    const authButtons = document.getElementById('authButtons');
+    const userMenu    = document.getElementById('userMenu');
+    const loginBtn    = document.getElementById('loginBtn');
+    const registerBtn = document.getElementById('registerBtn');
+    const accountBtn  = document.getElementById('accountBtn');
+    const logoutBtn   = document.getElementById('logoutBtn');
+
+    const loginModal    = document.getElementById('loginModal');
+    const registerModal = document.getElementById('registerModal');
+    const closeBtns     = document.querySelectorAll('.modal-close');
+    const switchToRegister = document.getElementById('switchToRegister');
+    const switchToLogin    = document.getElementById('switchToLogin');
+
+    const loginForm    = document.getElementById('loginForm');
+    const registerForm = document.getElementById('registerForm');
+    const googleBtnRegister = document.getElementById('googleLoginBtn');
+    const googleBtnLogin    = document.getElementById('googleLoginBtnLogin');
+
+    const openModal  = (m) => m && (m.style.display = 'flex');
+    const closeModal = (m) => m && (m.style.display = 'none');
+
+    function renderMobileAuth(user) {
+      const navMenu = document.querySelector('.nav-menu');
+      const mobileAuthC = document.getElementById('mobileAuth');
+      if (!mobileAuthC) return;
+
+      if (user) {
+        const label = user.displayName ? user.displayName.split(' ')[0] : (user.email || 'Użytkownik');
+        mobileAuthC.innerHTML = `
+          <div class="nav-link" style="font-weight:600;">
+            <i class="fas fa-user"></i> ${label}
+          </div>
+          <button class="btn btn-secondary" id="mobileLogoutBtn" style="width:100%;">
+            <i class="fas fa-sign-out-alt"></i> Wyloguj się
+          </button>
+        `;
+      } else {
+        mobileAuthC.innerHTML = `
+          <a href="#" id="loginLink" class="nav-link">Zaloguj się</a>
+          <a href="#" id="registerLink" class="nav-link">Zarejestruj się</a>
+        `;
+      }
+
+      const loginLink = document.getElementById('loginLink');
+      const registerLink = document.getElementById('registerLink');
+      const mobileLogoutBtn = document.getElementById('mobileLogoutBtn');
+
+      loginLink && loginLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        openModal(loginModal);
+        navMenu?.classList.remove('active');
+        mobileAuthC.style.display = 'none';
+      });
+
+      registerLink && registerLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        openModal(registerModal);
+        navMenu?.classList.remove('active');
+        mobileAuthC.style.display = 'none';
+      });
+
+      mobileLogoutBtn && mobileLogoutBtn.addEventListener('click', async () => {
+        try { await signOut(auth); } catch(e){ console.error(e); }
+        navMenu?.classList.remove('active');
+        mobileAuthC.style.display = 'none';
+      });
+
+      mobileAuthC.style.display = navMenu?.classList.contains('active') ? 'flex' : 'none';
+    }
+
+    loginBtn    && loginBtn.addEventListener('click', () => openModal(loginModal));
+    registerBtn && registerBtn.addEventListener('click', () => openModal(registerModal));
+    accountBtn  && accountBtn.addEventListener('click', () => { window.location.href = 'oferty.html#userDashboard'; });
+    closeBtns.forEach(b => b.addEventListener('click', () => closeModal(b.closest('.modal'))));
+    window.addEventListener('click', (e) => {
+      if (e.target.classList?.contains('modal')) closeModal(e.target);
+    });
+
+    const niceErr = (err) => {
+      switch (err?.code) {
+        case 'auth/invalid-email': return 'Nieprawidłowy adres e-mail.';
+        case 'auth/missing-password': return 'Podaj hasło.';
+        case 'auth/user-not-found':
+        case 'auth/wrong-password':
+        case 'auth/invalid-credential': return 'Nieprawidłowy e-mail lub hasło.';
+        case 'auth/too-many-requests': return 'Za dużo prób. Spróbuj później.';
+        case 'auth/unauthorized-domain': return `Domena ${location.hostname} nie jest dodana w Firebase (Authorized domains).`;
+        case 'auth/popup-blocked': return 'Przeglądarka zablokowała okno logowania Google.';
+        case 'auth/operation-not-supported-in-this-environment': return 'Uruchom stronę przez http/https (nie file://).';
+        default: return 'Błąd: ' + (err?.code || err?.message || 'nieznany');
+      }
+    };
+
+    loginForm && loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('loginEmail').value.trim();
+      const pass  = document.getElementById('loginPassword').value;
+      try { await signInWithEmailAndPassword(auth, email, pass); closeModal(loginModal); }
+      catch (err) { showToast(niceErr(err)); }
+    });
+
+    registerForm && registerForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name  = document.getElementById('registerName').value.trim();
+      const email = document.getElementById('registerEmail').value.trim();
+      const pass1 = document.getElementById('registerPassword').value;
+      const pass2 = document.getElementById('registerConfirmPassword').value;
+      if (pass1 !== pass2) return showToast('Hasła nie są identyczne!');
+      try {
+        const { user } = await createUserWithEmailAndPassword(auth, email, pass1);
+        if (name) await updateProfile(user, { displayName: name });
+        await setDoc(doc(db, "users", user.uid), { name: name || null, email, createdAt: new Date(), provider: 'password' }, { merge: true });
+        closeModal(registerModal);
+      } catch (err) { showToast(niceErr(err)); }
+    });
+
+    async function signInWithGoogleSmart() {
+      if (!['http:', 'https:'].includes(location.protocol))
+        return showToast('Uruchom stronę przez http/https (nie file://).');
+      try {
+        const res = await signInWithPopup(auth, googleProvider);
+        const user = res.user;
+        await setDoc(doc(db, "users", user.uid), {
+          name: user.displayName || null,
+          email: user.email || null,
+          provider: 'google',
+          createdAt: new Date(),
+        }, { merge: true });
+        closeModal(loginModal); closeModal(registerModal);
+      } catch (err) {
+        if (err?.code === 'auth/popup-blocked' || err?.code === 'auth/operation-not-supported-in-this-environment') {
+          await signInWithRedirect(auth, googleProvider);
+        } else {
+          showToast(niceErr(err));
+        }
+      }
+    }
+
+    googleBtnRegister && googleBtnRegister.addEventListener('click', signInWithGoogleSmart);
+    googleBtnLogin    && googleBtnLogin.addEventListener('click', signInWithGoogleSmart);
+    logoutBtn && logoutBtn.addEventListener('click', async () => { try { await signOut(auth); } catch(e){ console.error(e); } });
+
+    onAuthStateChanged(auth, (user) => {
+      if (user) {
+        authButtons && (authButtons.style.display = 'none');
+        userMenu && (userMenu.style.display = 'flex');
+        if (accountBtn) {
+          const label = user.displayName || user.email || 'Moje konto';
+          accountBtn.innerHTML = `<i class="fas fa-user me-1"></i> ${label}`;
+        }
+      } else {
+        authButtons && (authButtons.style.display = 'flex');
+        userMenu && (userMenu.style.display = 'none');
+      }
+      renderMobileAuth(user);
+    });
+  </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+      const navMenu = document.querySelector('.nav-menu');
+      const mobileAuth = document.getElementById('mobileAuth');
+
+      mobileMenuBtn?.addEventListener('click', function () {
+        navMenu.classList.toggle('active');
+        if (mobileAuth) {
+          mobileAuth.style.display = navMenu.classList.contains('active') ? 'flex' : 'none';
+        }
+      });
+
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 768) {
+          navMenu.classList.remove('active');
+          if (mobileAuth) mobileAuth.style.display = 'none';
+        }
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Use site-standard login buttons and remove Bootstrap to match other pages
- Replace Bootstrap toasts with shared vanilla toast implementation and styles
- Offset add-offer form and map below the fixed header

## Testing
- `npx htmlhint dodaj.html` (fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)


------
https://chatgpt.com/codex/tasks/task_e_68c7448f58f0832b8945cda369f660c0