### PR TITLE
Add legal policy pages for RODO and privacy

### DIFF
--- a/RODO.html
+++ b/RODO.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Informacja o przetwarzaniu danych osobowych (RODO) — Grunteo</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="icon" type="image/png" sizes="64x64" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/header.css">
+  <link rel="stylesheet" href="assets/legal.css">
+</head>
+<body class="legal-page">
+  <div class="top-navbar">
+    <div class="contact-info">
+      <i class="fas fa-clock"></i> Poniedziałek - Piątek 9:00 - 18:00
+      <span><i class="fas fa-phone"></i> +48 505 849 404</span>
+    </div>
+
+    <div class="auth-buttons" id="authButtons">
+      <button class="btn btn-outline-primary btn-sm" id="loginBtn">
+        <i class="fas fa-sign-in-alt"></i> Zaloguj się
+      </button>
+      <button class="btn btn-primary btn-sm" id="registerBtn">
+        <i class="fas fa-user-plus"></i> Zarejestruj się
+      </button>
+    </div>
+
+    <div class="user-menu" id="userMenu" style="display:none;">
+      <button class="btn btn-outline-primary btn-sm" id="accountBtn">
+        <i class="fas fa-user"></i> Moje konto
+      </button>
+      <button class="btn btn-secondary btn-sm" id="logoutBtn">
+        <i class="fas fa-sign-out-alt"></i> Wyloguj
+      </button>
+    </div>
+  </div>
+
+  <header>
+    <a href="index.html" class="logo">
+      <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+      <span>Grunteo</span>
+    </a>
+
+    <nav class="desktop-nav">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+    </nav>
+
+    <a href="dodaj.html" class="desktop-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+    <a href="dodaj.html" class="mobile-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+
+    <button class="mobile-menu-btn" aria-label="Otwórz menu">
+      <i class="fas fa-bars"></i>
+    </button>
+
+    <nav class="nav-menu">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+      <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
+    </nav>
+  </header>
+
+  <main class="legal-main">
+    <div class="container">
+      <div class="legal-wrapper">
+        <span class="legal-tagline"><i class="fas fa-shield-alt" aria-hidden="true"></i> Ochrona danych osobowych</span>
+        <h1>Informacja o przetwarzaniu danych osobowych (RODO) — Grunteo</h1>
+        <p class="legal-lead">Niniejszy komunikat realizuje obowiązek informacyjny wynikający z art. 13 Rozporządzenia Parlamentu Europejskiego i Rady (UE) 2016/679 z 27.04.2016 r. (RODO).</p>
+
+        <section class="legal-section" id="administrator">
+          <h2>Kto decyduje o Twoich danych</h2>
+          <div class="legal-card">
+            <p><strong>Administrator danych:</strong> Grunteo z siedzibą we Wrocławiu, ul. Edwarda Suchardy 4, 50-362 Wrocław.</p>
+            <address>
+              <strong>Kontakt w sprawach danych</strong>
+              <a href="mailto:info@grunteo.pl">info@grunteo.pl</a><br>
+              lub korespondencyjnie na adres siedziby z dopiskiem &bdquo;RODO&rdquo;.
+            </address>
+            <p class="legal-paragraph">Administrator nie wyznaczył Inspektora Ochrony Danych.</p>
+          </div>
+        </section>
+
+        <section class="legal-section" id="purposes">
+          <h2>Po co i na jakiej podstawie przetwarzamy dane</h2>
+          <p class="legal-paragraph">Przetwarzamy Twoje dane tylko wtedy, gdy mamy ku temu podstawę prawną. W szczególności dzieje się to w następujących celach:</p>
+          <ul class="legal-list">
+            <li>
+              <strong>Umowa i działania przedumowne.</strong> Aby zawrzeć i wykonać umowę, przygotować ofertę oraz obsłużyć zamówione usługi.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. b RODO.</span>
+            </li>
+            <li>
+              <strong>Komunikacja i wsparcie.</strong> Odpowiadanie na zapytania z formularzy, wiadomości e-mail czy infolinii oraz prowadzenie korespondencji.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. f RODO (nasz prawnie uzasadniony interes).</span>
+            </li>
+            <li>
+              <strong>Dochodzenie roszczeń i obrona.</strong> Windykacja należności, zabezpieczenie dowodów oraz inne działania potrzebne do ochrony naszych praw.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. f RODO.</span>
+            </li>
+            <li>
+              <strong>Analityka, statystyka, rozwój usług i archiwizacja.</strong> Ulepszanie działania serwisu, raportowanie wewnętrzne i cele dowodowe.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. f RODO.</span>
+            </li>
+            <li>
+              <strong>Marketing.</strong> Wysyłka treści marketingowych oraz newsletterów tylko na podstawie udzielonej zgody.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. a RODO.</span>
+            </li>
+            <li>
+              <strong>Współpraca z partnerami przy transakcjach.</strong> Przekazanie danych niezbędnych do zawarcia umowy z partnerem zainteresowanym nieruchomością.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. b RODO (gdy jest to konieczne do wykonania umowy) lub art. 6 ust. 1 lit. a RODO (gdy wymagamy zgody).</span>
+            </li>
+            <li>
+              <strong>Obowiązki prawne.</strong> Prowadzenie księgowości, rozliczeń podatkowych i innych wymogów ustawowych.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. c RODO.</span>
+            </li>
+          </ul>
+          <p class="legal-paragraph">Zgoda jest dobrowolna i możesz ją odwołać w każdej chwili (odwołanie nie działa wstecz). Brak danych wymaganych przepisami lub niezbędnych do zawarcia umowy może uniemożliwić jej zawarcie lub realizację.</p>
+          <div class="legal-note">
+            Nie prowadzimy profilowania ani zautomatyzowanego podejmowania decyzji, które wywołują skutki prawne lub w inny istotny sposób wpływają na Twoją sytuację.
+          </div>
+        </section>
+
+        <section class="legal-section" id="rights">
+          <h2>Jakie prawa Ci przysługują</h2>
+          <p class="legal-paragraph">Masz prawo do pełnej kontroli nad swoimi danymi osobowymi:</p>
+          <div class="legal-rights">
+            <div class="legal-right-box">
+              <h3>Dostęp do danych</h3>
+              <p>Otrzymasz informacje, czy przetwarzamy Twoje dane, oraz kopię tych danych.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Sprostowanie</h3>
+              <p>Możesz żądać poprawienia lub uzupełnienia nieaktualnych danych.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Usunięcie</h3>
+              <p>Możesz zażądać usunięcia danych („prawo do bycia zapomnianym”), jeśli nie ma podstaw do ich dalszego przetwarzania.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Ograniczenie</h3>
+              <p>Masz prawo ograniczyć przetwarzanie, np. na czas rozpatrywania sprzeciwu lub wniosku o sprostowanie.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Przenoszenie</h3>
+              <p>Możesz otrzymać swoje dane w ustrukturyzowanym formacie oraz przekazać je innemu administratorowi.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Sprzeciw</h3>
+              <p>Możesz wnieść sprzeciw wobec przetwarzania opartego na naszym uzasadnionym interesie lub wobec marketingu bezpośredniego.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Wycofanie zgody</h3>
+              <p>Zgodę możesz odwołać w dowolnym momencie, bez wpływu na zgodność z prawem działań sprzed odwołania.</p>
+            </div>
+          </div>
+          <p class="legal-paragraph">Przysługuje Ci też prawo wniesienia skargi do Prezesa Urzędu Ochrony Danych Osobowych (ul. Stawki 2, 00-193 Warszawa).</p>
+        </section>
+
+        <section class="legal-section" id="sharing">
+          <h2>Komu ujawniamy dane</h2>
+          <p class="legal-paragraph">Dane przekazujemy wyłącznie podmiotom, które pomagają nam realizować usługi:</p>
+          <ul class="legal-list">
+            <li>pracownikom i współpracownikom Grunteo upoważnionym do przetwarzania danych;</li>
+            <li>dostawcom usług IT, hostingu, infolinii i analityki;</li>
+            <li>biurom księgowym oraz podmiotom obsługującym sprawy podatkowe;</li>
+            <li>kancelariom prawnym i notarialnym, a także firmom kurierskim i pocztowym;</li>
+            <li>innym pośrednikom, architektom oraz partnerom handlowym zainteresowanym nieruchomościami w kontekście transakcji.</li>
+          </ul>
+        </section>
+
+        <section class="legal-section" id="retention">
+          <h2>Jak długo przechowujemy dane</h2>
+          <p class="legal-paragraph">Czas przetwarzania zależy od celu i podstawy prawnej:</p>
+          <ul class="legal-list">
+            <li>przez czas trwania umowy lub świadczonej usługi, a następnie do upływu terminów przedawnienia roszczeń;</li>
+            <li>przez okres wymagany prawem, np. dla dokumentacji księgowej i podatkowej;</li>
+            <li>w oparciu o uzasadniony interes – do momentu jego realizacji lub skutecznego sprzeciwu;</li>
+            <li>w przypadku zgody – do momentu jej wycofania.</li>
+          </ul>
+        </section>
+
+        <section class="legal-section" id="transfer">
+          <h2>Czy dane wyjeżdżają poza EOG</h2>
+          <p class="legal-paragraph">Co do zasady nie przekazujemy danych do państw trzecich. Jeśli wyjątkowo dojdzie do transferu za pośrednictwem narzędzi dostawców (np. rozwiązań analitycznych), stosujemy wymagane zabezpieczenia prawne, takie jak standardowe klauzule umowne.</p>
+          <p class="legal-paragraph">Szczegółowe informacje znajdziesz w Polityce prywatności i plików cookies Grunteo.</p>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <footer id="contact">
+    <div class="container">
+      <div class="footer-container">
+        <div class="footer-about">
+          <a href="index.html" class="footer-logo">
+            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+            <span>Grunteo</span>
+          </a>
+          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
+        </div>
+
+        <div class="footer-links">
+          <h3>Przydatne linki</h3>
+          <ul>
+            <li><a href="index.html">Strona główna</a></li>
+            <li><a href="oferty.html">Oferty</a></li>
+            <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+        </div>
+
+        <div class="footer-contact">
+          <h3>Kontakt</h3>
+          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
+          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+      const navMenu = document.querySelector('.nav-menu');
+      const mobileAuth = document.getElementById('mobileAuth');
+
+      mobileMenuBtn?.addEventListener('click', function () {
+        navMenu?.classList.toggle('active');
+        if (mobileAuth) {
+          mobileAuth.style.display = navMenu?.classList.contains('active') ? 'flex' : 'none';
+        }
+      });
+
+      window.addEventListener('resize', function () {
+        if (window.innerWidth > 768) {
+          navMenu?.classList.remove('active');
+          if (mobileAuth) {
+            mobileAuth.style.display = 'none';
+          }
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/assets/legal.css
+++ b/assets/legal.css
@@ -1,0 +1,291 @@
+body.legal-page {
+  background: linear-gradient(180deg, #f4f8ff 0%, #ffffff 45%);
+  color: var(--dark);
+}
+
+.legal-main {
+  padding: calc(var(--topbar-height) + var(--header-height) + 48px) 0 4rem;
+}
+
+.legal-main .container {
+  max-width: 980px;
+}
+
+.legal-wrapper {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 2.75rem 2.5rem;
+  box-shadow: 0 28px 60px -24px rgba(30, 111, 186, 0.35);
+  border: 1px solid rgba(30, 111, 186, 0.12);
+}
+
+.legal-wrapper h1 {
+  font-size: 2.15rem;
+  margin-bottom: 1.25rem;
+  color: var(--darker);
+}
+
+.legal-lead {
+  font-size: 1.05rem;
+  color: #4a5d78;
+  margin-bottom: 1.75rem;
+}
+
+.legal-section + .legal-section {
+  margin-top: 2.75rem;
+}
+
+.legal-section h2 {
+  font-size: 1.65rem;
+  margin-bottom: 1.1rem;
+  color: var(--primary-dark);
+}
+
+.legal-section h3 {
+  font-size: 1.1rem;
+  margin-bottom: 0.8rem;
+  color: var(--primary);
+}
+
+.legal-paragraph {
+  margin-bottom: 1.1rem;
+  color: #334155;
+}
+
+.legal-list {
+  list-style: disc;
+  margin-left: 1.5rem;
+  color: #1f2937;
+}
+
+.legal-list li {
+  margin-bottom: 0.75rem;
+  line-height: 1.65;
+}
+
+.legal-list li strong {
+  color: var(--primary-dark);
+}
+
+.legal-sublist {
+  list-style: circle;
+  margin-left: 1.35rem;
+  margin-top: 0.5rem;
+}
+
+.legal-basis {
+  display: inline-block;
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.legal-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.legal-card {
+  background: linear-gradient(180deg, rgba(59, 163, 227, 0.08) 0%, rgba(255, 255, 255, 0.6) 100%);
+  border: 1px solid rgba(30, 111, 186, 0.16);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 38px -28px rgba(30, 111, 186, 0.55);
+}
+
+.legal-card p,
+.legal-card address {
+  margin: 0 0 0.65rem;
+  color: #1e293b;
+  font-style: normal;
+  line-height: 1.6;
+}
+
+.legal-card address strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--primary-dark);
+}
+
+.legal-tagline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(30, 111, 186, 0.09);
+  border-radius: 999px;
+  padding: 0.45rem 1.05rem;
+  color: var(--primary-dark);
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 1.8rem;
+}
+
+.legal-note {
+  background: rgba(148, 163, 184, 0.18);
+  border-left: 4px solid var(--primary);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  font-size: 0.92rem;
+  color: #334155;
+  margin-top: 1.4rem;
+}
+
+.legal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.legal-grid-item {
+  background: #f8fbff;
+  border: 1px solid rgba(30, 111, 186, 0.14);
+  border-radius: 14px;
+  padding: 1.15rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.legal-grid-item strong {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--primary);
+}
+
+.legal-grid-item p {
+  margin: 0;
+  color: #1f2937;
+  font-size: 0.93rem;
+  line-height: 1.55;
+}
+
+.legal-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-size: 0.93rem;
+}
+
+.legal-table thead {
+  background: rgba(30, 111, 186, 0.08);
+}
+
+.legal-table th,
+.legal-table td {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.legal-table th {
+  color: var(--primary-dark);
+  font-weight: 600;
+}
+
+.legal-rights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.legal-right-box {
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 14px;
+  padding: 1.1rem 1.2rem;
+  box-shadow: 0 6px 16px -10px rgba(15, 23, 42, 0.25);
+}
+
+.legal-right-box h3 {
+  font-size: 1.05rem;
+  margin-bottom: 0.6rem;
+}
+
+.legal-right-box p {
+  margin: 0;
+  color: #44546b;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 768px) {
+  .legal-main {
+    padding: calc(var(--topbar-height) + var(--header-height) + 24px) 0 3rem;
+  }
+
+  .legal-wrapper {
+    padding: 2.2rem 1.5rem;
+    border-radius: 16px;
+  }
+
+  .legal-wrapper h1 {
+    font-size: 1.8rem;
+  }
+
+  .legal-section h2 {
+    font-size: 1.45rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body.legal-page {
+    background: linear-gradient(180deg, #0f172a 0%, #0b1120 70%);
+    color: #e2e8f0;
+  }
+
+  .legal-wrapper {
+    background: rgba(15, 23, 42, 0.82);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 24px 50px -30px rgba(15, 23, 42, 0.75);
+  }
+
+  .legal-wrapper h1,
+  .legal-section h2,
+  .legal-section h3 {
+    color: #f8fafc;
+  }
+
+  .legal-paragraph,
+  .legal-list,
+  .legal-list li,
+  .legal-card p,
+  .legal-card address,
+  .legal-grid-item p,
+  .legal-right-box p {
+    color: #cbd5f5;
+  }
+
+  .legal-card {
+    background: linear-gradient(180deg, rgba(59, 163, 227, 0.18) 0%, rgba(15, 23, 42, 0.9) 100%);
+    border: 1px solid rgba(59, 163, 227, 0.35);
+  }
+
+  .legal-grid-item {
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(59, 163, 227, 0.25);
+    box-shadow: none;
+  }
+
+  .legal-right-box {
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: none;
+  }
+
+  .legal-note {
+    background: rgba(148, 163, 184, 0.12);
+    color: #e2e8f0;
+  }
+
+  .legal-table thead {
+    background: rgba(59, 163, 227, 0.2);
+  }
+
+  .legal-table th,
+  .legal-table td {
+    border-color: rgba(148, 163, 184, 0.3);
+    color: #e2e8f0;
+  }
+}

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Polityka prywatności i cookies — Grunteo</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="icon" type="image/png" sizes="64x64" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png">
+  <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/header.css">
+  <link rel="stylesheet" href="assets/legal.css">
+</head>
+<body class="legal-page">
+  <div class="top-navbar">
+    <div class="contact-info">
+      <i class="fas fa-clock"></i> Poniedziałek - Piątek 9:00 - 18:00
+      <span><i class="fas fa-phone"></i> +48 505 849 404</span>
+    </div>
+
+    <div class="auth-buttons" id="authButtons">
+      <button class="btn btn-outline-primary btn-sm" id="loginBtn">
+        <i class="fas fa-sign-in-alt"></i> Zaloguj się
+      </button>
+      <button class="btn btn-primary btn-sm" id="registerBtn">
+        <i class="fas fa-user-plus"></i> Zarejestruj się
+      </button>
+    </div>
+
+    <div class="user-menu" id="userMenu" style="display:none;">
+      <button class="btn btn-outline-primary btn-sm" id="accountBtn">
+        <i class="fas fa-user"></i> Moje konto
+      </button>
+      <button class="btn btn-secondary btn-sm" id="logoutBtn">
+        <i class="fas fa-sign-out-alt"></i> Wyloguj
+      </button>
+    </div>
+  </div>
+
+  <header>
+    <a href="index.html" class="logo">
+      <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+      <span>Grunteo</span>
+    </a>
+
+    <nav class="desktop-nav">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+    </nav>
+
+    <a href="dodaj.html" class="desktop-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+    <a href="dodaj.html" class="mobile-add-offer">
+      <i class="fas fa-plus"></i> Dodaj ofertę
+    </a>
+
+    <button class="mobile-menu-btn" aria-label="Otwórz menu">
+      <i class="fas fa-bars"></i>
+    </button>
+
+    <nav class="nav-menu">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link">Dodaj</a>
+      <a href="#contact" class="nav-link">Kontakt</a>
+      <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
+    </nav>
+  </header>
+
+  <main class="legal-main">
+    <div class="container">
+      <div class="legal-wrapper">
+        <span class="legal-tagline"><i class="fas fa-user-shield" aria-hidden="true"></i> Transparentność i bezpieczeństwo</span>
+        <h1>Polityka prywatności i cookies — Grunteo</h1>
+        <p class="legal-lead">Dbamy o to, by korzystanie z naszych usług było bezpieczne i przejrzyste. Poniżej znajdziesz informacje o tym, jakie dane zbieramy, w jakich celach je wykorzystujemy i jakie prawa Ci przysługują.</p>
+
+        <section class="legal-section" id="dictionary">
+          <h2>Słownik pojęć (w skrócie)</h2>
+          <div class="legal-grid">
+            <div class="legal-grid-item">
+              <strong>Administrator / my</strong>
+              <p>Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław.</p>
+            </div>
+            <div class="legal-grid-item">
+              <strong>Użytkownik / Klient</strong>
+              <p>Każda osoba lub podmiot korzystający z naszych usług albo odwiedzający stronę Grunteo.</p>
+            </div>
+            <div class="legal-grid-item">
+              <strong>Konto</strong>
+              <p>Profil Użytkownika w systemie serwisu. Możliwa jest rejestracja przez zewnętrznych dostawców logowania – obowiązują wtedy ich regulaminy.</p>
+            </div>
+            <div class="legal-grid-item">
+              <strong>Serwis / Portal</strong>
+              <p>Strona internetowa dostępna pod adresem <a href="https://grunteo.pl">grunteo.pl</a> wraz z funkcjami i narzędziami.</p>
+            </div>
+            <div class="legal-grid-item">
+              <strong>RODO</strong>
+              <p>Rozporządzenie Parlamentu Europejskiego i Rady (UE) 2016/679 w sprawie ochrony danych osobowych.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="legal-section" id="controller-contact">
+          <h2>Kto jest administratorem i jak się skontaktować</h2>
+          <div class="legal-card">
+            <p><strong>Administrator danych:</strong> Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław.</p>
+            <address>
+              <strong>Kontakt:</strong>
+              <a href="mailto:info@grunteo.pl">info@grunteo.pl</a><br>
+              Korespondencja tradycyjna: adres siedziby z dopiskiem „RODO”.
+            </address>
+            <p class="legal-paragraph">Na pytania odpowiadamy niezwłocznie, a najpóźniej w ciągu 1 miesiąca. W przypadku skomplikowanych spraw termin może zostać wydłużony o kolejne 2 miesiące.</p>
+          </div>
+        </section>
+
+        <section class="legal-section" id="scope">
+          <h2>Zakres danych, które możemy przetwarzać</h2>
+          <p class="legal-paragraph">W zależności od świadczonej usługi możemy poprosić o:</p>
+          <ul class="legal-list">
+            <li>imię i nazwisko, dane kontaktowe (telefon, e-mail) oraz adres korespondencyjny;</li>
+            <li>dane nieruchomości, takie jak lokalizacja, powierzchnia, numer działki, księga wieczysta i cena;</li>
+            <li>preferencje dotyczące działek, parametry inwestycji i oczekiwania dotyczące transakcji;</li>
+            <li>dane wymagane do przygotowania i realizacji umowy: adres zamieszkania, PESEL, numer dokumentu tożsamości, rachunek bankowy;</li>
+            <li>informacje przekazywane dobrowolnie w ramach korespondencji lub formularzy.</li>
+          </ul>
+          <div class="legal-note">Treści wymieniane między Użytkownikami (np. na czacie) zależą wyłącznie od nich — nie mamy wpływu na ich zakres.</div>
+        </section>
+
+        <section class="legal-section" id="purposes">
+          <h2>Po co używamy danych i na jakiej podstawie</h2>
+          <ul class="legal-list">
+            <li>
+              <strong>Świadczenie usług i realizacja umów.</strong> Publikacja ogłoszeń, analizy nieruchomości, obsługa transakcji i bieżąca współpraca.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. b RODO.</span>
+            </li>
+            <li>
+              <strong>Zgoda.</strong> Marketing bezpośredni oraz kontakt w sprawie oferty partnera zainteresowanego Twoją nieruchomością.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. a RODO.</span>
+            </li>
+            <li>
+              <strong>Uzasadniony interes.</strong> Obejmuje m.in.:
+              <ul class="legal-sublist">
+                <li>wyszukiwanie gruntów w źródłach publicznych (np. geoportale) w celu kontaktu biznesowego;</li>
+                <li>wsparcie techniczne oraz obsługę zapytań, skarg i reklamacji;</li>
+                <li>badanie jakości i użyteczności serwisu, prowadzenie statystyk i pomiarów;</li>
+                <li>dochodzenie lub obronę przed roszczeniami.</li>
+              </ul>
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. f RODO.</span>
+            </li>
+            <li>
+              <strong>Obowiązki prawne.</strong> Prowadzenie księgowości, rozliczeń podatkowych i wypełnianie innych wymogów ustawowych.
+              <span class="legal-basis">Podstawa: art. 6 ust. 1 lit. c RODO.</span>
+            </li>
+          </ul>
+        </section>
+
+        <section class="legal-section" id="retention">
+          <h2>Jak długo przechowujemy dane</h2>
+          <p class="legal-paragraph">Okres przechowywania zależy od charakteru współpracy:</p>
+          <ul class="legal-list">
+            <li>przez czas trwania relacji (umowa/usługa), a po jej zakończeniu — do przedawnienia roszczeń;</li>
+            <li>przez czas wymagany przepisami prawa (np. dokumenty księgowo-podatkowe — co do zasady 5 lat od końca roku podatkowego);</li>
+            <li>w ramach uzasadnionego interesu — do jego realizacji lub skutecznego sprzeciwu;</li>
+            <li>w przypadku zgody — do momentu jej odwołania.</li>
+          </ul>
+          <div class="legal-note">Dane Użytkowników niezalogowanych przechowujemy tak długo, jak aktywne są pliki cookies na urządzeniu (albo do ich usunięcia).</div>
+        </section>
+
+        <section class="legal-section" id="sharing">
+          <h2>Udostępnianie i powierzanie danych</h2>
+          <p class="legal-paragraph">Współpracujemy wyłącznie z zaufanymi dostawcami usług wspierających nasze działania:</p>
+          <ul class="legal-list">
+            <li>dostawcy IT, hostingu, analityki, poczty e-mail, czatów i narzędzi komunikacyjnych (np. Google, Salesforce, Hotjar);</li>
+            <li>biura księgowe, kancelarie prawne i notarialne, pośrednicy oraz architekci zaangażowani w transakcje;</li>
+            <li>firmy kurierskie i pocztowe realizujące doręczenia;</li>
+            <li>podmioty dochodzące roszczeń lub świadczące pomoc prawną w razie sporów.</li>
+          </ul>
+          <p class="legal-paragraph">W ramach ogłoszeń dane mogą być dostępne innym Użytkownikom. Jeśli wymaga tego transakcja, przekazujemy informacje partnerom handlowym po wcześniejszym uzgodnieniu.</p>
+        </section>
+
+        <section class="legal-section" id="eog">
+          <h2>Przekazywanie danych poza EOG</h2>
+          <p class="legal-paragraph">Zasadniczo nie przekazujemy danych do państw trzecich. Niektóre narzędzia analityczne lub marketingowe (np. Google) mogą jednak przetwarzać zanonimizowane informacje na serwerach poza Europejskim Obszarem Gospodarczym.</p>
+          <p class="legal-paragraph">W takich sytuacjach stosujemy wymagane mechanizmy ochrony, w tym standardowe klauzule umowne lub inne zabezpieczenia przewidziane przez RODO.</p>
+        </section>
+
+        <section class="legal-section" id="rights">
+          <h2>Twoje prawa</h2>
+          <p class="legal-paragraph">Masz pełen zestaw uprawnień gwarantowanych przez RODO:</p>
+          <div class="legal-rights">
+            <div class="legal-right-box">
+              <h3>Dostęp</h3>
+              <p>Możesz sprawdzić, jakie dane przetwarzamy, i otrzymać ich kopię.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Sprostowanie</h3>
+              <p>Masz prawo poprawić lub uzupełnić nieprawidłowe dane.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Usunięcie</h3>
+              <p>W określonych sytuacjach możesz zażądać usunięcia danych (prawo do bycia zapomnianym).</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Ograniczenie i przenoszenie</h3>
+              <p>Możesz ograniczyć przetwarzanie danych lub uzyskać je w ustrukturyzowanej formie i przekazać innemu administratorowi.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Sprzeciw</h3>
+              <p>Masz prawo sprzeciwić się przetwarzaniu opartego na uzasadnionym interesie oraz marketingowi bezpośredniemu.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Wycofanie zgody</h3>
+              <p>Zgoda udzielona na przetwarzanie danych może być odwołana w każdej chwili.</p>
+            </div>
+            <div class="legal-right-box">
+              <h3>Skarga</h3>
+              <p>Przysługuje Ci prawo złożenia skargi do Prezesa UODO (ul. Stawki 2, 00-193 Warszawa).</p>
+            </div>
+          </div>
+          <div class="legal-note">Na Twoje wnioski odpowiadamy bez zbędnej zwłoki, maksymalnie w ciągu 1 miesiąca. Przy skomplikowanych sprawach termin może zostać wydłużony o kolejne 2 miesiące — poinformujemy Cię o tym.</div>
+        </section>
+
+        <section class="legal-section" id="cookies">
+          <h2>Polityka plików „cookies”</h2>
+          <h3>Co to są cookies i po co je stosujemy</h3>
+          <p class="legal-paragraph">Cookies to niewielkie pliki tekstowe zapisywane na Twoim urządzeniu. Dzięki nim serwis działa sprawniej, może zapamiętać Twoje ustawienia i dostarczać dopasowane treści. Akceptując Politykę cookies wyrażasz zgodę na opisane niżej wykorzystanie plików.</p>
+
+          <h3>Kategorie cookies, które możemy wykorzystywać</h3>
+          <ul class="legal-list">
+            <li><strong>Niezbędne.</strong> Umożliwiają podstawowe działanie serwisu i zapis ustawień. Bez nich niektóre funkcje nie będą działać poprawnie.</li>
+            <li><strong>Funkcjonalne/analityczne (zewnętrzne).</strong> Pomagają zrozumieć, jak korzystasz z serwisu, abyśmy mogli go ulepszać. Dostawcami mogą być m.in. Google, Salesforce, Hotjar.</li>
+            <li><strong>Reklamowe i pomiarowe.</strong> Ułatwiają personalizację treści i analizę skuteczności kampanii. Mogą je dostarczać m.in. Google, Facebook, LinkedIn.</li>
+          </ul>
+
+          <h3>Bezpieczeństwo</h3>
+          <p class="legal-paragraph">Stosowane przez nas cookies nie instalują złośliwego oprogramowania i nie służą do bezpośredniej identyfikacji użytkownika.</p>
+
+          <h3>Google Analytics i podobne narzędzia</h3>
+          <p class="legal-paragraph">Korzystamy z narzędzi analitycznych w celu tworzenia zagregowanych statystyk. Dostawcy otrzymują zanonimizowane dane o ruchu i aktywności. Informacje te mogą być przetwarzane poza EOG zgodnie z politykami dostawców. Możesz zarządzać preferencjami reklamowymi Google oraz zainstalować dodatek opt-out do przeglądarki.</p>
+
+          <h3>Wtyczki społecznościowe</h3>
+          <p class="legal-paragraph">Na stronie mogą pojawiać się przyciski serwisów społecznościowych (np. Facebook, X/Twitter, YouTube, Instagram). Kliknięcie przycisku może skutkować zapisaniem cookie danego serwisu i powiązaniem aktywności z Twoim kontem (jeśli jesteś zalogowany/a). Szczegóły znajdziesz w politykach prywatności tych dostawców.</p>
+
+          <h3>Linki zewnętrzne</h3>
+          <p class="legal-paragraph">Nasza strona może kierować do witryn zewnętrznych. Nie odpowiadamy za ich polityki dotyczące cookies i prywatności.</p>
+
+          <h3>Logi systemowe</h3>
+          <p class="legal-paragraph">Dla bezpieczeństwa i diagnostyki system automatycznie zapisuje logi (np. znaczniki czasu, adres IP, zdarzenia systemowe). Dostęp do nich mają wyłącznie upoważnione osoby.</p>
+
+          <h3>Jak wyłączyć lub usunąć cookies</h3>
+          <p class="legal-paragraph">Większość przeglądarek pozwala zarządzać plikami cookies: blokować je, usuwać lub dodawać wyjątki. Ograniczenie cookies może utrudnić korzystanie z niektórych funkcji serwisu. Instrukcje znajdziesz na stronach producentów przeglądarek. Dla Google Analytics dostępny jest dodatek opt-out.</p>
+
+          <h3>Zmiany Polityki</h3>
+          <p class="legal-paragraph">Technologia i prawo się zmieniają, dlatego Polityka może być aktualizowana. Aktualna wersja jest zawsze publikowana w serwisie, a zapisy regularnie weryfikujemy, aby były zgodne z przepisami i dobrymi praktykami.</p>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <footer id="contact">
+    <div class="container">
+      <div class="footer-container">
+        <div class="footer-about">
+          <a href="index.html" class="footer-logo">
+            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+            <span>Grunteo</span>
+          </a>
+          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
+        </div>
+
+        <div class="footer-links">
+          <h3>Przydatne linki</h3>
+          <ul>
+            <li><a href="index.html">Strona główna</a></li>
+            <li><a href="oferty.html">Oferty</a></li>
+            <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+        </div>
+
+        <div class="footer-contact">
+          <h3>Kontakt</h3>
+          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
+          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+      const navMenu = document.querySelector('.nav-menu');
+      const mobileAuth = document.getElementById('mobileAuth');
+
+      mobileMenuBtn?.addEventListener('click', function () {
+        navMenu?.classList.toggle('active');
+        if (mobileAuth) {
+          mobileAuth.style.display = navMenu?.classList.contains('active') ? 'flex' : 'none';
+        }
+      });
+
+      window.addEventListener('resize', function () {
+        if (window.innerWidth > 768) {
+          navMenu?.classList.remove('active');
+          if (mobileAuth) {
+            mobileAuth.style.display = 'none';
+          }
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -175,7 +175,7 @@
           <h2>Udostępnianie i powierzanie danych</h2>
           <p class="legal-paragraph">Współpracujemy wyłącznie z zaufanymi dostawcami usług wspierających nasze działania:</p>
           <ul class="legal-list">
-            <li>dostawcy IT, hostingu, analityki, poczty e-mail, czatów i narzędzi komunikacyjnych (np. Google, Salesforce, Hotjar);</li>
+            <li>dostawcy IT, hostingu, analityki, poczty e-mail, czatów i narzędzi komunikacyjnych (np. Google, Firebase, Hotjar);</li>
             <li>biura księgowe, kancelarie prawne i notarialne, pośrednicy oraz architekci zaangażowani w transakcje;</li>
             <li>firmy kurierskie i pocztowe realizujące doręczenia;</li>
             <li>podmioty dochodzące roszczeń lub świadczące pomoc prawną w razie sporów.</li>


### PR DESCRIPTION
## Summary
- add a dedicated RODO information page with full legal content and shared navigation/footer layout
- add a privacy and cookies policy page describing data scope, rights and cookie usage
- introduce a reusable legal stylesheet to style both pages consistently

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68c97781bdbc832b954c6acf7cac3d7c