### PR TITLE
refactor: extract header styles into shared file

### DIFF
--- a/assets/dodaj.css
+++ b/assets/dodaj.css
@@ -100,9 +100,3 @@ textarea[readonly], textarea:disabled {
 @media (max-width: 992px) {
   .map-overlay-desktop { display: none !important; }
 }
-
-@media (min-width: 768px) {
-  header { justify-content: flex-start; }
-  .desktop-nav { flex: 1; justify-content: center; }
-}
-

--- a/assets/header.css
+++ b/assets/header.css
@@ -1,0 +1,91 @@
+/* ====== Top Navbar (desktop) ====== */
+.top-navbar{
+  display:flex;justify-content:space-between;align-items:center;
+  position:fixed;top:0;width:100%;background:#fff;z-index:1200;
+  border-bottom:1px solid #eee;padding:.3rem .75rem;font-size:.8rem;
+  height:var(--topbar-height);
+}
+.contact-info{display:flex;align-items:center;gap:1.5rem;font-size:.9rem;}
+.auth-buttons,.user-menu{display:flex;align-items:center;gap:.5rem;}
+.top-navbar .btn-sm{padding:.4rem .8rem;font-size:.8rem;}
+
+/* ====== Header + Nav ====== */
+header{
+  display:flex;justify-content:space-between;align-items:center;
+  position:fixed;top:var(--topbar-height);left:0;right:0;z-index:1100;background:#fff;
+  padding:.4rem .75rem;border-bottom:1px solid #eee;height:var(--header-height);
+}
+
+/* POWIĘKSZONE LOGO (tylko te dwie klasy) */
+.logo{
+  display:flex;align-items:center;gap:.625rem;font-weight:700;font-size:1.35rem;color:var(--darker);
+}
+.logo img{height:70px;width:auto;}        /* było 42px */
+.logo span{font-size:1.05rem;line-height:1.1;}
+
+.desktop-nav{display:flex;gap:1.5rem;}
+.desktop-nav .nav-link{color:#333;font-weight:500;font-size:.9rem;position:relative;}
+.nav-link::after{
+  content:'';position:absolute;bottom:-5px;left:0;width:0;height:2px;
+  background:var(--gradient-primary);transition:var(--transition);
+}
+.nav-link:hover::after{width:100%;}
+.nav-link.active::after{width:100%;}
+
+.desktop-add-offer,.mobile-add-offer{
+  display:inline-flex;align-items:center;padding:.35rem .7rem;border-radius:6px;
+  background:linear-gradient(90deg,#007bff,#0056b3);color:#fff;font-weight:500;
+  font-size:.8rem;text-decoration:none;transition:.3s;
+}
+.desktop-add-offer:hover,.mobile-add-offer:hover{transform:translateY(-2px);box-shadow:0 4px 8px rgba(0,0,0,.2);}
+
+.mobile-menu-btn{background:none;border:0;font-size:1.5rem;display:none;}
+
+/* MENU MOBILNE – rozwija się spod headera (lista zaczyna się pod nagłówkiem) */
+.nav-menu{
+  position:fixed;left:0;right:0;top:var(--nav-top);
+  display:flex;flex-direction:column;background:#fff;
+  padding:1.1rem;box-shadow:0 4px 12px rgba(0,0,0,.15);
+  max-height:0;overflow:hidden;opacity:0;visibility:hidden;
+  transition:max-height .35s ease,opacity .2s ease,visibility .2s ease;
+  z-index:1000;
+  transform-origin:top;
+}
+.nav-menu.active{
+  max-height:calc(100vh - var(--nav-top)); /* płynne rozwijanie od headera */
+  opacity:1;visibility:visible;
+}
+.nav-menu .nav-link{margin-bottom:.7rem;font-size:.95rem;color:#333;text-decoration:none;}
+.mobile-auth{display:flex;flex-direction:column;gap:1rem;margin-top:1.5rem;border-top:1px solid #eee;padding-top:1.5rem;}
+
+@media (max-width:1024px){
+  .logo img{height:50px;} /* skalowanie w dół z zachowaniem powiększenia */
+  .desktop-nav .nav-link{font-size:.85rem;}
+}
+
+@media (max-width:768px){
+  /* układ na telefonie: bez top-baru, header przy górze */
+  .top-navbar,.desktop-nav,.desktop-add-offer{display:none !important;}
+  header{top:0;}
+
+  .mobile-add-offer,.mobile-menu-btn{display:inline-flex;}
+
+  /* Header logo: obrazek po lewej, napis po prawej */
+  .logo{
+    flex-direction:row;
+    align-items:center;
+    gap:.5rem;
+  }
+  .logo img{height:60px;}
+  .logo span{white-space:nowrap;}
+}
+
+@media (min-width:769px){
+  .nav-menu,.mobile-add-offer,.mobile-menu-btn,.mobile-auth{display:none !important;}
+}
+
+@media (min-width:768px){
+  header{justify-content:flex-start;}
+  .desktop-nav{flex:1;justify-content:center;}
+}
+

--- a/assets/main.css
+++ b/assets/main.css
@@ -73,70 +73,10 @@ a{color:var(--primary);text-decoration:none;transition:var(--transition);}
 .section{padding:2rem 0;}
 .section-title{text-align:center;margin-bottom:2.5rem;}
 .section-title h2{position:relative;display:inline-block;margin-bottom:1.25rem;}
-.section-title h2::after{
-  content:'';position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);
-  width:50px;height:3px;background:var(--gradient-primary);border-radius:2px;
-}
-
-/* ====== Top Navbar (desktop) ====== */
-.top-navbar{
-  display:flex;justify-content:space-between;align-items:center;
-  position:fixed;top:0;width:100%;background:#fff;z-index:1200;
-  border-bottom:1px solid #eee;padding:.3rem .75rem;font-size:.8rem;
-  height:var(--topbar-height);
-}
-.contact-info{display:flex;align-items:center;gap:1.5rem;font-size:.9rem;}
-.auth-buttons,.user-menu{display:flex;align-items:center;gap:.5rem;}
-.top-navbar .btn-sm{padding:.4rem .8rem;font-size:.8rem;}
-
-/* ====== Header + Nav ====== */
-header{
-  display:flex;justify-content:space-between;align-items:center;
-  position:fixed;top:var(--topbar-height);left:0;right:0;z-index:1100;background:#fff;
-  padding:.4rem .75rem;border-bottom:1px solid #eee;height:var(--header-height);
-}
-
-/* POWIĘKSZONE LOGO (tylko te dwie klasy) */
-.logo{
-  display:flex;align-items:center;gap:.625rem;font-weight:700;font-size:1.35rem;color:var(--darker);
-}
-.logo img{height:70px;width:auto;}        /* było 42px */
-.logo span{font-size:1.05rem;line-height:1.1;}
-
-.desktop-nav{display:flex;gap:1.5rem;}
-.desktop-nav .nav-link{color:#333;font-weight:500;font-size:.9rem;position:relative;}
-.nav-link::after{
-  content:'';position:absolute;bottom:-5px;left:0;width:0;height:2px;
-  background:var(--gradient-primary);transition:var(--transition);
-}
-.nav-link:hover::after{width:100%;}
-.nav-link.active::after{width:100%;}
-
-.desktop-add-offer,.mobile-add-offer{
-  display:inline-flex;align-items:center;padding:.35rem .7rem;border-radius:6px;
-  background:linear-gradient(90deg,#007bff,#0056b3);color:#fff;font-weight:500;
-  font-size:.8rem;text-decoration:none;transition:.3s;
-}
-.desktop-add-offer:hover,.mobile-add-offer:hover{transform:translateY(-2px);box-shadow:0 4px 8px rgba(0,0,0,.2);}
-
-.mobile-menu-btn{background:none;border:0;font-size:1.5rem;display:none;}
-
-/* MENU MOBILNE – rozwija się spod headera (lista zaczyna się pod nagłówkiem) */
-.nav-menu{
-  position:fixed;left:0;right:0;top:var(--nav-top);
-  display:flex;flex-direction:column;background:#fff;
-  padding:1.1rem;box-shadow:0 4px 12px rgba(0,0,0,.15);
-  max-height:0;overflow:hidden;opacity:0;visibility:hidden;
-  transition:max-height .35s ease,opacity .2s ease,visibility .2s ease;
-  z-index:1000;
-  transform-origin:top;
-}
-.nav-menu.active{
-  max-height:calc(100vh - var(--nav-top)); /* płynne rozwijanie od headera */
-  opacity:1;visibility:visible;
-}
-.nav-menu .nav-link{margin-bottom:.7rem;font-size:.95rem;color:#333;text-decoration:none;}
-.mobile-auth{display:flex;flex-direction:column;gap:1rem;margin-top:1.5rem;border-top:1px solid #eee;padding-top:1.5rem;}
+  .section-title h2::after{
+    content:'';position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);
+    width:50px;height:3px;background:var(--gradient-primary);border-radius:2px;
+  }
 
 /* ====== Modals ====== */
 .modal{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:1100;align-items:center;justify-content:center;}
@@ -261,8 +201,6 @@ footer{background:var(--darker);color:#fff;padding:2.5rem 0 1.25rem}
 /* ====== Responsive ====== */
 @media (max-width:1024px){
   html{font-size:14px;}
-  .logo img{height:50px;} /* skalowanie w dół z zachowaniem powiększenia */
-  .desktop-nav .nav-link{font-size:.85rem;}
   .modal-content{max-width:340px;}
 }
 
@@ -275,22 +213,6 @@ footer{background:var(--darker);color:#fff;padding:2.5rem 0 1.25rem}
 
 @media (max-width:768px){
   html{font-size:13px;}
-
-  /* układ na telefonie: bez top-baru, header przy górze */
-  .top-navbar,.desktop-nav,.desktop-add-offer{display:none !important;}
-  header{top:0;}
-
-  .mobile-add-offer,.mobile-menu-btn{display:inline-flex;}
-
-  /* Header logo: obrazek po lewej, napis po prawej */
-  .logo{
-    flex-direction:row;
-    align-items:center;
-    gap:.5rem;
-  }
-  .logo img{height:60px;}
-  .logo span{white-space:nowrap;}
-
   /* Footer logo: JEDEN POD DRUGIM, WYRÓWNANE DO LEWEJ */
   .footer-logo{
     flex-direction:column;
@@ -304,10 +226,6 @@ footer{background:var(--darker);color:#fff;padding:2.5rem 0 1.25rem}
   .hero{padding:calc(var(--header-height) + 20px) 0 2rem;}
   .hero-text h1{font-size:1.6rem;}
   .hero-buttons{justify-content:center;}
-}
-
-@media (min-width:769px){
-  .nav-menu,.mobile-add-offer,.mobile-menu-btn,.mobile-auth{display:none !important;}
 }
 
 @media (max-width:576px){

--- a/dodaj.html
+++ b/dodaj.html
@@ -45,6 +45,7 @@
   </script>
 
   <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/header.css">
   <link rel="stylesheet" href="assets/dodaj.css">
 </head>
 

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/png" sizes="512x512" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
   
 <link rel="stylesheet" href="assets/main.css"/>
+<link rel="stylesheet" href="assets/header.css"/>
 <link rel="stylesheet" href="assets/oferty.css"/>
 	
 	

--- a/oferty.html
+++ b/oferty.html
@@ -22,6 +22,7 @@
 
 
   <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/header.css">
   <link rel="stylesheet" href="assets/oferty.css">
 
   </head>


### PR DESCRIPTION
## Summary
- move navigation and topbar styles into new `header.css`
- load shared header styles across `index.html`, `oferty.html`, and `dodaj.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7eb8b9ca4832bafbbed5628de35f4