### PR TITLE
Add read-only details page and inline edit view

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -1,0 +1,603 @@
+body.property-page {
+  background: #f3f8ff;
+  color: var(--darker);
+}
+
+main.property-wrapper {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.loading-state,
+.error-state {
+  background: #fff;
+  border-radius: 16px;
+  padding: 2.5rem 1.8rem;
+  box-shadow: var(--shadow-sm);
+  text-align: center;
+  margin-top: 1.5rem;
+  font-size: 1rem;
+  color: var(--gray);
+}
+
+.error-state {
+  color: #c53030;
+}
+
+.property-hero {
+  background: #fff;
+  border-radius: 20px;
+  padding: 2rem 2.2rem;
+  box-shadow: var(--shadow-md);
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+}
+
+.property-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.property-heading h1 {
+  font-size: 2rem;
+  margin-bottom: .6rem;
+  color: var(--darker);
+}
+
+.property-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .65rem;
+}
+
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  padding: .45rem .75rem;
+  border-radius: 999px;
+  background: #eef5ff;
+  color: var(--primary);
+  font-weight: 600;
+  font-size: .85rem;
+}
+
+.meta-chip i {
+  color: var(--primary);
+}
+
+.price-box {
+  background: #fff;
+  border: 1px solid rgba(30,111,186,.12);
+  border-radius: 16px;
+  padding: 1.4rem 1.2rem;
+  box-shadow: var(--shadow-sm);
+  min-width: 220px;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: .65rem;
+}
+
+.price-line {
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
+}
+
+.price-line .price-amount {
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: var(--darker);
+}
+
+.price-meta {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+  font-size: .9rem;
+  color: var(--gray);
+}
+
+.price-meta strong {
+  color: var(--darker);
+}
+
+.property-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: #f7fbff;
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  box-shadow: inset 0 0 0 1px rgba(30,111,186,.08);
+}
+
+.stat-card h4 {
+  font-size: .95rem;
+  margin-bottom: .35rem;
+  color: var(--primary);
+}
+
+.stat-card p {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--darker);
+}
+
+.property-layout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.8rem;
+  margin-bottom: 2rem;
+}
+
+.map-panel,
+.plan-panel,
+.description-card,
+.tags-card,
+.contact-card,
+.contact-form-card {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: var(--shadow-sm);
+}
+
+.map-panel {
+  padding: 1.6rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.map-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.map-toolbar h3 {
+  margin: 0;
+}
+
+.map-modes {
+  display: inline-flex;
+  border-radius: 999px;
+  background: #eef5ff;
+  padding: .25rem;
+  gap: .25rem;
+}
+
+.map-mode-btn {
+  border: 0;
+  background: transparent;
+  color: var(--primary);
+  font-weight: 600;
+  padding: .4rem .9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background .2s ease, color .2s ease;
+}
+
+.map-mode-btn.active {
+  background: #fff;
+  color: var(--darker);
+  box-shadow: 0 6px 14px rgba(30,111,186,.18);
+}
+
+#propertyMap {
+  width: 100%;
+  height: 360px;
+  border-radius: 16px;
+  background: #dbe8f7;
+}
+
+.location-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.location-card {
+  background: #f7fbff;
+  border-radius: 14px;
+  padding: 1.1rem;
+  box-shadow: inset 0 0 0 1px rgba(30,111,186,.08);
+}
+
+.location-card h4 {
+  margin: 0 0 .4rem;
+  font-size: 1rem;
+}
+
+.location-card p {
+  margin: 0;
+  color: var(--darker);
+  font-size: .95rem;
+}
+
+.plan-panel {
+  padding: 1.6rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.section-header h2,
+.section-header h3 {
+  margin: 0;
+}
+
+.plan-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+}
+
+.plan-badge,
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  background: #eef5ff;
+  color: var(--primary);
+  padding: .4rem .75rem;
+  border-radius: 999px;
+  font-size: .85rem;
+  font-weight: 600;
+}
+
+.plan-info-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .85rem 1.2rem;
+}
+
+.plan-info-grid dl {
+  margin: 0;
+}
+
+.plan-info-grid dt {
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--gray);
+  margin-bottom: .15rem;
+}
+
+.plan-info-grid dd {
+  margin: 0;
+  font-size: .95rem;
+  font-weight: 600;
+  color: var(--darker);
+}
+
+.plan-notes {
+  background: #f9fcff;
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  font-size: .95rem;
+  color: var(--darker);
+  white-space: pre-wrap;
+}
+
+.utilities-section,
+.description-section,
+.tags-section,
+.contact-section {
+  margin-bottom: 2rem;
+}
+
+.utilities-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.utility-card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  gap: .9rem;
+  align-items: center;
+  border: 1px solid rgba(30,111,186,.12);
+  cursor: default;
+  transition: none;
+}
+
+.utility-icon {
+  font-size: 1.8rem;
+}
+
+.utility-content h4 {
+  margin: 0 0 .25rem;
+  font-size: 1rem;
+}
+
+.utility-status {
+  font-size: .9rem;
+  color: var(--gray);
+  font-weight: 600;
+}
+
+.utilities-grid .utility-card:hover {
+  transform: none;
+  box-shadow: var(--shadow-sm);
+}
+
+.description-card {
+  padding: 1.6rem 1.4rem;
+}
+
+.description-text {
+  white-space: pre-wrap;
+  font-size: .95rem;
+  color: var(--darker);
+  line-height: 1.6;
+}
+
+.tags-card {
+  padding: 1.4rem 1.4rem 1.1rem;
+}
+
+.tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .6rem;
+}
+
+.tags-empty {
+  margin: 0;
+  color: var(--gray);
+  font-size: .9rem;
+}
+
+.contact-wrapper {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1.2rem;
+}
+
+.contact-card {
+  padding: 1.6rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.contact-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.contact-details {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  font-size: .95rem;
+}
+
+.contact-details span {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  color: var(--darker);
+}
+
+.contact-details a {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .6rem;
+}
+
+.contact-form-card {
+  padding: 1.6rem 1.4rem;
+}
+
+.contact-form-card h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.contact-form {
+  display: grid;
+  gap: .9rem;
+}
+
+.contact-form label {
+  font-weight: 600;
+  font-size: .85rem;
+  color: var(--gray);
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: .65rem .75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(30,111,186,.2);
+  font-size: .95rem;
+  font-family: inherit;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(30,111,186,.18);
+}
+
+.contact-form textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.contact-form button {
+  justify-self: flex-start;
+}
+
+.toast-container {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1400;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.toast-lite {
+  min-width: 280px;
+  max-width: 92vw;
+  background: #fff;
+  color: #0f172a;
+  border-radius: 10px;
+  box-shadow: 0 10px 20px rgba(0,0,0,.12), 0 3px 6px rgba(0,0,0,.08);
+  padding: 12px 14px 12px 12px;
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  transform: translateY(-8px);
+  opacity: 0;
+  transition: transform .18s ease, opacity .18s ease;
+  pointer-events: auto;
+}
+
+.toast-lite.show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.toast-lite .toast-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 14px;
+  color: #fff;
+}
+
+.toast-lite .toast-msg {
+  line-height: 1.45;
+  font-size: .95rem;
+}
+
+.toast-lite .toast-close {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  color: #64748b;
+  padding: 4px;
+}
+
+.toast-lite .toast-close:hover {
+  color: #0f172a;
+}
+
+.toast-success .toast-icon { background: #16a34a; }
+.toast-info .toast-icon { background: #1e6fba; }
+.toast-warning .toast-icon { background: #f59e0b; }
+.toast-error .toast-icon { background: #dc2626; }
+
+@media (max-width: 1024px) {
+  .property-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-wrapper {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  main.property-wrapper {
+    padding: 1.6rem 1rem 2.5rem;
+  }
+
+  .property-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .price-box {
+    width: 100%;
+  }
+
+  #propertyMap {
+    height: 300px;
+  }
+
+  .map-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .map-modes {
+    align-self: flex-start;
+  }
+
+  .property-stats {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .toast-container {
+    top: 10px;
+    right: 10px;
+  }
+}
+
+@media (max-width: 520px) {
+  .meta-chip {
+    font-size: .8rem;
+  }
+
+  .property-hero {
+    padding: 1.5rem 1.2rem;
+  }
+
+  .map-panel,
+  .plan-panel,
+  .description-card,
+  .tags-card,
+  .contact-card,
+  .contact-form-card {
+    padding: 1.3rem 1.1rem;
+  }
+
+  .location-details {
+    grid-template-columns: 1fr;
+  }
+
+  .plan-info-grid {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/assets/details.js
+++ b/assets/details.js
@@ -1,0 +1,622 @@
+import {
+  initFirebase,
+  doc,
+  getDoc,
+  onAuthStateChanged,
+  parseQueryParams,
+  formatNumber,
+  formatCurrency,
+  formatArea,
+  formatDateTime,
+  normalizeUtilityStatus,
+  getUtilityLabel,
+  UTILITY_ORDER,
+  loadGoogleMaps,
+  showToast,
+  textContentOrFallback,
+  sanitizeMultilineText,
+  ensureArray,
+  parseNumberFromText,
+  syncMobileMenu
+} from './property-common.js';
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  GoogleAuthProvider,
+  signInWithPopup
+} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+
+const state = {
+  user: null,
+  offerId: '',
+  plotIndex: 0,
+  offerData: null,
+  plotData: null,
+  price: null,
+  area: null,
+  map: null,
+  marker: null
+};
+
+const elements = {
+  loadingState: document.getElementById('loadingState'),
+  errorState: document.getElementById('errorState'),
+  propertyContent: document.getElementById('propertyContent'),
+  propertyTitle: document.getElementById('propertyTitle'),
+  propertyLocation: document.getElementById('propertyLocation'),
+  propertyArea: document.getElementById('propertyArea'),
+  propertyType: document.getElementById('propertyType'),
+  ownershipStatus: document.getElementById('ownershipStatus'),
+  priceValueText: document.getElementById('priceValueText'),
+  pricePerSqm: document.getElementById('pricePerSqm'),
+  priceUpdatedAt: document.getElementById('priceUpdatedAt'),
+  plotNumber: document.getElementById('plotNumber'),
+  landRegister: document.getElementById('landRegister'),
+  plotAreaStat: document.getElementById('plotAreaStat'),
+  plotStatus: document.getElementById('plotStatus'),
+  locationAddress: document.getElementById('locationAddress'),
+  locationAccess: document.getElementById('locationAccess'),
+  planBadges: document.getElementById('planBadges'),
+  planDesignation: document.getElementById('planDesignation'),
+  planHeight: document.getElementById('planHeight'),
+  planIntensity: document.getElementById('planIntensity'),
+  planGreen: document.getElementById('planGreen'),
+  planNotes: document.getElementById('planNotes'),
+  utilitiesGrid: document.getElementById('utilitiesGrid'),
+  descriptionText: document.getElementById('descriptionText'),
+  tagsList: document.getElementById('tagsList'),
+  tagsEmpty: document.getElementById('tagsEmpty'),
+  contactName: document.getElementById('contactName'),
+  contactPhoneLink: document.getElementById('contactPhoneLink'),
+  contactEmailLink: document.getElementById('contactEmailLink'),
+  savePlotBtn: document.getElementById('savePlotBtn'),
+  inquiryForm: document.getElementById('inquiryForm'),
+  mapSection: document.getElementById('mapSection'),
+  mapElement: document.getElementById('propertyMap'),
+  mapModeButtons: Array.from(document.querySelectorAll('.map-mode-btn')),
+  authButtons: document.getElementById('authButtons'),
+  userMenu: document.getElementById('userMenu'),
+  loginBtn: document.getElementById('loginBtn'),
+  registerBtn: document.getElementById('registerBtn'),
+  accountBtn: document.getElementById('accountBtn'),
+  logoutBtn: document.getElementById('logoutBtn'),
+  mobileAuth: document.getElementById('mobileAuth'),
+  loginModal: document.getElementById('loginModal'),
+  registerModal: document.getElementById('registerModal'),
+  loginForm: document.getElementById('loginForm'),
+  registerForm: document.getElementById('registerForm'),
+  switchToRegister: document.getElementById('switchToRegister'),
+  switchToLogin: document.getElementById('switchToLogin'),
+  modalCloseButtons: Array.from(document.querySelectorAll('.modal-close')),
+  googleRegisterBtn: document.getElementById('googleLoginBtn'),
+  googleLoginBtn: document.getElementById('googleLoginBtnLogin')
+};
+
+const MAP_MODES = {
+  base: 'hybrid',
+  mpzp: 'satellite',
+  studium: 'terrain'
+};
+
+function pickValue(...values) {
+  for (const value of values) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) return trimmed;
+      continue;
+    }
+    return value;
+  }
+  return null;
+}
+
+function formatPrice(value) {
+  const formatted = formatCurrency(value);
+  return formatted ? `${formatted}` : '—';
+}
+
+function formatPerSqm(price, area) {
+  if (!Number.isFinite(price) || !Number.isFinite(area) || area <= 0) {
+    return '—';
+  }
+  const result = Math.round(price / area);
+  const formatted = formatNumber(result);
+  return formatted ? `${formatted} zł/m²` : '—';
+}
+
+function formatAreaText(value) {
+  const formatted = formatArea(value);
+  return formatted ? formatted : '—';
+}
+
+function setTextContent(element, value, fallback = '—') {
+  if (!element) return;
+  element.textContent = textContentOrFallback(value, fallback);
+}
+
+function setMultilineText(element, value, fallback = '—') {
+  if (!element) return;
+  const text = value === null || value === undefined || value === ''
+    ? fallback
+    : sanitizeMultilineText(value);
+  element.textContent = text;
+}
+
+function formatPhoneNumber(phone) {
+  if (!phone) return '';
+  const digits = String(phone).replace(/\D/g, '');
+  if (!digits) return '';
+  if (digits.length >= 9) {
+    const core = digits.slice(-9);
+    return `+48 ${core.slice(0,3)}-${core.slice(3,6)}-${core.slice(6)}`;
+  }
+  return digits;
+}
+
+function setContactLink(anchor, value, type) {
+  if (!anchor) return;
+  if (!value) {
+    anchor.textContent = type === 'phone' ? 'Brak numeru' : 'Brak adresu';
+    anchor.setAttribute('href', '#');
+    return;
+  }
+  const text = type === 'phone' ? formatPhoneNumber(value) : value.trim();
+  anchor.textContent = text || (type === 'phone' ? 'Brak numeru' : 'Brak adresu');
+  if (!text) {
+    anchor.setAttribute('href', '#');
+    return;
+  }
+  if (type === 'phone') {
+    const digits = String(value).replace(/\D/g, '');
+    anchor.setAttribute('href', digits ? `tel:${digits}` : '#');
+  } else {
+    anchor.setAttribute('href', `mailto:${text}`);
+  }
+}
+
+function renderPlanBadges(badges) {
+  if (!elements.planBadges) return;
+  const list = ensureArray(badges).map(badge => typeof badge === 'string' ? badge.trim() : badge?.label).filter(Boolean);
+  elements.planBadges.innerHTML = '';
+  if (!list.length) {
+    const chip = document.createElement('span');
+    chip.className = 'plan-badge';
+    chip.textContent = 'Brak oznaczeń';
+    elements.planBadges.appendChild(chip);
+    return;
+  }
+  list.forEach(text => {
+    const chip = document.createElement('span');
+    chip.className = 'plan-badge';
+    chip.textContent = text;
+    elements.planBadges.appendChild(chip);
+  });
+}
+
+function renderTags(tags) {
+  if (!elements.tagsList || !elements.tagsEmpty) return;
+  elements.tagsList.innerHTML = '';
+  const list = ensureArray(tags)
+    .map(tag => typeof tag === 'string' ? tag.trim() : '')
+    .filter(Boolean);
+  if (!list.length) {
+    elements.tagsEmpty.hidden = false;
+    return;
+  }
+  elements.tagsEmpty.hidden = true;
+  list.forEach(tag => {
+    const chip = document.createElement('span');
+    chip.className = 'tag-chip';
+    chip.textContent = tag;
+    elements.tagsList.appendChild(chip);
+  });
+}
+
+function renderUtilities(utilities) {
+  if (!elements.utilitiesGrid) return;
+  const source = utilities && typeof utilities === 'object' ? utilities : {};
+  const cards = Array.from(elements.utilitiesGrid.querySelectorAll('.utility-card'));
+  cards.forEach(card => {
+    const key = card.dataset.utility;
+    const rawStatus = source[key];
+    const status = normalizeUtilityStatus(rawStatus);
+    card.dataset.status = status;
+    const label = card.querySelector('.utility-status');
+    if (label) {
+      label.textContent = getUtilityLabel(status, 'details');
+    }
+  });
+}
+
+function setPrice(price) {
+  state.price = Number.isFinite(price) ? price : null;
+  elements.priceValueText.textContent = formatPrice(state.price);
+}
+
+function setArea(area) {
+  state.area = Number.isFinite(area) ? area : null;
+  const text = formatAreaText(state.area);
+  elements.propertyArea.textContent = text;
+  elements.plotAreaStat.textContent = text;
+}
+
+function renderPriceMetadata(priceUpdatedAt) {
+  const formatted = formatDateTime(priceUpdatedAt);
+  elements.priceUpdatedAt.textContent = formatted ? `Aktualizacja: ${formatted}` : 'Aktualizacja: —';
+  elements.pricePerSqm.textContent = formatPerSqm(state.price, state.area);
+}
+
+function showContent() {
+  elements.loadingState?.classList.add('hidden');
+  elements.errorState?.classList.add('hidden');
+  elements.propertyContent?.classList.remove('hidden');
+}
+
+function showError(message) {
+  elements.loadingState?.classList.add('hidden');
+  if (elements.errorState) {
+    elements.errorState.textContent = message;
+    elements.errorState.classList.remove('hidden');
+  }
+}
+
+function mergeUtilities(dataUtilities, plotUtilities) {
+  const base = {};
+  const assignUtilities = (source) => {
+    if (!source) return;
+    if (Array.isArray(source)) {
+      source.forEach(item => {
+        if (typeof item === 'string') {
+          base[item] = 'available';
+        } else if (item && typeof item === 'object' && item.type) {
+          base[item.type] = item.status || item.value || item.available;
+        }
+      });
+      return;
+    }
+    Object.entries(source).forEach(([key, value]) => {
+      base[key] = value;
+    });
+  };
+  assignUtilities(dataUtilities);
+  assignUtilities(plotUtilities);
+  return base;
+}
+
+function renderOffer(data, plot) {
+  const title = pickValue(plot.title, plot.name, plot.Id, `Działka ${state.plotIndex + 1}`);
+  elements.propertyTitle.textContent = textContentOrFallback(title, 'Działka');
+  document.title = `Grunteo - ${textContentOrFallback(title, 'Działka')}`;
+
+  const location = pickValue(plot.location, plot.city, data.city, data.location, 'Polska');
+  setTextContent(elements.propertyLocation, location, 'Polska');
+
+  const propertyType = pickValue(plot.propertyType, plot.type, data.propertyType, 'Rodzaj');
+  setTextContent(elements.propertyType, propertyType, 'Rodzaj');
+
+  const ownership = pickValue(plot.ownershipStatus, plot.ownership, data.ownershipStatus, 'Własność');
+  setTextContent(elements.ownershipStatus, ownership, 'Własność');
+
+  const priceRaw = pickValue(plot.price, data.price);
+  const price = parseNumberFromText(priceRaw);
+  setPrice(price);
+
+  const areaRaw = pickValue(plot.pow_dzialki_m2_uldk, plot.area, plot.surface, data.area);
+  const area = parseNumberFromText(areaRaw);
+  setArea(area);
+
+  renderPriceMetadata(pickValue(plot.priceUpdatedAt, data.updatedAt, data.timestamp));
+
+  setTextContent(elements.plotNumber, pickValue(plot.plotNumber, plot.Id, plot.number), '—');
+  setTextContent(elements.landRegister, pickValue(plot.landRegister, plot.kwNumber, plot.landRegistry, plot.numer_kw), '—');
+  setTextContent(elements.plotStatus, pickValue(plot.status, plot.offerStatus, data.status), '—');
+
+  setMultilineText(elements.locationAddress, pickValue(plot.locationAddress, data.address, plot.address), 'Dodaj adres działki');
+  setMultilineText(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access), 'Opisz komunikację, dostęp do drogi, najbliższe punkty orientacyjne.');
+
+  renderPlanBadges(pickValue(plot.planBadges, data.planBadges));
+  setTextContent(elements.planDesignation, pickValue(plot.planDesignation, plot.planUsage, data.planDesignation), 'Brak informacji');
+  setTextContent(elements.planHeight, pickValue(plot.planHeight, data.planHeight), '—');
+  setTextContent(elements.planIntensity, pickValue(plot.planIntensity, data.planIntensity), '—');
+  setTextContent(elements.planGreen, pickValue(plot.planGreen, data.planGreen), '—');
+  setMultilineText(elements.planNotes, pickValue(plot.planNotes, data.planNotes), 'Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.');
+
+  const utilities = mergeUtilities(data.utilities, plot.utilities);
+  renderUtilities(utilities);
+
+  setMultilineText(elements.descriptionText, pickValue(plot.description, data.description), 'Brak opisu');
+
+  renderTags(pickValue(plot.tags, data.tags));
+
+  const contactName = pickValue(plot.contactName, data.contactName, data.firstName, 'Właściciel');
+  setTextContent(elements.contactName, contactName, 'Właściciel');
+
+  const phone = pickValue(plot.contactPhone, data.contactPhone, data.phone);
+  setContactLink(elements.contactPhoneLink, phone, 'phone');
+
+  const email = pickValue(plot.contactEmail, data.contactEmail, data.email);
+  setContactLink(elements.contactEmailLink, email, 'email');
+}
+
+function setMapMode(mode) {
+  if (!state.map) return;
+  const type = MAP_MODES[mode] || MAP_MODES.base;
+  state.map.setMapTypeId(type === 'hybrid'
+    ? google.maps.MapTypeId.HYBRID
+    : type === 'satellite'
+      ? google.maps.MapTypeId.SATELLITE
+      : google.maps.MapTypeId.TERRAIN);
+}
+
+function setupMapModeButtons() {
+  elements.mapModeButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (btn.classList.contains('active')) return;
+      elements.mapModeButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      setMapMode(btn.dataset.mode);
+    });
+  });
+}
+
+async function renderMap(plot) {
+  if (!elements.mapElement) return;
+  const lat = parseFloat(pickValue(plot.lat, plot.latitude, plot.coords?.lat));
+  const lng = parseFloat(pickValue(plot.lng, plot.longitude, plot.coords?.lng));
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    elements.mapElement.innerHTML = '<p style="padding:1rem;color:var(--gray);">Brak współrzędnych do wyświetlenia mapy.</p>';
+    return;
+  }
+  try {
+    await loadGoogleMaps();
+  } catch (err) {
+    elements.mapElement.innerHTML = '<p style="padding:1rem;color:#c53030;">Nie udało się załadować mapy.</p>';
+    return;
+  }
+  const center = { lat, lng };
+  state.map = new google.maps.Map(elements.mapElement, {
+    center,
+    zoom: 15,
+    mapTypeId: google.maps.MapTypeId.HYBRID,
+    mapTypeControl: true,
+    streetViewControl: false,
+    fullscreenControl: false
+  });
+  state.marker = new google.maps.Marker({
+    map: state.map,
+    position: center,
+    title: textContentOrFallback(elements.propertyTitle?.textContent, 'Działka')
+  });
+}
+
+function setupInquiryForm() {
+  if (!elements.inquiryForm) return;
+  elements.inquiryForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const name = form.inquiryName?.value?.trim();
+    const email = form.inquiryEmail?.value?.trim();
+    const message = form.inquiryMessage?.value?.trim();
+    if (!name || !email || !message) {
+      showToast('Uzupełnij wszystkie pola formularza.', 'warning');
+      return;
+    }
+    showToast('Wiadomość została wysłana. Skontaktujemy się wkrótce.', 'success');
+    form.reset();
+  });
+}
+
+function setupSaveButton() {
+  if (!elements.savePlotBtn) return;
+  elements.savePlotBtn.addEventListener('click', () => {
+    showToast('Funkcja zapisywania działek będzie dostępna wkrótce.', 'info');
+  });
+}
+
+function openModal(modal) {
+  if (!modal) return;
+  modal.style.display = 'flex';
+}
+
+function closeModal(modal) {
+  if (!modal) return;
+  modal.style.display = 'none';
+}
+
+function setupModalHandlers() {
+  elements.modalCloseButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      closeModal(button.closest('.modal'));
+    });
+  });
+  [elements.loginModal, elements.registerModal].forEach(modal => {
+    modal?.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeModal(modal);
+      }
+    });
+  });
+}
+
+function updateAuthUI(user) {
+  state.user = user;
+  if (elements.authButtons) {
+    elements.authButtons.style.display = user ? 'none' : 'flex';
+  }
+  if (elements.userMenu) {
+    elements.userMenu.style.display = user ? 'flex' : 'none';
+  }
+
+  if (elements.mobileAuth) {
+    if (user) {
+      const label = user.displayName ? user.displayName.split(' ')[0] : (user.email || 'Konto');
+      elements.mobileAuth.innerHTML = `
+        <div class="nav-link" style="font-weight:600;"><i class="fas fa-user"></i> ${label}</div>
+        <a href="index.html#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
+        <button class="btn btn-secondary" id="mobileLogoutBtn" style="width:100%;"><i class="fas fa-sign-out-alt"></i> Wyloguj</button>
+      `;
+      const mobileLogoutBtn = document.getElementById('mobileLogoutBtn');
+      mobileLogoutBtn?.addEventListener('click', () => performLogout());
+      const mobileAccountLink = document.getElementById('mobileAccountLink');
+      mobileAccountLink?.addEventListener('click', () => {
+        window.location.href = 'index.html#userDashboard';
+      });
+    } else {
+      elements.mobileAuth.innerHTML = `
+        <button class="btn btn-outline-primary btn-sm" id="mobileLoginBtn" style="width:100%;margin-bottom:.5rem;">
+          <i class="fas fa-sign-in-alt"></i> Zaloguj się
+        </button>
+        <button class="btn btn-primary btn-sm" id="mobileRegisterBtn" style="width:100%;">
+          <i class="fas fa-user-plus"></i> Zarejestruj się
+        </button>
+      `;
+      document.getElementById('mobileLoginBtn')?.addEventListener('click', () => openModal(elements.loginModal));
+      document.getElementById('mobileRegisterBtn')?.addEventListener('click', () => openModal(elements.registerModal));
+    }
+  }
+}
+
+async function performLogout() {
+  try {
+    const { auth } = initFirebase();
+    await signOut(auth);
+    showToast('Wylogowano pomyślnie.', 'success');
+  } catch (error) {
+    showToast('Nie udało się wylogować. Spróbuj ponownie.', 'error');
+  }
+}
+
+function setupAuthUI() {
+  const { auth } = initFirebase();
+  const provider = new GoogleAuthProvider();
+  provider.setCustomParameters({ prompt: 'select_account' });
+
+  if (elements.loginBtn) {
+    elements.loginBtn.addEventListener('click', () => openModal(elements.loginModal));
+  }
+  if (elements.registerBtn) {
+    elements.registerBtn.addEventListener('click', () => openModal(elements.registerModal));
+  }
+  if (elements.accountBtn) {
+    elements.accountBtn.addEventListener('click', () => {
+      window.location.href = 'index.html#userDashboard';
+    });
+  }
+  if (elements.logoutBtn) {
+    elements.logoutBtn.addEventListener('click', () => performLogout());
+  }
+  setupModalHandlers();
+
+  elements.switchToRegister?.addEventListener('click', (event) => {
+    event.preventDefault();
+    closeModal(elements.loginModal);
+    openModal(elements.registerModal);
+  });
+  elements.switchToLogin?.addEventListener('click', (event) => {
+    event.preventDefault();
+    closeModal(elements.registerModal);
+    openModal(elements.loginModal);
+  });
+
+  elements.loginForm?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const email = event.target.loginEmail?.value?.trim();
+    const password = event.target.loginPassword?.value;
+    if (!email || !password) {
+      showToast('Podaj adres email i hasło.', 'warning');
+      return;
+    }
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      showToast('Zalogowano pomyślnie.', 'success');
+      closeModal(elements.loginModal);
+      event.target.reset();
+    } catch (error) {
+      showToast('Nie udało się zalogować: ' + (error.message || ''), 'error');
+    }
+  });
+
+  elements.registerForm?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const email = event.target.registerEmail?.value?.trim();
+    const password = event.target.registerPassword?.value;
+    if (!email || !password) {
+      showToast('Podaj adres email i hasło.', 'warning');
+      return;
+    }
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+      showToast('Konto zostało utworzone.', 'success');
+      closeModal(elements.registerModal);
+      event.target.reset();
+    } catch (error) {
+      showToast('Nie udało się utworzyć konta: ' + (error.message || ''), 'error');
+    }
+  });
+
+  const handleGoogleLogin = async () => {
+    try {
+      await signInWithPopup(auth, provider);
+      showToast('Zalogowano przez Google.', 'success');
+      closeModal(elements.loginModal);
+      closeModal(elements.registerModal);
+    } catch (error) {
+      showToast('Nie udało się zalogować przez Google.', 'error');
+    }
+  };
+
+  elements.googleRegisterBtn?.addEventListener('click', handleGoogleLogin);
+  elements.googleLoginBtn?.addEventListener('click', handleGoogleLogin);
+
+  onAuthStateChanged(auth, (user) => {
+    updateAuthUI(user);
+  });
+}
+
+async function loadProperty() {
+  if (!state.offerId) {
+    showError('Nie wskazano identyfikatora oferty.');
+    return;
+  }
+  const { db } = initFirebase();
+  try {
+    const offerRef = doc(db, 'propertyListings', state.offerId);
+    const snap = await getDoc(offerRef);
+    if (!snap.exists()) {
+      showError('Ogłoszenie nie istnieje lub zostało usunięte.');
+      return;
+    }
+    const data = snap.data();
+    const plots = Array.isArray(data.plots) ? data.plots : [];
+    const plot = plots[state.plotIndex];
+    if (!plot) {
+      showError('Nie odnaleziono wskazanej działki.');
+      return;
+    }
+    state.offerData = data;
+    state.plotData = plot;
+    renderOffer(data, plot);
+    await renderMap(plot);
+    showContent();
+  } catch (error) {
+    console.error('loadProperty', error);
+    showError('Wystąpił błąd podczas ładowania danych działki.');
+  }
+}
+
+async function init() {
+  syncMobileMenu();
+  const { offerId, plotIndex } = parseQueryParams();
+  state.offerId = offerId;
+  state.plotIndex = plotIndex;
+  initFirebase();
+  setupAuthUI();
+  setupMapModeButtons();
+  setupInquiryForm();
+  setupSaveButton();
+  await loadProperty();
+}
+
+init();

