### PR TITLE
Add RODO and privacy policy links across site

### DIFF
--- a/RODO.html
+++ b/RODO.html
@@ -216,6 +216,8 @@
             <li><a href="index.html">Strona główna</a></li>
             <li><a href="oferty.html">Oferty</a></li>
             <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="RODO.html">Informacja RODO</a></li>
+            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
             <li><a href="#contact">Kontakt</a></li>
           </ul>
         </div>

--- a/details.html
+++ b/details.html
@@ -321,8 +321,44 @@
       <div class="form-footer">
         <p>Masz już konto? <a href="#" id="switchToLogin">Zaloguj się</a></p>
       </div>
-    </div>
   </div>
+</div>
+
+  <footer id="contact">
+    <div class="container">
+      <div class="footer-container">
+        <div class="footer-about">
+          <a href="index.html" class="footer-logo">
+            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+            <span>Grunteo</span>
+          </a>
+          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
+        </div>
+
+        <div class="footer-links">
+          <h3>Przydatne linki</h3>
+          <ul>
+            <li><a href="index.html">Strona główna</a></li>
+            <li><a href="oferty.html">Oferty</a></li>
+            <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="RODO.html">Informacja RODO</a></li>
+            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+        </div>
+
+        <div class="footer-contact">
+          <h3>Kontakt</h3>
+          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
+          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
+      </div>
+    </div>
+  </footer>
 
   <script type="module" src="assets/details.js"></script>
 </body>

--- a/dodaj.html
+++ b/dodaj.html
@@ -434,42 +434,6 @@
   </div>
 </div>
 
-  <footer id="contact">
-    <div class="container">
-      <div class="footer-container">
-        <div class="footer-about">
-          <a href="index.html" class="footer-logo">
-            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
-            <span>Grunteo</span>
-          </a>
-          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
-        </div>
-
-        <div class="footer-links">
-          <h3>Przydatne linki</h3>
-          <ul>
-            <li><a href="index.html">Strona główna</a></li>
-            <li><a href="oferty.html">Oferty</a></li>
-            <li><a href="dodaj.html">Dodaj ofertę</a></li>
-            <li><a href="RODO.html">Informacja RODO</a></li>
-            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
-            <li><a href="#contact">Kontakt</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-contact">
-          <h3>Kontakt</h3>
-          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
-          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
-        </div>
-      </div>
-
-      <div class="footer-bottom">
-        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
-      </div>
-    </div>
-  </footer>
-
     <!-- Bootstrap + jQuery -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/dodaj.html
+++ b/dodaj.html
@@ -416,7 +416,7 @@
 
           <div class="form-check mb-2">
             <input class="form-check-input" type="checkbox" id="termsConsent" required />
-            <label class="form-check-label" for="termsConsent">Zapoznałem się z <a href="#" target="_blank">RODO</a> i <a href="#" target="_blank">Polityką prywatności</a> oraz akceptuję ich treść *</label>
+            <label class="form-check-label" for="termsConsent">Zapoznałem się z <a href="RODO.html" target="_blank" rel="noopener">Informacją RODO</a> i <a href="polityka-prywatnosci.html" target="_blank" rel="noopener">Polityką prywatności</a> oraz akceptuję ich treść *</label>
           </div>
 
           <div class="form-check mb-3">
@@ -429,10 +429,46 @@
       </form>
 
       <div class="privacy-text">
-        Za przetwarzanie danych osobowych podanych w formularzu odpowiada Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Współadministratorem pozostaje Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Zasady przetwarzania opisaliśmy tutaj: <a href="https://www.grunteo.pl/polityka-prywatnosci" target="_blank">www.grunteo.pl/polityka-prywatnosci</a>. Masz prawo odwołać zgody w dowolnym momencie.
+        Za przetwarzanie danych osobowych podanych w formularzu odpowiada Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Współadministratorem pozostaje Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Zasady przetwarzania opisaliśmy w <a href="RODO.html" target="_blank" rel="noopener">Informacji RODO</a> oraz <a href="polityka-prywatnosci.html" target="_blank" rel="noopener">Polityce prywatności</a>. Masz prawo odwołać zgody w dowolnym momencie.
+      </div>
+  </div>
+</div>
+
+  <footer id="contact">
+    <div class="container">
+      <div class="footer-container">
+        <div class="footer-about">
+          <a href="index.html" class="footer-logo">
+            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+            <span>Grunteo</span>
+          </a>
+          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
+        </div>
+
+        <div class="footer-links">
+          <h3>Przydatne linki</h3>
+          <ul>
+            <li><a href="index.html">Strona główna</a></li>
+            <li><a href="oferty.html">Oferty</a></li>
+            <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="RODO.html">Informacja RODO</a></li>
+            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+        </div>
+
+        <div class="footer-contact">
+          <h3>Kontakt</h3>
+          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
+          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
       </div>
     </div>
-  </div>
+  </footer>
 
     <!-- Bootstrap + jQuery -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>

--- a/dodaj.html
+++ b/dodaj.html
@@ -416,7 +416,7 @@
 
           <div class="form-check mb-2">
             <input class="form-check-input" type="checkbox" id="termsConsent" required />
