### PR TITLE
Fix plot number display and read-only behaviour on details page

### DIFF
--- a/details.html
+++ b/details.html
@@ -86,7 +86,7 @@
             <h1 id="propertyTitle">Działka</h1>
             <div class="property-meta">
               <span class="meta-chip"><i class="fas fa-map-marker-alt"></i> <span id="propertyLocation">Polska</span></span>
-              <span class="meta-chip"><i class="fas fa-ruler-combined"></i> <span id="propertyArea">0 m²</span></span>
+              <span class="meta-chip"><i class="fas fa-ruler-combined"></i> <span id="propertyArea" contenteditable="false">0 m²</span></span>
               <span class="meta-chip"><i class="fas fa-layer-group"></i> <span id="propertyType">Rodzaj</span></span>
               <span class="meta-chip"><i class="fas fa-landmark"></i> <span id="ownershipStatus">Własność</span></span>
             </div>
@@ -106,7 +106,7 @@
         <div class="property-stats">
           <div class="stat-card">
             <h4>Numer działki</h4>
-            <p id="plotNumber">—</p>
+            <p id="plotNumber" contenteditable="false">—</p>
           </div>
           <div class="stat-card">
             <h4>Numer księgi wieczystej</h4>
@@ -114,7 +114,7 @@
           </div>
           <div class="stat-card">
             <h4>Powierzchnia</h4>
-            <p id="plotAreaStat">—</p>
+            <p id="plotAreaStat" contenteditable="false">—</p>
           </div>
           <div class="stat-card">
             <h4>Status</h4>


### PR DESCRIPTION
## Summary
- ensure the plot number and area widgets on the details view stay read-only even after authentication by locking their content
- format the displayed plot number so only the segment after the last dot (e.g. `65/1`) is shown for long identifiers
- mark the corresponding fields in `details.html` as non-editable to reinforce the read-only behaviour

## Testing
- not run (static pages)


------
https://chatgpt.com/codex/tasks/task_e_68c955a724f4832b82038728c7920cc1