### PR TITLE
Style home offers grid as chessboard

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -107,6 +107,41 @@ a{color:var(--primary);text-decoration:none;transition:var(--transition);}
 .offer-actions{display:flex;gap:.5rem;}
 .offer-actions.center{justify-content:center;}
 
+/* ====== Home page offers grid (chessboard layout) ====== */
+body.home-page .offers-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:1.5rem;
+  align-items:stretch;
+  grid-auto-rows:1fr;
+}
+
+@media (min-width:768px){
+  body.home-page .offers-grid{
+    grid-template-columns:repeat(2,minmax(0,1fr));
+  }
+}
+
+body.home-page .offer-card{
+  margin-bottom:0;
+  height:100%;
+  display:flex;
+  flex-direction:column;
+  border:1px solid #e5effa;
+}
+
+body.home-page .offer-card .offer-actions{
+  margin-top:auto;
+}
+
+@media (min-width:768px){
+  body.home-page .offer-card:nth-child(4n+2),
+  body.home-page .offer-card:nth-child(4n+3){
+    background:#f5f9ff;
+    border-color:#dbe8f7;
+  }
+}
+
 /* ====== Hero ====== */
 .hero{
   padding:calc(var(--topbar-height) + var(--header-height) + 20px) 0 2.5rem;

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.8.0/proj4.js"></script>
 </head>
-<body>
+<body class="home-page">
 
   <!-- Top Navbar (desktop) -->
   <div class="top-navbar">


### PR DESCRIPTION
## Summary
- scope the home page with a dedicated body class so its dashboard layout can be customized
- restyle the home "Moje oferty" grid to use a two-column chessboard layout with alternating tile backgrounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8662a8ecc832b8f0bbe300391bae2