--- a/assets/edit.css
+++ b/assets/edit.css
@@ -1,0 +1,169 @@
+.edit-toolbar {
+  position: sticky;
+  top: calc(var(--nav-top, 0px) + 8px);
+  z-index: 6;
+  display: flex;
+  justify-content: flex-end;
+  gap: .6rem;
+  margin-bottom: 1rem;
+}
+
+[contenteditable="true"] {
+  outline: 2px solid transparent;
+  transition: outline-color .15s ease, background-color .15s ease;
+  border-radius: 6px;
+  cursor: text;
+}
+
+[contenteditable="true"]:hover {
+  outline-color: rgba(30,111,186,.18);
+}
+
+[contenteditable="true"]:focus {
+  outline-color: rgba(30,111,186,.45);
+  background: rgba(30,111,186,.06);
+}
+
+[contenteditable="true"].single-line {
+  white-space: nowrap;
+}
+
+.property-meta [contenteditable="true"],
+.stat-card [contenteditable="true"],
+.plan-info-grid [contenteditable="true"],
+.location-card [contenteditable="true"],
+.plan-notes[contenteditable="true"],
+.description-text[contenteditable="true"],
+.contact-card [contenteditable="true"] {
+  min-height: 1.2em;
+}
+
+.utilities-grid .utility-card {
+  cursor: pointer;
+  transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+}
+
+.utilities-grid .utility-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+.utilities-grid .utility-card[data-status="available"] {
+  border-color: rgba(34,197,94,.35);
+  background: #ecfdf5;
+}
+
+.utilities-grid .utility-card[data-status="planned"] {
+  border-color: rgba(250,204,21,.35);
+  background: #fffbeb;
+}
+
+.utilities-grid .utility-card[data-status="missing"] {
+  border-color: rgba(148,163,184,.35);
+  background: #fff;
+}
+
+.utilities-grid .utility-card[data-status="available"] .utility-status {
+  color: #047857;
+}
+
+.utilities-grid .utility-card[data-status="planned"] .utility-status {
+  color: #b45309;
+}
+
+.utilities-grid .utility-card[data-status="missing"] .utility-status {
+  color: var(--gray);
+}
+
+.tags-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tag-form {
+  display: flex;
+  gap: .6rem;
+  flex-wrap: wrap;
+}
+
+.tag-form input {
+  flex: 1 1 220px;
+  padding: .6rem .8rem;
+  border-radius: 10px;
+  border: 1px solid rgba(30,111,186,.25);
+  font-size: .95rem;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.tag-form input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(30,111,186,.16);
+}
+
+.tag-form button {
+  align-self: center;
+}
+
+.tag-chip.removable {
+  background: #e6f2ff;
+  color: var(--darker);
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  padding-right: .5rem;
+}
+
+.tag-chip .tag-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(15,23,42,.12);
+  color: var(--darker);
+  font-size: .75rem;
+  font-weight: 700;
+}
+
+.tag-chip .tag-remove:hover {
+  background: rgba(15,23,42,.25);
+}
+
+.tag-chip button.tag-remove {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+
+.contact-details a[contenteditable="true"] {
+  display: inline-block;
+  min-width: 4ch;
+}
+
+.description-text[contenteditable="true"] {
+  min-height: 160px;
+}
+
+.plan-notes[contenteditable="true"] {
+  min-height: 120px;
+}
+
+.edit-toolbar .btn {
+  box-shadow: var(--shadow-md);
+}
+
+@media (max-width: 768px) {
+  .edit-toolbar {
+    position: static;
+    justify-content: stretch;
+  }
+
+  .edit-toolbar .btn {
+    width: 100%;
+  }
+}
+

--- a/assets/edit.js
+++ b/assets/edit.js
@@ -1,0 +1,861 @@
+import {
+  initFirebase,
+  doc,
+  getDoc,
+  updateDoc,
+  serverTimestamp,
+  onAuthStateChanged,
+  parseQueryParams,
+  formatNumber,
+  formatCurrency,
+  formatArea,
+  formatDateTime,
+  normalizeUtilityStatus,
+  getUtilityLabel,
+  UTILITY_ORDER,
+  loadGoogleMaps,
+  showToast,
+  textContentOrFallback,
+  sanitizeMultilineText,
+  ensureArray,
+  parseNumberFromText,
+  cloneDeep,
+  stripHtml,
+  syncMobileMenu
+} from './property-common.js';
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  GoogleAuthProvider,
+  signInWithPopup
+} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
+
+const state = {
+  user: null,
+  offerId: '',
+  plotIndex: 0,
+  offerData: null,
+  plotData: null,
+  utilities: {},
+  tags: [],
+  price: null,
+  area: null,
+  saving: false,
+  planBadges: null,
+  map: null,
+  marker: null,
+  hasLoaded: false
+};
+
+const elements = {
+  loadingState: document.getElementById('loadingState'),
+  errorState: document.getElementById('errorState'),
+  propertyContent: document.getElementById('propertyContent'),
+  saveChangesBtn: document.getElementById('saveChangesBtn'),
+  propertyTitle: document.getElementById('propertyTitle'),
+  propertyLocation: document.getElementById('propertyLocation'),
+  propertyArea: document.getElementById('propertyArea'),
+  propertyType: document.getElementById('propertyType'),
+  ownershipStatus: document.getElementById('ownershipStatus'),
+  priceValueText: document.getElementById('priceValueText'),
+  pricePerSqm: document.getElementById('pricePerSqm'),
+  priceUpdatedAt: document.getElementById('priceUpdatedAt'),
+  plotNumber: document.getElementById('plotNumber'),
+  landRegister: document.getElementById('landRegister'),
+  plotAreaStat: document.getElementById('plotAreaStat'),
+  plotStatus: document.getElementById('plotStatus'),
+  locationAddress: document.getElementById('locationAddress'),
+  locationAccess: document.getElementById('locationAccess'),
+  planBadges: document.getElementById('planBadges'),
+  planDesignation: document.getElementById('planDesignation'),
+  planHeight: document.getElementById('planHeight'),
+  planIntensity: document.getElementById('planIntensity'),
+  planGreen: document.getElementById('planGreen'),
+  planNotes: document.getElementById('planNotes'),
+  utilitiesGrid: document.getElementById('utilitiesGrid'),
+  descriptionText: document.getElementById('descriptionText'),
+  tagsList: document.getElementById('tagsList'),
+  tagsEmpty: document.getElementById('tagsEmpty'),
+  tagInput: document.getElementById('tagInput'),
+  addTagBtn: document.getElementById('addTagBtn'),
+  contactName: document.getElementById('contactName'),
+  contactPhoneLink: document.getElementById('contactPhoneLink'),
+  contactEmailLink: document.getElementById('contactEmailLink'),
+  mapElement: document.getElementById('propertyMap'),
+  mapModeButtons: Array.from(document.querySelectorAll('.map-mode-btn')),
+  authButtons: document.getElementById('authButtons'),
+  userMenu: document.getElementById('userMenu'),
+  loginBtn: document.getElementById('loginBtn'),
+  registerBtn: document.getElementById('registerBtn'),
+  accountBtn: document.getElementById('accountBtn'),
+  logoutBtn: document.getElementById('logoutBtn'),
+  mobileAuth: document.getElementById('mobileAuth'),
+  loginModal: document.getElementById('loginModal'),
+  registerModal: document.getElementById('registerModal'),
+  loginForm: document.getElementById('loginForm'),
+  registerForm: document.getElementById('registerForm'),
+  switchToRegister: document.getElementById('switchToRegister'),
+  switchToLogin: document.getElementById('switchToLogin'),
+  modalCloseButtons: Array.from(document.querySelectorAll('.modal-close')),
+  googleRegisterBtn: document.getElementById('googleLoginBtn'),
+  googleLoginBtn: document.getElementById('googleLoginBtnLogin')
+};
+
+const MAP_MODES = {
+  base: 'hybrid',
+  mpzp: 'satellite',
+  studium: 'terrain'
+};
+
+function pickValue(...values) {
+  for (const value of values) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) return trimmed;
+      continue;
+    }
+    return value;
+  }
+  return null;
+}
+
+function formatPerSqm(price, area) {
+  if (!Number.isFinite(price) || !Number.isFinite(area) || area <= 0) {
+    return '—';
+  }
+  const ppm = Math.round(price / area);
+  const formatted = formatNumber(ppm);
+  return formatted ? `${formatted} zł/m²` : '—';
+}
+
+function formatPrice(value) {
+  const formatted = formatCurrency(value);
+  return formatted ? `${formatted}` : '—';
+}
+
+function formatAreaText(value) {
+  const formatted = formatArea(value);
+  return formatted ? formatted : '—';
+}
+
+function setPriceEdit(price) {
+  state.price = Number.isFinite(price) ? price : null;
+  elements.priceValueText.textContent = formatPrice(state.price);
+  updatePricePerSqm();
+}
+
+let updatingArea = false;
+function setAreaEdit(area) {
+  state.area = Number.isFinite(area) ? area : null;
+  updateAreaDisplay();
+  updatePricePerSqm();
+}
+
+function updateAreaDisplay() {
+  const text = formatAreaText(state.area);
+  updatingArea = true;
+  elements.propertyArea.textContent = text;
+  elements.plotAreaStat.textContent = text;
+  updatingArea = false;
+}
+
+function updatePricePerSqm() {
+  elements.pricePerSqm.textContent = formatPerSqm(state.price, state.area);
+}
+
+function renderPriceUpdatedAt(value) {
+  const formatted = formatDateTime(value);
+  elements.priceUpdatedAt.textContent = formatted ? `Aktualizacja: ${formatted}` : 'Aktualizacja: —';
+}
+
+function formatPhoneNumber(phone) {
+  if (!phone) return '';
+  const digits = String(phone).replace(/\D/g, '');
+  if (!digits) return '';
+  if (digits.length >= 9) {
+    const core = digits.slice(-9);
+    return `+48 ${core.slice(0,3)}-${core.slice(3,6)}-${core.slice(6)}`;
+  }
+  return digits;
+}
+
+function updateContactPhoneHref() {
+  if (!elements.contactPhoneLink) return;
+  const raw = stripHtml(elements.contactPhoneLink.innerHTML).trim();
+  const digits = raw.replace(/\D/g, '');
+  elements.contactPhoneLink.href = digits ? `tel:${digits}` : '#';
+}
+
+function updateContactEmailHref() {
+  if (!elements.contactEmailLink) return;
+  const raw = stripHtml(elements.contactEmailLink.innerHTML).trim();
+  elements.contactEmailLink.href = raw ? `mailto:${raw}` : '#';
+}
+
+function renderPlanBadges(badges) {
+  if (!elements.planBadges) return;
+  elements.planBadges.innerHTML = '';
+  const list = ensureArray(badges)
+    .map(item => typeof item === 'string' ? item.trim() : item?.label)
+    .filter(Boolean);
+  if (!list.length) {
+    const chip = document.createElement('span');
+    chip.className = 'plan-badge';
+    chip.textContent = 'Brak oznaczeń';
+    elements.planBadges.appendChild(chip);
+    return;
+  }
+  list.forEach(text => {
+    const chip = document.createElement('span');
+    chip.className = 'plan-badge';
+    chip.textContent = text;
+    elements.planBadges.appendChild(chip);
+  });
+}
+
+function mergeUtilities(dataUtilities, plotUtilities) {
+  const base = {};
+  const assign = (source) => {
+    if (!source) return;
+    if (Array.isArray(source)) {
+      source.forEach(item => {
+        if (typeof item === 'string') {
+          base[item] = 'available';
+        } else if (item && typeof item === 'object' && item.type) {
+          base[item.type] = item.status || item.value || item.available;
+        }
+      });
+      return;
+    }
+    Object.entries(source).forEach(([key, value]) => {
+      base[key] = value;
+    });
+  };
+  assign(dataUtilities);
+  assign(plotUtilities);
+  return base;
+}
+
+function renderUtilitiesEdit() {
+  if (!elements.utilitiesGrid) return;
+  const cards = Array.from(elements.utilitiesGrid.querySelectorAll('.utility-card'));
+  cards.forEach(card => {
+    const key = card.dataset.utility;
+    const status = normalizeUtilityStatus(state.utilities[key]);
+    state.utilities[key] = status;
+    card.dataset.status = status;
+    const label = card.querySelector('.utility-status');
+    if (label) {
+      label.textContent = getUtilityLabel(status, 'edit');
+    }
+  });
+}
+
+function renderTagsEdit() {
+  if (!elements.tagsList || !elements.tagsEmpty) return;
+  elements.tagsList.innerHTML = '';
+  if (!state.tags.length) {
+    elements.tagsEmpty.hidden = false;
+    return;
+  }
+  elements.tagsEmpty.hidden = true;
+  state.tags.forEach((tag, index) => {
+    const chip = document.createElement('span');
+    chip.className = 'tag-chip removable';
+    chip.innerHTML = `<span>${tag}</span><button type="button" class="tag-remove" data-index="${index}" aria-label="Usuń znacznik">&times;</button>`;
+    elements.tagsList.appendChild(chip);
+  });
+}
+
+function showContent() {
+  elements.loadingState?.classList.add('hidden');
+  elements.errorState?.classList.add('hidden');
+  elements.propertyContent?.classList.remove('hidden');
+}
+
+function showError(message) {
+  elements.loadingState?.classList.add('hidden');
+  if (elements.errorState) {
+    elements.errorState.textContent = message;
+    elements.errorState.classList.remove('hidden');
+  }
+  elements.propertyContent?.classList.add('hidden');
+}
+
+function redirectToDetails() {
+  const url = `details.html?id=${encodeURIComponent(state.offerId)}&plot=${state.plotIndex}`;
+  window.location.replace(url);
+}
+
+function selectAllText(element) {
+  if (!element) return;
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function preventNewline(element) {
+  element?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+    }
+  });
+}
+
+function attachEditorListeners() {
+  if (elements.priceValueText) {
+    elements.priceValueText.addEventListener('focus', () => {
+      if (state.price !== null) {
+        elements.priceValueText.textContent = String(state.price);
+        selectAllText(elements.priceValueText);
+      } else {
+        elements.priceValueText.textContent = '';
+      }
+    });
+    elements.priceValueText.addEventListener('input', () => {
+      const value = parseNumberFromText(elements.priceValueText.textContent);
+      state.price = Number.isFinite(value) ? value : null;
+      updatePricePerSqm();
+    });
+    elements.priceValueText.addEventListener('blur', () => {
+      const value = parseNumberFromText(elements.priceValueText.textContent);
+      state.price = Number.isFinite(value) ? value : null;
+      elements.priceValueText.textContent = formatPrice(state.price);
+      updatePricePerSqm();
+    });
+  }
+
+  const handleAreaFocus = (element) => {
+    element.addEventListener('focus', () => {
+      if (state.area !== null) {
+        element.textContent = String(state.area);
+        selectAllText(element);
+      } else {
+        element.textContent = '';
+      }
+    });
+  };
+
+  const handleAreaBlur = (element) => {
+    element.addEventListener('blur', () => {
+      const value = parseNumberFromText(element.textContent);
+      state.area = Number.isFinite(value) ? value : null;
+      updateAreaDisplay();
+      updatePricePerSqm();
+    });
+  };
+
+  const handleAreaInput = (element) => {
+    element.addEventListener('input', () => {
+      if (updatingArea) return;
+      const value = parseNumberFromText(element.textContent);
+      state.area = Number.isFinite(value) ? value : null;
+      updatePricePerSqm();
+    });
+  };
+
+  [elements.propertyArea, elements.plotAreaStat].forEach(element => {
+    if (!element) return;
+    handleAreaFocus(element);
+    handleAreaBlur(element);
+    handleAreaInput(element);
+  });
+
+  [
+    elements.propertyTitle,
+    elements.propertyLocation,
+    elements.propertyType,
+    elements.ownershipStatus,
+    elements.plotNumber,
+    elements.landRegister,
+    elements.plotStatus,
+    elements.planDesignation,
+    elements.planHeight,
+    elements.planIntensity,
+    elements.planGreen,
+    elements.contactName,
+    elements.contactPhoneLink,
+    elements.contactEmailLink
+  ].forEach(element => {
+    preventNewline(element);
+    element?.addEventListener('blur', () => {
+      const text = stripHtml(element.innerHTML).trim();
+      element.textContent = text;
+      if (element === elements.contactPhoneLink) {
+        updateContactPhoneHref();
+      }
+      if (element === elements.contactEmailLink) {
+        updateContactEmailHref();
+      }
+    });
+  });
+
+  elements.contactPhoneLink?.addEventListener('input', () => {
+    const formatted = formatPhoneNumber(stripHtml(elements.contactPhoneLink.innerHTML));
+    if (formatted) {
+      elements.contactPhoneLink.textContent = formatted;
+      selectAllText(elements.contactPhoneLink);
+    }
+  });
+
+  elements.utilitiesGrid?.addEventListener('click', (event) => {
+    const card = event.target.closest('.utility-card');
+    if (!card) return;
+    const key = card.dataset.utility;
+    const current = card.dataset.status || 'missing';
+    const index = UTILITY_ORDER.indexOf(current);
+    const next = UTILITY_ORDER[(index + 1) % UTILITY_ORDER.length];
+    card.dataset.status = next;
+    const label = card.querySelector('.utility-status');
+    if (label) {
+      label.textContent = getUtilityLabel(next, 'edit');
+    }
+    state.utilities[key] = next;
+  });
+
+  elements.addTagBtn?.addEventListener('click', () => {
+    addTag(elements.tagInput?.value || '');
+  });
+
+  elements.tagInput?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      addTag(elements.tagInput.value || '');
+    }
+  });
+
+  elements.tagsList?.addEventListener('click', (event) => {
+    const button = event.target.closest('.tag-remove');
+    if (!button) return;
+    const index = Number.parseInt(button.dataset.index, 10);
+    if (Number.isInteger(index)) {
+      state.tags.splice(index, 1);
+      renderTagsEdit();
+    }
+  });
+}
+
+function addTag(rawValue) {
+  const value = (rawValue || '').trim();
+  if (!value) {
+    showToast('Podaj treść znacznika.', 'warning');
+    return;
+  }
+  const tag = value.startsWith('#') ? value : `#${value}`;
+  if (state.tags.some(existing => existing.toLowerCase() === tag.toLowerCase())) {
+    showToast('Taki znacznik już istnieje.', 'info');
+    if (elements.tagInput) elements.tagInput.value = '';
+    return;
+  }
+  state.tags.push(tag);
+  renderTagsEdit();
+  if (elements.tagInput) elements.tagInput.value = '';
+}
+
+function renderEditor(data, plot) {
+  const rebind = !!state.plotData;
+  state.offerData = data;
+  state.plotData = cloneDeep(plot);
+
+  const title = pickValue(plot.title, plot.name, plot.Id, `Działka ${state.plotIndex + 1}`);
+  elements.propertyTitle.textContent = textContentOrFallback(title, 'Działka');
+  document.title = `Edycja działki - ${textContentOrFallback(title, 'Działka')}`;
+
+  const location = pickValue(plot.location, plot.city, data.city, data.location, 'Polska');
+  elements.propertyLocation.textContent = textContentOrFallback(location, 'Polska');
+
+  const propertyType = pickValue(plot.propertyType, plot.type, data.propertyType, 'Rodzaj');
+  elements.propertyType.textContent = textContentOrFallback(propertyType, 'Rodzaj');
+
+  const ownership = pickValue(plot.ownershipStatus, plot.ownership, data.ownershipStatus, 'Własność');
+  elements.ownershipStatus.textContent = textContentOrFallback(ownership, 'Własność');
+
+  const price = parseNumberFromText(pickValue(plot.price, data.price));
+  setPriceEdit(price);
+
+  const area = parseNumberFromText(pickValue(plot.pow_dzialki_m2_uldk, plot.area, data.area));
+  setAreaEdit(area);
+
+  renderPriceUpdatedAt(pickValue(plot.priceUpdatedAt, data.updatedAt, data.timestamp));
+
+  elements.plotNumber.textContent = textContentOrFallback(pickValue(plot.plotNumber, plot.Id, plot.number), '—');
+  elements.landRegister.textContent = textContentOrFallback(pickValue(plot.landRegister, plot.kwNumber, plot.landRegistry, plot.numer_kw), '—');
+  elements.plotStatus.textContent = textContentOrFallback(pickValue(plot.status, plot.offerStatus, data.status), '—');
+
+  elements.locationAddress.textContent = sanitizeMultilineText(pickValue(plot.locationAddress, data.address, plot.address) || '');
+  elements.locationAccess.textContent = sanitizeMultilineText(pickValue(plot.locationAccess, plot.access, data.access) || '');
+
+  state.planBadges = cloneDeep(pickValue(plot.planBadges, data.planBadges));
+  renderPlanBadges(state.planBadges);
+  elements.planDesignation.textContent = textContentOrFallback(pickValue(plot.planDesignation, plot.planUsage, data.planDesignation), 'Brak informacji');
+  elements.planHeight.textContent = textContentOrFallback(pickValue(plot.planHeight, data.planHeight), '—');
+  elements.planIntensity.textContent = textContentOrFallback(pickValue(plot.planIntensity, data.planIntensity), '—');
+  elements.planGreen.textContent = textContentOrFallback(pickValue(plot.planGreen, data.planGreen), '—');
+  elements.planNotes.textContent = sanitizeMultilineText(pickValue(plot.planNotes, data.planNotes) || '');
+
+  state.utilities = mergeUtilities(data.utilities, plot.utilities);
+  renderUtilitiesEdit();
+
+  elements.descriptionText.textContent = sanitizeMultilineText(pickValue(plot.description, data.description) || '');
+
+  state.tags = ensureArray(pickValue(plot.tags, data.tags))
+    .map(tag => typeof tag === 'string' ? tag.trim() : '')
+    .filter(Boolean);
+  renderTagsEdit();
+
+  const contactName = pickValue(plot.contactName, data.contactName, data.firstName, 'Właściciel');
+  elements.contactName.textContent = textContentOrFallback(contactName, 'Właściciel');
+
+  const phone = pickValue(plot.contactPhone, data.contactPhone, data.phone);
+  if (phone) {
+    elements.contactPhoneLink.textContent = formatPhoneNumber(phone);
+  } else {
+    elements.contactPhoneLink.textContent = 'Brak numeru';
+  }
+  updateContactPhoneHref();
+
+  const email = pickValue(plot.contactEmail, data.contactEmail, data.email);
+  elements.contactEmailLink.textContent = textContentOrFallback(email, 'Brak adresu');
+  updateContactEmailHref();
+
+  if (!rebind) {
+    attachEditorListeners();
+  }
+}
+
+function setupMapModeButtons() {
+  elements.mapModeButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (btn.classList.contains('active')) return;
+      elements.mapModeButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      setMapMode(btn.dataset.mode);
+    });
+  });
+}
+
+function setMapMode(mode) {
+  if (!state.map) return;
+  const type = MAP_MODES[mode] || MAP_MODES.base;
+  state.map.setMapTypeId(type === 'hybrid'
+    ? google.maps.MapTypeId.HYBRID
+    : type === 'satellite'
+      ? google.maps.MapTypeId.SATELLITE
+      : google.maps.MapTypeId.TERRAIN);
+}
+
+async function renderMap(plot) {
+  if (!elements.mapElement) return;
+  const lat = parseFloat(pickValue(plot.lat, plot.latitude, plot.coords?.lat));
+  const lng = parseFloat(pickValue(plot.lng, plot.longitude, plot.coords?.lng));
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    elements.mapElement.innerHTML = '<p style="padding:1rem;color:var(--gray);">Brak współrzędnych do wyświetlenia mapy.</p>';
+    return;
+  }
+  try {
+    await loadGoogleMaps();
+  } catch (error) {
+    elements.mapElement.innerHTML = '<p style="padding:1rem;color:#c53030;">Nie udało się załadować mapy.</p>';
+    return;
+  }
+  const center = { lat, lng };
+  state.map = new google.maps.Map(elements.mapElement, {
+    center,
+    zoom: 15,
+    mapTypeId: google.maps.MapTypeId.HYBRID,
+    mapTypeControl: true,
+    streetViewControl: false,
+    fullscreenControl: false
+  });
+  state.marker = new google.maps.Marker({
+    map: state.map,
+    position: center,
+    title: textContentOrFallback(elements.propertyTitle?.textContent, 'Działka')
+  });
+}
+
+function openModal(modal) {
+  if (!modal) return;
+  modal.style.display = 'flex';
+}
+
+function closeModal(modal) {
+  if (!modal) return;
+  modal.style.display = 'none';
+}
+
+function setupModalHandlers() {
+  elements.modalCloseButtons.forEach(button => {
+    button.addEventListener('click', () => closeModal(button.closest('.modal')));
+  });
+  [elements.loginModal, elements.registerModal].forEach(modal => {
+    modal?.addEventListener('click', (event) => {
+      if (event.target === modal) closeModal(modal);
+    });
+  });
+}
+
+function updateAuthUI(user) {
+  state.user = user;
+  if (elements.authButtons) {
+    elements.authButtons.style.display = user ? 'none' : 'flex';
+  }
+  if (elements.userMenu) {
+    elements.userMenu.style.display = user ? 'flex' : 'none';
+  }
+  if (elements.mobileAuth) {
+    if (user) {
+      const label = user.displayName ? user.displayName.split(' ')[0] : (user.email || 'Konto');
+      elements.mobileAuth.innerHTML = `
+        <div class="nav-link" style="font-weight:600;"><i class="fas fa-user"></i> ${label}</div>
+        <a href="index.html#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
+        <button class="btn btn-secondary" id="mobileLogoutBtn" style="width:100%;"><i class="fas fa-sign-out-alt"></i> Wyloguj</button>
+      `;
+      document.getElementById('mobileLogoutBtn')?.addEventListener('click', () => performLogout());
+      document.getElementById('mobileAccountLink')?.addEventListener('click', () => {
+        window.location.href = 'index.html#userDashboard';
+      });
+    } else {
+      elements.mobileAuth.innerHTML = `
+        <button class="btn btn-outline-primary btn-sm" id="mobileLoginBtn" style="width:100%;margin-bottom:.5rem;">
+          <i class="fas fa-sign-in-alt"></i> Zaloguj się
+        </button>
+        <button class="btn btn-primary btn-sm" id="mobileRegisterBtn" style="width:100%;">
+          <i class="fas fa-user-plus"></i> Zarejestruj się
+        </button>
+      `;
+      document.getElementById('mobileLoginBtn')?.addEventListener('click', () => openModal(elements.loginModal));
+      document.getElementById('mobileRegisterBtn')?.addEventListener('click', () => openModal(elements.registerModal));
+    }
+  }
+}
+
+async function performLogout() {
+  try {
+    const { auth } = initFirebase();
+    await signOut(auth);
+    showToast('Wylogowano pomyślnie.', 'success');
+  } catch (error) {
+    showToast('Nie udało się wylogować. Spróbuj ponownie.', 'error');
+  }
+}
+
+function setupAuthUI() {
+  const { auth } = initFirebase();
+  const provider = new GoogleAuthProvider();
+  provider.setCustomParameters({ prompt: 'select_account' });
+
+  elements.loginBtn?.addEventListener('click', () => openModal(elements.loginModal));
+  elements.registerBtn?.addEventListener('click', () => openModal(elements.registerModal));
+  elements.accountBtn?.addEventListener('click', () => {
+    window.location.href = 'index.html#userDashboard';
+  });
+  elements.logoutBtn?.addEventListener('click', () => performLogout());
+
+  setupModalHandlers();
+
+  elements.switchToRegister?.addEventListener('click', (event) => {
+    event.preventDefault();
+    closeModal(elements.loginModal);
+    openModal(elements.registerModal);
+  });
+  elements.switchToLogin?.addEventListener('click', (event) => {
+    event.preventDefault();
+    closeModal(elements.registerModal);
+    openModal(elements.loginModal);
+  });
+
+  elements.loginForm?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const email = event.target.loginEmail?.value?.trim();
+    const password = event.target.loginPassword?.value;
+    if (!email || !password) {
+      showToast('Podaj adres email i hasło.', 'warning');
+      return;
+    }
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      showToast('Zalogowano pomyślnie.', 'success');
+      closeModal(elements.loginModal);
+      event.target.reset();
+    } catch (error) {
+      showToast('Nie udało się zalogować: ' + (error.message || ''), 'error');
+    }
+  });
+
+  elements.registerForm?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const email = event.target.registerEmail?.value?.trim();
+    const password = event.target.registerPassword?.value;
+    if (!email || !password) {
+      showToast('Podaj adres email i hasło.', 'warning');
+      return;
+    }
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+      showToast('Konto zostało utworzone.', 'success');
+      closeModal(elements.registerModal);
+      event.target.reset();
+    } catch (error) {
+      showToast('Nie udało się utworzyć konta: ' + (error.message || ''), 'error');
+    }
+  });
+
+  const handleGoogleLogin = async () => {
+    try {
+      await signInWithPopup(auth, provider);
+      showToast('Zalogowano przez Google.', 'success');
+      closeModal(elements.loginModal);
+      closeModal(elements.registerModal);
+    } catch (error) {
+      showToast('Nie udało się zalogować przez Google.', 'error');
+    }
+  };
+
+  elements.googleRegisterBtn?.addEventListener('click', handleGoogleLogin);
+  elements.googleLoginBtn?.addEventListener('click', handleGoogleLogin);
+
+  onAuthStateChanged(auth, async (user) => {
+    updateAuthUI(user);
+    if (!user) {
+      showToast('Zaloguj się, aby edytować ofertę.', 'info');
+      redirectToDetails();
+      return;
+    }
+    state.user = user;
+    if (!state.hasLoaded) {
+      await loadProperty();
+      state.hasLoaded = true;
+    }
+  });
+}
+
+function validatePlot(plot) {
+  if (plot.price !== null && plot.price < 0) {
+    showToast('Cena nie może być ujemna.', 'error');
+    return false;
+  }
+  if (plot.pow_dzialki_m2_uldk !== null && plot.pow_dzialki_m2_uldk <= 0) {
+    showToast('Powierzchnia musi być większa od zera.', 'error');
+    return false;
+  }
+  return true;
+}
+
+function buildUpdatedPlot() {
+  const base = cloneDeep(state.plotData || {});
+  base.title = stripHtml(elements.propertyTitle.innerHTML).trim() || 'Działka';
+  base.location = stripHtml(elements.propertyLocation.innerHTML).trim();
+  base.propertyType = stripHtml(elements.propertyType.innerHTML).trim();
+  base.ownershipStatus = stripHtml(elements.ownershipStatus.innerHTML).trim();
+  base.price = state.price;
+  base.pricePerSqm = state.price && state.area ? Math.round(state.price / state.area) : null;
+  base.priceUpdatedAt = new Date().toISOString();
+  base.pow_dzialki_m2_uldk = state.area;
+  base.area = state.area;
+  base.plotNumber = stripHtml(elements.plotNumber.innerHTML).trim();
+  base.landRegister = stripHtml(elements.landRegister.innerHTML).trim();
+  base.status = stripHtml(elements.plotStatus.innerHTML).trim();
+  base.locationAddress = sanitizeMultilineText(elements.locationAddress.textContent || '');
+  base.locationAccess = sanitizeMultilineText(elements.locationAccess.textContent || '');
+  base.planDesignation = stripHtml(elements.planDesignation.innerHTML).trim();
+  base.planHeight = stripHtml(elements.planHeight.innerHTML).trim();
+  base.planIntensity = stripHtml(elements.planIntensity.innerHTML).trim();
+  base.planGreen = stripHtml(elements.planGreen.innerHTML).trim();
+  base.planNotes = sanitizeMultilineText(elements.planNotes.textContent || '');
+  base.description = sanitizeMultilineText(elements.descriptionText.textContent || '');
+  base.utilities = { ...state.utilities };
+  base.tags = [...state.tags];
+  base.contactName = stripHtml(elements.contactName.innerHTML).trim();
+  base.contactPhone = stripHtml(elements.contactPhoneLink.innerHTML).trim();
+  base.contactEmail = stripHtml(elements.contactEmailLink.innerHTML).trim();
+  base.planBadges = state.planBadges || base.planBadges || [];
+  return base;
+}
+
+async function handleSave() {
+  if (state.saving) return;
+  const updatedPlot = buildUpdatedPlot();
+  if (!validatePlot(updatedPlot)) return;
+
+  try {
+    state.saving = true;
+    if (elements.saveChangesBtn) elements.saveChangesBtn.disabled = true;
+    const { db } = initFirebase();
+    const offerRef = doc(db, 'propertyListings', state.offerId);
+    const plots = Array.isArray(state.offerData?.plots) ? cloneDeep(state.offerData.plots) : [];
+    plots[state.plotIndex] = updatedPlot;
+    await updateDoc(offerRef, { plots, updatedAt: serverTimestamp() });
+    showToast('Zapisano zmiany.', 'success');
+    state.offerData.plots = plots;
+    state.plotData = cloneDeep(updatedPlot);
+    renderPriceUpdatedAt(new Date());
+    setPriceEdit(state.price);
+    setAreaEdit(state.area);
+    renderUtilitiesEdit();
+    renderTagsEdit();
+  } catch (error) {
+    console.error('handleSave', error);
+    showToast('Nie udało się zapisać zmian. Spróbuj ponownie.', 'error');
+  } finally {
+    state.saving = false;
+    if (elements.saveChangesBtn) elements.saveChangesBtn.disabled = false;
+  }
+}
+
+async function loadProperty() {
+  if (!state.offerId) {
+    showError('Nie wskazano oferty do edycji.');
+    return;
+  }
+  const { db } = initFirebase();
+  try {
+    const offerRef = doc(db, 'propertyListings', state.offerId);
+    const snap = await getDoc(offerRef);
+    if (!snap.exists()) {
+      showError('Ogłoszenie nie istnieje lub zostało usunięte.');
+      return;
+    }
+    const data = snap.data();
+    const ownerUid = pickValue(data.ownerUid, data.userUid, data.uid, data.ownerId);
+    if (ownerUid && ownerUid !== state.user?.uid) {
+      showToast('Nie masz uprawnień do edycji tej oferty.', 'error');
+      redirectToDetails();
+      return;
+    }
+    const plots = Array.isArray(data.plots) ? data.plots : [];
+    const plot = plots[state.plotIndex];
+    if (!plot) {
+      showError('Nie odnaleziono wskazanej działki.');
+      return;
+    }
+    renderEditor(data, plot);
+    await renderMap(plot);
+    showContent();
+  } catch (error) {
+    console.error('loadProperty', error);
+    showError('Wystąpił błąd podczas wczytywania danych.');
+  }
+}
+
+async function init() {
+  syncMobileMenu();
+  const { offerId, plotIndex } = parseQueryParams();
+  state.offerId = offerId;
+  state.plotIndex = plotIndex;
+  if (!offerId) {
+    showError('Nie wskazano oferty do edycji.');
+    return;
+  }
+  initFirebase();
+  setupAuthUI();
+  setupMapModeButtons();
+  elements.saveChangesBtn?.addEventListener('click', () => handleSave());
+}
+
+init();

