### PR TITLE
Hide add offer button on dodaj page

### DIFF
--- a/assets/dodaj.css
+++ b/assets/dodaj.css
@@ -2,6 +2,12 @@ body {
   background: var(--light);
 }
 
+/* Na stronie dodaj ukrywamy przycisk dodawania oferty, zachowując układ */
+.desktop-add-offer,
+.mobile-add-offer {
+  visibility: hidden;
+}
+
 /* Toast notifications */
 .toast-container {
   position: fixed;


### PR DESCRIPTION
## Summary
- hide the desktop and mobile "Dodaj ofertę" buttons on the add listing page while keeping layout spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c861b40c60832ba3d5dbb070cdcbc3