-            <label class="form-check-label" for="termsConsent">Zapoznałem się z <a href="RODO.html" target="_blank" rel="noopener">Informacją RODO</a> i <a href="polityka-prywatnosci.html" target="_blank" rel="noopener">Polityką prywatności</a> oraz akceptuję ich treść *</label>
+            <label class="form-check-label" for="termsConsent">Zapoznałem się z <a href="RODO.html" target="_blank" rel="noopener">RODO</a> i <a href="polityka-prywatnosci.html" target="_blank" rel="noopener">Polityką prywatności</a> oraz akceptuję ich treść *</label>
           </div>
 
           <div class="form-check mb-3">

--- a/edit.html
+++ b/edit.html
@@ -336,6 +336,42 @@
     </div>
   </div>
 
+  <footer id="contact">
+    <div class="container">
+      <div class="footer-container">
+        <div class="footer-about">
+          <a href="index.html" class="footer-logo">
+            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+            <span>Grunteo</span>
+          </a>
+          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
+        </div>
+
+        <div class="footer-links">
+          <h3>Przydatne linki</h3>
+          <ul>
+            <li><a href="index.html">Strona główna</a></li>
+            <li><a href="oferty.html">Oferty</a></li>
+            <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="RODO.html">Informacja RODO</a></li>
+            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+        </div>
+
+        <div class="footer-contact">
+          <h3>Kontakt</h3>
+          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
+          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
+      </div>
+    </div>
+  </footer>
+
   <script type="module" src="assets/edit.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -445,6 +445,8 @@ window.showConfirmModal = showConfirmModal;
           <li><a href="index.html">Strona główna</a></li>
           <li><a href="oferty.html">Oferty</a></li>
           <li><a href="dodaj.html">Dodaj ofertę</a></li>
+          <li><a href="RODO.html">Informacja RODO</a></li>
+          <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
           <li><a href="#contact">Kontakt</a></li>
         </ul>
       </div>

--- a/oferty.html
+++ b/oferty.html
@@ -320,8 +320,44 @@ window.showConfirmModal = showConfirmModal;
         
         <button type="submit" class="btn btn-primary" style="width: 100%;">Zaktualizuj ofertę</button>
       </form>
-    </div>
   </div>
+</div>
+
+  <footer id="contact">
+    <div class="container">
+      <div class="footer-container">
+        <div class="footer-about">
+          <a href="index.html" class="footer-logo">
+            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
+            <span>Grunteo</span>
+          </a>
+          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
+        </div>
+
+        <div class="footer-links">
+          <h3>Przydatne linki</h3>
+          <ul>
+            <li><a href="index.html">Strona główna</a></li>
+            <li><a href="oferty.html">Oferty</a></li>
+            <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="RODO.html">Informacja RODO</a></li>
+            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
+            <li><a href="#contact">Kontakt</a></li>
+          </ul>
+        </div>
+
+        <div class="footer-contact">
+          <h3>Kontakt</h3>
+          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
+          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
+        </div>
+      </div>
+
+      <div class="footer-bottom">
+        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
+      </div>
+    </div>
+  </footer>
   <!-- Firebase -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js";

--- a/oferty.html
+++ b/oferty.html
@@ -322,42 +322,6 @@ window.showConfirmModal = showConfirmModal;
       </form>
   </div>
 </div>
-
-  <footer id="contact">
-    <div class="container">
-      <div class="footer-container">
-        <div class="footer-about">
-          <a href="index.html" class="footer-logo">
-            <img src="https://storage.waw.cloud.ovh.net/v1/AUTH_024f82ed62da4186825a5b526cd1a61e/FishFounder/Grunteo_logo.png" alt="Grunteo">
-            <span>Grunteo</span>
-          </a>
-          <p>Bezpłatne ogłoszenia nieruchomości. Szybka sprzedaż działek bez zbędnych kosztów i formalności.</p>
-        </div>
-
-        <div class="footer-links">
-          <h3>Przydatne linki</h3>
-          <ul>
-            <li><a href="index.html">Strona główna</a></li>
-            <li><a href="oferty.html">Oferty</a></li>
-            <li><a href="dodaj.html">Dodaj ofertę</a></li>
-            <li><a href="RODO.html">Informacja RODO</a></li>
-            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
-            <li><a href="#contact">Kontakt</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-contact">
-          <h3>Kontakt</h3>
-          <p><i class="fas fa-envelope"></i> info@grunteo.pl</p>
-          <p><i class="fas fa-phone"></i> +48 123 456 789</p>
-        </div>
-      </div>
-
-      <div class="footer-bottom">
-        © 2025 Grunteo. Wszelkie prawa zastrzeżone.
-      </div>
-    </div>
-  </footer>
   <!-- Firebase -->
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/9.22.0/firebase-app.js";

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -279,6 +279,8 @@
             <li><a href="index.html">Strona główna</a></li>
             <li><a href="oferty.html">Oferty</a></li>
             <li><a href="dodaj.html">Dodaj ofertę</a></li>
+            <li><a href="RODO.html">Informacja RODO</a></li>
+            <li><a href="polityka-prywatnosci.html">Polityka prywatności</a></li>
             <li><a href="#contact">Kontakt</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- add a consistent footer with links to the RODO notice and privacy policy on every page
- update the add-offer consent text to point at the local RODO and privacy documents

## Testing
- not run (static HTML site)

------
https://chatgpt.com/codex/tasks/task_e_68c97e85b4b8832b92fa69640fe41505