--- a/assets/property-common.js
+++ b/assets/property-common.js
@@ -1,0 +1,311 @@
+import { initializeApp, getApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import {
+  getFirestore,
+  doc,
+  getDoc,
+  updateDoc,
+  serverTimestamp
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+import {
+  getAuth,
+  onAuthStateChanged
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBdhMIiqetOfDGP85ERxtgwn3AXR50pBcE",
+  authDomain: "base-468e0.firebaseapp.com",
+  projectId: "base-468e0",
+  storageBucket: "base-468e0.firebasestorage.app",
+  messagingSenderId: "829161895559",
+  appId: "1:829161895559:web:d832541aac05b35847ea22"
+};
+
+let firebaseCache = null;
+
+export function initFirebase() {
+  if (firebaseCache) {
+    return firebaseCache;
+  }
+  const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+  const auth = getAuth(app);
+  firebaseCache = { app, db, auth };
+  return firebaseCache;
+}
+
+export { doc, getDoc, updateDoc, serverTimestamp, onAuthStateChanged };
+
+export function parseQueryParams() {
+  const params = new URLSearchParams(window.location.search);
+  const offerId = params.get("id") || "";
+  const plotParam = params.get("plot");
+  const plotIndex = plotParam !== null ? Number.parseInt(plotParam, 10) : 0;
+  return {
+    offerId,
+    plotIndex: Number.isFinite(plotIndex) && plotIndex >= 0 ? plotIndex : 0
+  };
+}
+
+export function formatNumber(value, options = {}) {
+  let number;
+  if (typeof value === "string") {
+    number = parseNumberFromText(value);
+  } else {
+    number = Number(value);
+  }
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+  return new Intl.NumberFormat("pl-PL", options).format(number);
+}
+
+export function parseNumberFromText(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  const text = String(value)
+    .replace(/[\u00A0]/g, "")
+    .replace(/\s+/g, "")
+    .replace(/zł|pln|m²|m2/gi, "")
+    .replace(/,/g, ".")
+    .replace(/[^0-9+\-.]/g, "");
+  if (!text) {
+    return null;
+  }
+  const parsed = Number.parseFloat(text);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function formatCurrency(value) {
+  const formatted = formatNumber(value);
+  return formatted ? `${formatted} zł` : null;
+}
+
+export function formatArea(value) {
+  const formatted = formatNumber(value);
+  return formatted ? `${formatted} m²` : null;
+}
+
+export function toDate(value) {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === "string") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof value === "object") {
+    if (typeof value.toDate === "function") {
+      const date = value.toDate();
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+    if ("seconds" in value && typeof value.seconds === "number") {
+      const date = new Date(value.seconds * 1000);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+  }
+  return null;
+}
+
+export function formatDateTime(value) {
+  const date = toDate(value);
+  if (!date) {
+    return null;
+  }
+  return new Intl.DateTimeFormat("pl-PL", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(date);
+}
+
+export const UTILITY_ORDER = ["missing", "planned", "available"];
+
+const UTILITY_SYNONYMS = {
+  available: ["available", "dostepne", "dostępne", "yes", "tak", "true", "1", "on", "available"],
+  planned: ["planned", "w drodze", "wdrodze", "droga", "planned", "2", "soon", "plan", "planowana"],
+  missing: ["missing", "brak", "no", "false", "0", "off", "unknown", "n/a", "nie"]
+};
+
+export const UTILITY_LABELS = {
+  details: {
+    missing: "Brak informacji",
+    planned: "W drodze",
+    available: "Dostępne"
+  },
+  edit: {
+    missing: "Brak",
+    planned: "W drodze",
+    available: "Dostępne"
+  }
+};
+
+export function normalizeUtilityStatus(rawValue) {
+  if (rawValue && typeof rawValue === "object" && "status" in rawValue) {
+    rawValue = rawValue.status;
+  }
+  if (typeof rawValue === "boolean") {
+    return rawValue ? "available" : "missing";
+  }
+  if (typeof rawValue === "number") {
+    if (rawValue <= 0) return "missing";
+    if (rawValue === 1) return "available";
+    if (rawValue === 2) return "planned";
+    return "available";
+  }
+  if (typeof rawValue === "string") {
+    const value = rawValue.trim().toLowerCase();
+    if (!value) {
+      return "missing";
+    }
+    for (const [key, synonyms] of Object.entries(UTILITY_SYNONYMS)) {
+      if (synonyms.some(entry => entry.toLowerCase() === value)) {
+        return key;
+      }
+    }
+    if (value.includes("drogi") || value.includes("trakcie") || value.includes("plan")) {
+      return "planned";
+    }
+    if (value.includes("dost")) {
+      return "available";
+    }
+    if (value.includes("brak")) {
+      return "missing";
+    }
+  }
+  return "missing";
+}
+
+export function getUtilityLabel(status, variant = "details") {
+  const labels = UTILITY_LABELS[variant] || UTILITY_LABELS.details;
+  return labels[status] || labels.missing;
+}
+
+let googleMapsPromise = null;
+
+export function loadGoogleMaps() {
+  if (window.google && window.google.maps) {
+    return Promise.resolve(window.google.maps);
+  }
+  if (googleMapsPromise) {
+    return googleMapsPromise;
+  }
+  googleMapsPromise = new Promise((resolve, reject) => {
+    const apiKey = localStorage.getItem("googleMapsApiKey") || "AIzaSyCr5TmFxnT3enxmyr6vujF8leP995giw8I";
+    const script = document.createElement("script");
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&callback=__initPropertyMap`;
+    script.async = true;
+    script.defer = true;
+    window.__initPropertyMap = () => {
+      resolve(window.google.maps);
+      delete window.__initPropertyMap;
+    };
+    script.onerror = (event) => {
+      reject(event);
+      googleMapsPromise = null;
+      delete window.__initPropertyMap;
+    };
+    document.head.appendChild(script);
+  });
+  return googleMapsPromise;
+}
+
+const TOAST_ICONS = {
+  success: "✓",
+  info: "ℹ",
+  warning: "!",
+  error: "✕"
+};
+
+export function showToast(message, type = "info") {
+  const container = document.getElementById("toastContainer");
+  if (!container) return;
+
+  const toast = document.createElement("div");
+  toast.className = `toast-lite toast-${type}`;
+  toast.setAttribute("role", "status");
+  toast.setAttribute("aria-live", "polite");
+  toast.innerHTML = `
+    <div class="toast-icon" aria-hidden="true">${TOAST_ICONS[type] || TOAST_ICONS.info}</div>
+    <div class="toast-msg">${message}</div>
+    <button class="toast-close" aria-label="Zamknij">&times;</button>
+  `;
+
+  const closeToast = () => {
+    toast.classList.remove("show");
+    setTimeout(() => toast.remove(), 180);
+  };
+
+  toast.querySelector(".toast-close")?.addEventListener("click", closeToast);
+  container.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add("show"));
+
+  const hideTimeout = setTimeout(closeToast, 4000);
+  toast.addEventListener("mouseenter", () => clearTimeout(hideTimeout), { once: true });
+}
+
+export function textContentOrFallback(value, fallback = "—") {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+  const text = String(value).trim();
+  return text ? text : fallback;
+}
+
+export function sanitizeMultilineText(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+export function cloneDeep(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function ensureArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === null || value === undefined) return [];
+  return [value].filter(Boolean);
+}
+
+export function stripHtml(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const tmp = document.createElement("div");
+  tmp.innerHTML = value;
+  return tmp.textContent || tmp.innerText || "";
+}
+
+export function syncMobileMenu() {
+  const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+  const navMenu = document.querySelector('.nav-menu');
+  const mobileAuth = document.getElementById('mobileAuth');
+
+  mobileMenuBtn?.addEventListener('click', () => {
+    navMenu?.classList.toggle('active');
+    if (mobileAuth) {
+      mobileAuth.style.display = navMenu.classList.contains('active') ? 'flex' : 'none';
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 768) {
+      navMenu?.classList.remove('active');
+      if (mobileAuth) {
+        mobileAuth.style.display = 'none';
+      }
+    }
+  });
+}
+

--- a/details.html
+++ b/details.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Grunteo - Szczegóły działki</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+
+  <link rel="icon" type="image/png" sizes="32x32" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="icon" type="image/png" sizes="64x64" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+
+  <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/header.css">
+  <link rel="stylesheet" href="assets/details.css">
+</head>
+<body class="property-page" style="padding-top: calc(var(--topbar-height) + var(--header-height));">
+  <div class="top-navbar">
+    <div class="contact-info">
+      <i class="fas fa-clock"></i> Poniedziałek - Piątek 9:00 - 18:00
+      <span><i class="fas fa-phone"></i> +48 505 849 404</span>
+    </div>
+
+    <div class="auth-buttons" id="authButtons">
+      <button class="btn btn-outline-primary btn-sm" id="loginBtn">
+        <i class="fas fa-sign-in-alt"></i> Zaloguj się
+      </button>
+      <button class="btn btn-primary btn-sm" id="registerBtn">
+        <i class="fas fa-user-plus"></i> Zarejestruj się
+      </button>
+    </div>
+
+    <div class="user-menu" id="userMenu" style="display:none;">
+      <button class="btn btn-outline-primary btn-sm" id="accountBtn">
+        <i class="fas fa-user"></i> Moje konto
+      </button>
+      <button class="btn btn-secondary btn-sm" id="logoutBtn">
+        <i class="fas fa-sign-out-alt"></i> Wyloguj
+      </button>
+    </div>
+  </div>
+
+  <header>
+    <a href="index.html" class="logo">
+      <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+      <span>Grunteo</span>
+    </a>
+
+    <nav class="desktop-nav">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+    </nav>
+
+    <a href="dodaj.html" class="desktop-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+
+    <a href="dodaj.html" class="mobile-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+
+    <button class="mobile-menu-btn" aria-label="Otwórz menu">
+      <i class="fas fa-bars"></i>
+    </button>
+
+    <nav class="nav-menu">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+      <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
+    </nav>
+  </header>
+
+  <main class="property-wrapper">
+    <div id="loadingState" class="loading-state">Wczytywanie danych działki...</div>
+    <div id="errorState" class="error-state hidden">Nie odnaleziono wskazanej działki.</div>
+
+    <section id="propertyContent" class="hidden" aria-live="polite">
+      <section class="property-hero" aria-labelledby="propertyTitle">
+        <div class="property-heading">
+          <div class="title-group">
+            <h1 id="propertyTitle">Działka</h1>
+            <div class="property-meta">
+              <span class="meta-chip"><i class="fas fa-map-marker-alt"></i> <span id="propertyLocation">Polska</span></span>
+              <span class="meta-chip"><i class="fas fa-ruler-combined"></i> <span id="propertyArea">0 m²</span></span>
+              <span class="meta-chip"><i class="fas fa-layer-group"></i> <span id="propertyType">Rodzaj</span></span>
+              <span class="meta-chip"><i class="fas fa-landmark"></i> <span id="ownershipStatus">Własność</span></span>
+            </div>
+          </div>
+
+          <div class="price-box" aria-live="polite">
+            <div class="price-line">
+              <span id="priceValueText" class="price-amount">—</span>
+            </div>
+            <div class="price-meta">
+              <span>cena za m²: <strong id="pricePerSqm">—</strong></span>
+              <span id="priceUpdatedAt">Aktualizacja: —</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="property-stats">
+          <div class="stat-card">
+            <h4>Numer działki</h4>
+            <p id="plotNumber">—</p>
+          </div>
+          <div class="stat-card">
+            <h4>Numer księgi wieczystej</h4>
+            <p id="landRegister">—</p>
+          </div>
+          <div class="stat-card">
+            <h4>Powierzchnia</h4>
+            <p id="plotAreaStat">—</p>
+          </div>
+          <div class="stat-card">
+            <h4>Status</h4>
+            <p id="plotStatus">—</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="property-layout" id="mapSection">
+        <div class="map-panel">
+          <div class="map-toolbar">
+            <h3>Mapa i lokalizacja</h3>
+            <div class="map-modes" role="group" aria-label="Warstwy mapy">
+              <button class="map-mode-btn active" data-mode="base">Mapa</button>
+              <button class="map-mode-btn" data-mode="mpzp">MPZP</button>
+              <button class="map-mode-btn" data-mode="studium">Studium</button>
+            </div>
+          </div>
+          <div id="propertyMap" role="region" aria-label="Mapa działki"></div>
+          <div class="location-details">
+            <div class="location-card">
+              <h4>Adres</h4>
+              <p id="locationAddress">Dodaj adres działki</p>
+            </div>
+            <div class="location-card">
+              <h4>Dojazd i otoczenie</h4>
+              <p id="locationAccess">Opisz komunikację, dostęp do drogi, najbliższe punkty orientacyjne.</p>
+            </div>
+          </div>
+        </div>
+
+        <aside class="plan-panel">
+          <div class="section-header">
+            <h3>Plan zagospodarowania</h3>
+          </div>
+          <div class="plan-badges" id="planBadges"></div>
+          <div class="plan-info-grid">
+            <dl><dt>Przeznaczenie</dt><dd id="planDesignation">Brak informacji</dd></dl>
+            <dl><dt>Maks. wysokość</dt><dd id="planHeight">—</dd></dl>
+            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity">—</dd></dl>
+            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen">—</dd></dl>
+          </div>
+          <div class="plan-notes" id="planNotes">Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.</div>
+        </aside>
+      </section>
+
+      <section class="utilities-section" aria-labelledby="utilitiesTitle">
+        <div class="section-header">
+          <h2 id="utilitiesTitle">Uzbrojenie terenu</h2>
+        </div>
+        <div class="utilities-grid" id="utilitiesGrid">
+          <div class="utility-card" data-utility="electricity" data-status="missing" aria-disabled="true">
+            <div class="utility-icon">⚡</div>
+            <div class="utility-content">
+              <h4>Prąd</h4>
+              <div class="utility-status">Brak informacji</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="water" data-status="missing" aria-disabled="true">
+            <div class="utility-icon">💧</div>
+            <div class="utility-content">
+              <h4>Woda</h4>
+              <div class="utility-status">Brak informacji</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="gas" data-status="missing" aria-disabled="true">
+            <div class="utility-icon">🔥</div>
+            <div class="utility-content">
+              <h4>Gaz</h4>
+              <div class="utility-status">Brak informacji</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="sewage" data-status="missing" aria-disabled="true">
+            <div class="utility-icon">♻️</div>
+            <div class="utility-content">
+              <h4>Kanalizacja</h4>
+              <div class="utility-status">Brak informacji</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="fiber" data-status="missing" aria-disabled="true">
+            <div class="utility-icon">🌐</div>
+            <div class="utility-content">
+              <h4>Światłowód</h4>
+              <div class="utility-status">Brak informacji</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="description-section" aria-labelledby="descriptionTitle">
+        <div class="section-header">
+          <h2 id="descriptionTitle">Opis szczegółowy</h2>
+        </div>
+        <div class="description-card">
+          <div id="descriptionText" class="description-text">Brak opisu</div>
+        </div>
+      </section>
+
+      <section class="tags-section" aria-labelledby="tagsTitle">
+        <div class="section-header">
+          <h2 id="tagsTitle">Parametry dodatkowe</h2>
+        </div>
+        <div class="tags-card">
+          <div class="tags-list" id="tagsList"></div>
+          <p class="tags-empty" id="tagsEmpty" hidden>Brak dodatkowych parametrów.</p>
+        </div>
+      </section>
+
+      <section class="contact-section" id="contact" aria-labelledby="contactTitle">
+        <div class="section-header">
+          <h2 id="contactTitle">Skontaktuj się</h2>
+        </div>
+        <div class="contact-wrapper">
+          <div class="contact-card">
+            <h3 id="contactName">Właściciel</h3>
+            <div class="contact-details">
+              <span><i class="fas fa-phone"></i> <a href="#" id="contactPhoneLink">Brak numeru</a></span>
+              <span><i class="fas fa-envelope"></i> <a href="#" id="contactEmailLink">Brak adresu</a></span>
+            </div>
+            <div class="contact-actions">
+              <button class="btn btn-secondary" type="button" id="savePlotBtn">
+                <i class="fas fa-bookmark"></i> Zapisz działkę
+              </button>
+            </div>
+          </div>
+
+          <div class="contact-form-card">
+            <h3>Wyślij zapytanie</h3>
+            <form id="inquiryForm" class="contact-form">
+              <div>
+                <label for="inquiryName">Imię i nazwisko</label>
+                <input type="text" id="inquiryName" name="inquiryName" autocomplete="name" required>
+              </div>
+              <div>
+                <label for="inquiryEmail">Adres email</label>
+                <input type="email" id="inquiryEmail" name="inquiryEmail" autocomplete="email" required>
+              </div>
+              <div>
+                <label for="inquiryMessage">Wiadomość</label>
+                <textarea id="inquiryMessage" name="inquiryMessage" rows="5" required></textarea>
+              </div>
+              <button type="submit" class="btn btn-primary">
+                <i class="fas fa-paper-plane"></i> Wyślij wiadomość
+              </button>
+            </form>
+          </div>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
+
+  <div class="modal" id="loginModal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Zaloguj się</h3>
+        <button class="modal-close" aria-label="Zamknij">&times;</button>
+      </div>
+      <form id="loginForm">
+        <div class="form-group">
+          <label for="loginEmail">Email</label>
+          <input type="email" id="loginEmail" required>
+        </div>
+        <div class="form-group">
+          <label for="loginPassword">Hasło</label>
+          <input type="password" id="loginPassword" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Zaloguj się</button>
+      </form>
+      <div class="social-login">
+        <button type="button" class="btn btn-google" id="googleLoginBtnLogin">
+          <i class="fab fa-google"></i> Kontynuuj z Google
+        </button>
+      </div>
+      <div class="form-footer">
+        <p>Nie masz konta? <a href="#" id="switchToRegister">Zarejestruj się</a></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="registerModal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Utwórz konto</h3>
+        <button class="modal-close" aria-label="Zamknij">&times;</button>
+      </div>
+      <form id="registerForm">
+        <div class="form-group">
+          <label for="registerEmail">Email</label>
+          <input type="email" id="registerEmail" required>
+        </div>
+        <div class="form-group">
+          <label for="registerPassword">Hasło</label>
+          <input type="password" id="registerPassword" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Zarejestruj się</button>
+      </form>
+      <div class="social-login">
+        <button type="button" class="btn btn-google" id="googleLoginBtn">
+          <i class="fab fa-google"></i> Kontynuuj z Google
+        </button>
+      </div>
+      <div class="form-footer">
+        <p>Masz już konto? <a href="#" id="switchToLogin">Zaloguj się</a></p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="assets/details.js"></script>
+</body>
+</html>

--- a/edit.html
+++ b/edit.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Grunteo - Edycja działki</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+
+  <link rel="icon" type="image/png" sizes="32x32" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="icon" type="image/png" sizes="64x64" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+
+  <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/header.css">
+  <link rel="stylesheet" href="assets/details.css">
+  <link rel="stylesheet" href="assets/edit.css">
+</head>
+<body class="property-page" style="padding-top: calc(var(--topbar-height) + var(--header-height));">
+  <div class="top-navbar">
+    <div class="contact-info">
+      <i class="fas fa-clock"></i> Poniedziałek - Piątek 9:00 - 18:00
+      <span><i class="fas fa-phone"></i> +48 505 849 404</span>
+    </div>
+
+    <div class="auth-buttons" id="authButtons">
+      <button class="btn btn-outline-primary btn-sm" id="loginBtn">
+        <i class="fas fa-sign-in-alt"></i> Zaloguj się
+      </button>
+      <button class="btn btn-primary btn-sm" id="registerBtn">
+        <i class="fas fa-user-plus"></i> Zarejestruj się
+      </button>
+    </div>
+
+    <div class="user-menu" id="userMenu" style="display:none;">
+      <button class="btn btn-outline-primary btn-sm" id="accountBtn">
+        <i class="fas fa-user"></i> Moje konto
+      </button>
+      <button class="btn btn-secondary btn-sm" id="logoutBtn">
+        <i class="fas fa-sign-out-alt"></i> Wyloguj
+      </button>
+    </div>
+  </div>
+
+  <header>
+    <a href="index.html" class="logo">
+      <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+      <span>Grunteo</span>
+    </a>
+
+    <nav class="desktop-nav">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+    </nav>
+
+    <a href="dodaj.html" class="desktop-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+
+    <a href="dodaj.html" class="mobile-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+
+    <button class="mobile-menu-btn" aria-label="Otwórz menu">
+      <i class="fas fa-bars"></i>
+    </button>
+
+    <nav class="nav-menu">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+      <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
+    </nav>
+  </header>
+
+  <main class="property-wrapper">
+    <div id="loadingState" class="loading-state">Sprawdzanie uprawnień i wczytywanie danych...</div>
+    <div id="errorState" class="error-state hidden">Brak uprawnień do edycji tej działki.</div>
+
+    <section id="propertyContent" class="hidden" aria-live="polite">
+      <div class="edit-toolbar">
+        <button id="saveChangesBtn" class="btn btn-primary">
+          <i class="fas fa-save"></i> Zapisz zmiany
+        </button>
+      </div>
+
+      <section class="property-hero" aria-labelledby="propertyTitle">
+        <div class="property-heading">
+          <div class="title-group">
+            <h1 id="propertyTitle" contenteditable="true">Działka</h1>
+            <div class="property-meta">
+              <span class="meta-chip"><i class="fas fa-map-marker-alt"></i>
+                <span id="propertyLocation" contenteditable="true">Polska</span></span>
+              <span class="meta-chip"><i class="fas fa-ruler-combined"></i>
+                <span id="propertyArea" contenteditable="true">0 m²</span></span>
+              <span class="meta-chip"><i class="fas fa-layer-group"></i>
+                <span id="propertyType" contenteditable="true">Rodzaj</span></span>
+              <span class="meta-chip"><i class="fas fa-landmark"></i>
+                <span id="ownershipStatus" contenteditable="true">Własność</span></span>
+            </div>
+          </div>
+
+          <div class="price-box" aria-live="polite">
+            <div class="price-line">
+              <span id="priceValueText" class="price-amount" contenteditable="true">—</span>
+            </div>
+            <div class="price-meta">
+              <span>cena za m²: <strong id="pricePerSqm">—</strong></span>
+              <span id="priceUpdatedAt">Aktualizacja: —</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="property-stats">
+          <div class="stat-card">
+            <h4>Numer działki</h4>
+            <p id="plotNumber" contenteditable="true">—</p>
+          </div>
+          <div class="stat-card">
+            <h4>Numer księgi wieczystej</h4>
+            <p id="landRegister" contenteditable="true">—</p>
+          </div>
+          <div class="stat-card">
+            <h4>Powierzchnia</h4>
+            <p id="plotAreaStat" contenteditable="true">—</p>
+          </div>
+          <div class="stat-card">
+            <h4>Status</h4>
+            <p id="plotStatus" contenteditable="true">—</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="property-layout" id="mapSection">
+        <div class="map-panel">
+          <div class="map-toolbar">
+            <h3>Mapa i lokalizacja</h3>
+            <div class="map-modes" role="group" aria-label="Warstwy mapy">
+              <button class="map-mode-btn active" data-mode="base">Mapa</button>
+              <button class="map-mode-btn" data-mode="mpzp">MPZP</button>
+              <button class="map-mode-btn" data-mode="studium">Studium</button>
+            </div>
+          </div>
+          <div id="propertyMap" role="region" aria-label="Mapa działki"></div>
+          <div class="location-details">
+            <div class="location-card">
+              <h4>Adres</h4>
+              <p id="locationAddress" contenteditable="true">Dodaj adres działki</p>
+            </div>
+            <div class="location-card">
+              <h4>Dojazd i otoczenie</h4>
+              <p id="locationAccess" contenteditable="true">Opisz komunikację, dostęp do drogi, najbliższe punkty orientacyjne.</p>
+            </div>
+          </div>
+        </div>
+
+        <aside class="plan-panel">
+          <div class="section-header">
+            <h3>Plan zagospodarowania</h3>
+          </div>
+          <div class="plan-badges" id="planBadges"></div>
+          <div class="plan-info-grid">
+            <dl><dt>Przeznaczenie</dt><dd id="planDesignation" contenteditable="true">Brak informacji</dd></dl>
+            <dl><dt>Maks. wysokość</dt><dd id="planHeight" contenteditable="true">—</dd></dl>
+            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity" contenteditable="true">—</dd></dl>
+            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen" contenteditable="true">—</dd></dl>
+          </div>
+          <div class="plan-notes" id="planNotes" contenteditable="true">Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.</div>
+        </aside>
+      </section>
+
+      <section class="utilities-section" aria-labelledby="utilitiesTitle">
+        <div class="section-header">
+          <h2 id="utilitiesTitle">Uzbrojenie terenu</h2>
+          <span style="font-size:0.85rem;color:var(--gray);">Kliknij ikonę/kafelek, aby zmienić status</span>
+        </div>
+        <div class="utilities-grid" id="utilitiesGrid">
+          <div class="utility-card" data-utility="electricity" data-status="missing">
+            <div class="utility-icon">⚡</div>
+            <div class="utility-content">
+              <h4>Prąd</h4>
+              <div class="utility-status">Brak</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="water" data-status="missing">
+            <div class="utility-icon">💧</div>
+            <div class="utility-content">
+              <h4>Woda</h4>
+              <div class="utility-status">Brak</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="gas" data-status="missing">
+            <div class="utility-icon">🔥</div>
+            <div class="utility-content">
+              <h4>Gaz</h4>
+              <div class="utility-status">Brak</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="sewage" data-status="missing">
+            <div class="utility-icon">♻️</div>
+            <div class="utility-content">
+              <h4>Kanalizacja</h4>
+              <div class="utility-status">Brak</div>
+            </div>
+          </div>
+          <div class="utility-card" data-utility="fiber" data-status="missing">
+            <div class="utility-icon">🌐</div>
+            <div class="utility-content">
+              <h4>Światłowód</h4>
+              <div class="utility-status">Brak</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="description-section" aria-labelledby="descriptionTitle">
+        <div class="section-header">
+          <h2 id="descriptionTitle">Opis szczegółowy</h2>
+        </div>
+        <div class="description-card">
+          <div id="descriptionText" class="description-text" contenteditable="true">Brak opisu</div>
+        </div>
+      </section>
+
+      <section class="tags-section" aria-labelledby="tagsTitle">
+        <div class="section-header">
+          <h2 id="tagsTitle">Parametry dodatkowe</h2>
+        </div>
+        <div class="tags-card">
+          <div class="tags-list" id="tagsList"></div>
+          <p class="tags-empty" id="tagsEmpty" hidden>Brak dodatkowych parametrów.</p>
+          <div class="tag-form">
+            <input type="text" id="tagInput" placeholder="Dodaj własny znacznik, np. #Budowlana">
+            <button class="btn btn-primary" type="button" id="addTagBtn"><i class="fas fa-plus"></i> Dodaj</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="contact-section" id="contact" aria-labelledby="contactTitle">
+        <div class="section-header">
+          <h2 id="contactTitle">Skontaktuj się</h2>
+        </div>
+        <div class="contact-wrapper">
+          <div class="contact-card">
+            <h3 id="contactName" contenteditable="true">Właściciel</h3>
+            <div class="contact-details">
+              <span><i class="fas fa-phone"></i> <a href="#" id="contactPhoneLink" contenteditable="true">Brak numeru</a></span>
+              <span><i class="fas fa-envelope"></i> <a href="#" id="contactEmailLink" contenteditable="true">Brak adresu</a></span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
+
+  <div class="modal" id="loginModal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Zaloguj się</h3>
+        <button class="modal-close" aria-label="Zamknij">&times;</button>
+      </div>
+      <form id="loginForm">
+        <div class="form-group">
+          <label for="loginEmail">Email</label>
+          <input type="email" id="loginEmail" required>
+        </div>
+        <div class="form-group">
+          <label for="loginPassword">Hasło</label>
+          <input type="password" id="loginPassword" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Zaloguj się</button>
+      </form>
+      <div class="social-login">
+        <button type="button" class="btn btn-google" id="googleLoginBtnLogin">
+          <i class="fab fa-google"></i> Kontynuuj z Google
+        </button>
+      </div>
+      <div class="form-footer">
+        <p>Nie masz konta? <a href="#" id="switchToRegister">Zarejestruj się</a></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="registerModal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Utwórz konto</h3>
+        <button class="modal-close" aria-label="Zamknij">&times;</button>
+      </div>
+      <form id="registerForm">
+        <div class="form-group">
+          <label for="registerEmail">Email</label>
+          <input type="email" id="registerEmail" required>
+        </div>
+        <div class="form-group">
+          <label for="registerPassword">Hasło</label>
+          <input type="password" id="registerPassword" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Zarejestruj się</button>
+      </form>
+      <div class="social-login">
+        <button type="button" class="btn btn-google" id="googleLoginBtn">
+          <i class="fab fa-google"></i> Kontynuuj z Google
+        </button>
+      </div>
+      <div class="form-footer">
+        <p>Masz już konto? <a href="#" id="switchToLogin">Zaloguj się</a></p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="assets/edit.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -757,7 +757,7 @@ window.showConfirmModal = showConfirmModal;
               const city  = offer.city || 'Nie podano';
               const phone = offer.phone || 'Nie podano';
               const title = plot.Id || `Działka ${visibleIdx + 1}`;
-              const detailsUrl = `oferta.html?id=${offerId}&plot=${originalIndex}`;
+              const detailsUrl = `details.html?id=${offerId}&plot=${originalIndex}`;
 
               el.innerHTML = `
                 <h3 class="offer-title">${title}</h3>
@@ -773,7 +773,7 @@ window.showConfirmModal = showConfirmModal;
                   <a class="btn btn-accent btn-sm" target="_blank" href="${detailsUrl}">
                     <i class="fas fa-info-circle"></i> Szczegóły
                   </a>
-                  <button class="btn btn-primary btn-sm" onclick="window.location.href='dodaj.html?edit=${offerId}&plot=${originalIndex}'">
+                  <button class="btn btn-primary btn-sm" onclick="window.location.href='edit.html?id=${offerId}&plot=${originalIndex}'">
                     <i class="fas fa-edit"></i> Edytuj
                   </button>
                   <button class="btn btn-secondary btn-sm" onclick="deletePlot && deletePlot('${offerId}', ${originalIndex}, '${(title||'').replace(/'/g,"\\'")}')">

--- a/oferty.html
+++ b/oferty.html
@@ -381,7 +381,7 @@ window.showConfirmModal = showConfirmModal;
     const ppm2  = price && area ? (price/area).toFixed(0) : null;
     const city  = data.city || "brak";
     const phone = formatPhone(data.phone);
-    const detailsUrl = `oferta.html?id=${offerId}&plot=${plotIndex}`;
+    const detailsUrl = `details.html?id=${offerId}&plot=${plotIndex}`;
 
     return `
       <div class="map-info-window">
@@ -551,7 +551,7 @@ window.showConfirmModal = showConfirmModal;
       const price = Number(o.plot.price || 0);
       const area  = Number(o.plot.pow_dzialki_m2_uldk || 0);
       const ppm2  = price && area ? (price/area).toFixed(2) : "0.00";
-      const detailsUrl = `oferta.html?id=${o.id}&plot=${o.index}`;
+      const detailsUrl = `details.html?id=${o.id}&plot=${o.index}`;
 
       card.innerHTML = `
         <h5>${o.plot.Id || "Brak identyfikatora"}</h5>
@@ -933,7 +933,7 @@ async function loadUserOffers(email, uid) {
         const price = Number(plot.price || 0);
         const area  = Number(plot.pow_dzialki_m2_uldk || plot.area || plot.areaM2 || 0);
         const ppm2  = price && area ? Math.round(price/area) : 0;
-        const detailsUrl = `oferta.html?id=${offerId}&plot=${originalIndex}`;
+        const detailsUrl = `details.html?id=${offerId}&plot=${originalIndex}`;
 
         const el = document.createElement('div');
         el.className = 'offer-card';
@@ -950,7 +950,7 @@ async function loadUserOffers(email, uid) {
             <a class="btn btn-accent btn-sm" target="_blank" href="${detailsUrl}">
               <i class="fas fa-info-circle"></i> Szczegóły
             </a>
-            <button class="btn btn-primary btn-sm" onclick="window.location.href='dodaj.html?edit=${offerId}&plot=${originalIndex}'">
+            <button class="btn btn-primary btn-sm" onclick="window.location.href='edit.html?id=${offerId}&plot=${originalIndex}'">
               <i class="fas fa-edit"></i> Edytuj
             </button>
             <button class="btn btn-secondary btn-sm" onclick="deletePlot && deletePlot('${offerId}', ${originalIndex}, '${(plot.Id||`Działka ${i+1}`).replace(/'/g,"\\'")}')">


### PR DESCRIPTION
## Summary
- add a standalone read-only property details page with supporting styles and script logic
- add an inline edit page that mirrors the details layout and enables authenticated owners to update plot data
- share common Firebase helpers, update existing listings to link to the new details and edit pages, and refresh styling for the new views

## Testing
- not run (static files)

------
https://chatgpt.com/codex/tasks/task_e_68c91e458b38832bbb7562164601eec6