### PR TITLE
Sanitize favorites data before persisting

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -412,6 +412,30 @@ main.property-wrapper {
   gap: .6rem;
 }
 
+#savePlotBtn.is-saved {
+  background: rgba(30, 111, 186, .12);
+  color: var(--primary);
+  border-color: rgba(30, 111, 186, .35);
+  box-shadow: none;
+}
+
+#savePlotBtn.is-saved:hover {
+  background: rgba(30, 111, 186, .18);
+  transform: none;
+}
+
+#savePlotBtn.is-disabled {
+  background: #f1f3f5;
+  color: #7c8596;
+  border-color: #d8dde6;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+#savePlotBtn.is-disabled:hover {
+  transform: none;
+}
+
 .contact-form-card {
   padding: 1.6rem 1.4rem;
 }

--- a/assets/main.css
+++ b/assets/main.css
@@ -97,6 +97,13 @@ a{color:var(--primary);text-decoration:none;transition:var(--transition);}
 /* ====== User dashboard ====== */
 .user-dashboard{display:none;margin-top:calc(var(--topbar-height) + var(--header-height) + 40px);margin-bottom:20px;padding:2rem;background:#fff;border-radius:var(--radius);box-shadow:var(--shadow-md);}
 .user-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:2rem;padding-bottom:1rem;border-bottom:1px solid #eee;}
+.offers-wrapper{display:flex;flex-direction:column;gap:2rem;}
+.offers-section{display:flex;flex-direction:column;gap:1rem;}
+.offers-section-header{display:flex;justify-content:space-between;align-items:center;gap:1rem;}
+.offers-subtitle{margin:0;font-size:1rem;font-weight:600;color:#1f2a3d;display:flex;align-items:center;gap:.5rem;}
+.offers-subtitle i{color:var(--primary);}
+.offers-section-note{font-size:.85rem;color:#6d7686;}
+.dashboard-empty{margin:0;padding:1rem;border-radius:10px;background:#f7f9fd;border:1px dashed #c8d4e5;font-size:.9rem;color:#5b6575;}
 .offers-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:1rem;}
 .offer-card{background:#fff;border-radius:10px;box-shadow:0 4px 8px rgba(0,0,0,.08);padding:1rem;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease;margin-bottom:1rem;}
 .offer-card:hover{transform:translateY(-4px);box-shadow:0 6px 14px rgba(0,0,0,.12);}
@@ -106,6 +113,12 @@ a{color:var(--primary);text-decoration:none;transition:var(--transition);}
 .offer-card p{margin:.25rem 0;font-size:.9rem;color:#555;}
 .offer-actions{display:flex;gap:.5rem;}
 .offer-actions.center{justify-content:center;}
+.favorites-grid .offer-card{background:#e9f3ff;border:1px solid #c7ddf8;box-shadow:none;}
+.favorites-grid .offer-card:hover{box-shadow:0 6px 14px rgba(30,111,186,.2);transform:translateY(-2px);}
+.favorites-grid .offer-title{color:#1a4f85;}
+.favorites-grid .offer-details{color:#3f4d62;}
+.favorite-meta{font-size:.8rem;color:#51617a;margin-top:.4rem;}
+.favorite-ppm{color:#1f5ea8;font-size:.8rem;margin-left:.4rem;font-weight:600;}
 
 /* ====== Home page offers grid (chessboard layout) ====== */
 body.home-page .offers-grid{

--- a/assets/property-common.js
+++ b/assets/property-common.js
@@ -4,7 +4,8 @@ import {
   doc,
   getDoc,
   updateDoc,
-  serverTimestamp
+  serverTimestamp,
+  setDoc
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import {
   getAuth,
@@ -33,7 +34,7 @@ export function initFirebase() {
   return firebaseCache;
 }
 
-export { doc, getDoc, updateDoc, serverTimestamp, onAuthStateChanged };
+export { doc, getDoc, updateDoc, serverTimestamp, setDoc, onAuthStateChanged };
 
 export function parseQueryParams() {
   const params = new URLSearchParams(window.location.search);

--- a/index.html
+++ b/index.html
@@ -305,8 +305,23 @@ window.showConfirmModal = showConfirmModal;
         <i class="fas fa-plus me-1"></i> Dodaj ofertę
       </a>
     </div>
-    <div class="offers-grid" id="userOffers">
-      <!-- Oferty użytkownika -->
+    <div class="offers-wrapper" id="userOffers">
+      <section class="offers-section" id="ownedOffersSection">
+        <div class="offers-section-header">
+          <h3 class="offers-subtitle"><i class="fas fa-clipboard-list"></i> Moje aktywne ogłoszenia</h3>
+        </div>
+        <p class="dashboard-empty" id="ownedOffersEmpty" style="display:none;">Nie masz jeszcze żadnych ofert.</p>
+        <div class="offers-grid" id="userOwnedOffers"></div>
+      </section>
+
+      <section class="offers-section" id="favoriteOffersSection" style="display:none;">
+        <div class="offers-section-header">
+          <h3 class="offers-subtitle"><i class="fas fa-bookmark"></i> Moje ulubione</h3>
+          <span class="offers-section-note">Zapisane działki innych użytkowników.</span>
+        </div>
+        <p class="dashboard-empty" id="favoriteOffersEmpty" style="display:none;">Nie dodałeś jeszcze ulubionych działek.</p>
+        <div class="offers-grid favorites-grid" id="userFavoriteOffers"></div>
+      </section>
     </div>
   </div>
 
@@ -534,11 +549,146 @@ window.showConfirmModal = showConfirmModal;
     const registerForm  = document.getElementById('registerForm');
     const userDashboard = document.getElementById('userDashboard');
     const userOffers    = document.getElementById('userOffers');
+    const ownedOffers   = document.getElementById('userOwnedOffers');
+    const ownedEmpty    = document.getElementById('ownedOffersEmpty');
+    const favoriteSection = document.getElementById('favoriteOffersSection');
+    const favoriteOffers = document.getElementById('userFavoriteOffers');
+    const favoriteEmpty  = document.getElementById('favoriteOffersEmpty');
     const gBtn1         = document.getElementById('googleLoginBtn');
     const gBtn2         = document.getElementById('googleLoginBtnLogin');
 
     const openModal  = (m) => m && (m.style.display = 'flex');
     const closeModal = (m) => m && (m.style.display = 'none');
+
+    const toDate = (value) => {
+      if (!value) return null;
+      if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value;
+      }
+      if (typeof value === 'number') {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+      }
+      if (typeof value === 'string') {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+      }
+      if (typeof value === 'object') {
+        if (typeof value.toDate === 'function') {
+          const date = value.toDate();
+          return Number.isNaN(date.getTime()) ? null : date;
+        }
+        if ('seconds' in value && typeof value.seconds === 'number') {
+          const date = new Date(value.seconds * 1000);
+          return Number.isNaN(date.getTime()) ? null : date;
+        }
+      }
+      return null;
+    };
+
+    const formatDateTime = (value) => {
+      const date = toDate(value);
+      if (!date) return null;
+      return new Intl.DateTimeFormat('pl-PL', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+    };
+
+    const formatNumberPL = (value) => Number.isFinite(value) ? value.toLocaleString('pl-PL') : null;
+
+    const parseNumberFromText = (value) => {
+      if (value === null || value === undefined) return null;
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+      const text = String(value)
+        .replace(/\u00A0/g, '')
+        .replace(/\s+/g, '')
+        .replace(/zł|pln|m²|m2/gi, '')
+        .replace(/,/g, '.')
+        .replace(/[^0-9+\-.]/g, '');
+      if (!text) return null;
+      const parsed = Number.parseFloat(text);
+      return Number.isFinite(parsed) ? parsed : null;
+    };
+
+    const toNullableString = (value) => {
+      if (value === null || value === undefined) return null;
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed ? trimmed : null;
+      }
+      if (typeof value === 'number' || typeof value === 'boolean') {
+        const text = String(value).trim();
+        return text ? text : null;
+      }
+      return null;
+    };
+
+    const toNullableNumber = (value) => {
+      if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+      }
+      if (typeof value === 'string') {
+        const parsed = parseNumberFromText(value);
+        return Number.isFinite(parsed) ? parsed : null;
+      }
+      return null;
+    };
+
+    const toPlotIndex = (value) => {
+      const parsed = Number.parseInt(value, 10);
+      return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0;
+    };
+
+    const sanitizeTimestampValue = (value) => {
+      if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+      }
+      if (value instanceof Date) {
+        const time = value.getTime();
+        return Number.isNaN(time) ? null : time;
+      }
+      if (value && typeof value === 'object') {
+        if (typeof value.toMillis === 'function') {
+          const millis = value.toMillis();
+          return Number.isFinite(millis) ? millis : null;
+        }
+        if (typeof value.toDate === 'function') {
+          const date = value.toDate();
+          const millis = date?.getTime();
+          return Number.isNaN(millis) ? null : millis;
+        }
+        if (typeof value.seconds === 'number') {
+          return Number.isFinite(value.seconds) ? Math.round(value.seconds * 1000) : null;
+        }
+      }
+      return null;
+    };
+
+    const sanitizeFavoriteEntry = (raw) => {
+      if (!raw || typeof raw !== 'object') {
+        return null;
+      }
+
+      const entry = {
+        offerId: toNullableString(raw.offerId),
+        plotIndex: toPlotIndex(raw.plotIndex),
+        title: toNullableString(raw.title),
+        city: toNullableString(raw.city),
+        price: toNullableNumber(raw.price),
+        area: toNullableNumber(raw.area),
+        ownerUid: toNullableString(raw.ownerUid),
+        ownerEmail: toNullableString(raw.ownerEmail),
+        contactName: toNullableString(raw.contactName),
+        contactPhone: toNullableString(raw.contactPhone),
+        contactEmail: toNullableString(raw.contactEmail),
+        plotNumber: toNullableString(raw.plotNumber)
+      };
+
+      const savedAt = sanitizeTimestampValue(raw.savedAt);
+      entry.savedAt = savedAt !== null ? savedAt : Date.now();
+
+      return entry;
+    };
+
+    const sanitizeFavoriteList = (list) => Array.isArray(list) ? list.map(sanitizeFavoriteEntry).filter(Boolean) : [];
 
     // >>> renderMobileAuth PRZENIESIONE DO MODUŁU <<<
     function renderMobileAuth(user) {
@@ -610,13 +760,18 @@ window.showConfirmModal = showConfirmModal;
           accountBtn.innerHTML = `<i class="fas fa-user"></i> ${label}`;
         }
         userDashboard && (userDashboard.style.display = 'block');
+        favoriteSection && (favoriteSection.style.display = 'block');
         loadUserOffers(user.email || null, user.uid || null);
         closeModal(loginModal); closeModal(registerModal);
       } else {
         authButtons && (authButtons.style.display = 'flex');
         userMenu    && (userMenu.style.display = 'none');
         userDashboard && (userDashboard.style.display = 'none');
-        userOffers && (userOffers.innerHTML = '');
+        if (ownedOffers) ownedOffers.innerHTML = '';
+        if (favoriteOffers) favoriteOffers.innerHTML = '';
+        if (ownedEmpty) ownedEmpty.style.display = 'none';
+        if (favoriteEmpty) favoriteEmpty.style.display = 'none';
+        favoriteSection && (favoriteSection.style.display = 'none');
       }
       // aktualizuj sekcję menu mobilnego
       renderMobileAuth(user);
@@ -706,41 +861,47 @@ window.showConfirmModal = showConfirmModal;
     logoutBtn && logoutBtn.addEventListener('click', async () => {
       try { await signOut(auth); } catch(e){ console.error(e); }
     });
-
     // Oferty użytkownika
     async function loadUserOffers(email, uid) {
-      if (!userOffers) return;
-      userOffers.innerHTML = '<p>Ładuję Twoje oferty…</p>';
+      if (!ownedOffers) return;
+      ownedOffers.innerHTML = '';
+      if (ownedEmpty) {
+        ownedEmpty.textContent = 'Ładuję Twoje oferty…';
+        ownedEmpty.style.display = 'block';
+      }
+
+      if (favoriteOffers) favoriteOffers.innerHTML = '';
+      if (favoriteEmpty) {
+        favoriteEmpty.textContent = 'Ładuję ulubione…';
+        favoriteEmpty.style.display = uid ? 'block' : 'none';
+      }
+      if (favoriteSection) {
+        favoriteSection.style.display = uid ? 'block' : 'none';
+      }
 
       try {
-        const colRef = collection(db, "propertyListings");
+        const colRef = collection(db, 'propertyListings');
         const queries = [];
 
         if (email) {
-          queries.push(getDocs(query(colRef, where("email", "==", email))));
-          queries.push(getDocs(query(colRef, where("userEmail", "==", email))));
+          queries.push(getDocs(query(colRef, where('email', '==', email))));
+          queries.push(getDocs(query(colRef, where('userEmail', '==', email))));
         }
         if (uid) {
-          queries.push(getDocs(query(colRef, where("userUid", "==", uid))));
-          queries.push(getDocs(query(colRef, where("uid", "==", uid))));
-          queries.push(getDocs(query(colRef, where("ownerId", "==", uid))));
+          queries.push(getDocs(query(colRef, where('userUid', '==', uid))));
+          queries.push(getDocs(query(colRef, where('uid', '==', uid))));
+          queries.push(getDocs(query(colRef, where('ownerId', '==', uid))));
         }
 
-        const results = await Promise.allSettled(queries);
+        const results = queries.length ? await Promise.allSettled(queries) : [];
         const docsById = new Map();
-        results.forEach(r => {
-          if (r.status === "fulfilled") {
-            r.value.forEach(docSnap => docsById.set(docSnap.id, docSnap));
+        results.forEach(result => {
+          if (result.status === 'fulfilled') {
+            result.value.forEach(docSnap => docsById.set(docSnap.id, docSnap));
           }
         });
 
-        userOffers.innerHTML = '';
-
-        if (docsById.size === 0) {
-          userOffers.innerHTML = '<p>Nie masz jeszcze żadnych ofert.</p>';
-          return;
-        }
-
+        let hasOwned = false;
         docsById.forEach(docSnap => {
           const offer = docSnap.data();
           const offerId = docSnap.id;
@@ -754,11 +915,12 @@ window.showConfirmModal = showConfirmModal;
               el.className = 'offer-card';
 
               const price = Number(plot.price || 0);
-              const area  = Number(plot.pow_dzialki_m2_uldk || 0);
-              const ppm2  = price && area ? Math.round(price / area) : 0;
-              const city  = offer.city || 'Nie podano';
+              const area = Number(plot.pow_dzialki_m2_uldk || 0);
+              const ppm2 = price && area ? Math.round(price / area) : 0;
+              const city = offer.city || 'Nie podano';
               const phone = offer.phone || 'Nie podano';
               const title = plot.Id || `Działka ${visibleIdx + 1}`;
+              const safeTitle = (title || '').replace(/'/g, "\'");
               const detailsUrl = `details.html?id=${offerId}&plot=${originalIndex}`;
 
               el.innerHTML = `
@@ -766,7 +928,7 @@ window.showConfirmModal = showConfirmModal;
                 <div class="offer-details">
                   <p><strong>Lokalizacja:</strong> ${city}</p>
                   <p><strong>Telefon:</strong> ${phone}</p>
-                  ${area  ? `<p><strong>Powierzchnia:</strong> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
+                  ${area ? `<p><strong>Powierzchnia:</strong> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
                   ${price ? `<p><strong>Cena całkowita:</strong> ${price.toLocaleString('pl-PL')} zł
                     ${ppm2 ? `<span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2.toLocaleString('pl-PL')} zł/m²</span>` : ''}
                   </p>` : ''}
@@ -778,29 +940,160 @@ window.showConfirmModal = showConfirmModal;
                   <button class="btn btn-primary btn-sm" onclick="window.location.href='edit.html?id=${offerId}&plot=${originalIndex}'">
                     <i class="fas fa-edit"></i> Edytuj
                   </button>
-                  <button class="btn btn-secondary btn-sm" onclick="deletePlot && deletePlot('${offerId}', ${originalIndex}, '${(title||'').replace(/'/g,"\\'")}')">
+                  <button class="btn btn-secondary btn-sm" onclick="deletePlot && deletePlot('${offerId}', ${originalIndex}, '${safeTitle}')">
                     <i class="fas fa-trash"></i> Usuń
                   </button>
                 </div>
               `;
 
-              el.addEventListener('click', (e) => {
-                if (e.target.closest('.offer-actions')) return;
+              el.addEventListener('click', (event) => {
+                if (event.target.closest('.offer-actions')) return;
                 if (window.focusOfferOnMap) window.focusOfferOnMap(offerId, originalIndex);
               });
 
-              userOffers.appendChild(el);
+              ownedOffers.appendChild(el);
+              hasOwned = true;
             });
         });
 
-        if (!userOffers.querySelector('.offer-card')) {
-          userOffers.innerHTML = '<p>Nie masz jeszcze żadnych aktywnych ofert.</p>';
+        if (!hasOwned) {
+          if (ownedEmpty) {
+            ownedEmpty.textContent = 'Nie masz jeszcze żadnych ofert.';
+            ownedEmpty.style.display = 'block';
+          } else {
+            ownedOffers.innerHTML = '<p>Nie masz jeszcze żadnych ofert.</p>';
+          }
+        } else if (ownedEmpty) {
+          ownedEmpty.style.display = 'none';
         }
       } catch (err) {
         console.error('loadUserOffers:', err);
-        userOffers.innerHTML = '<p>Wystąpił błąd podczas ładowania ofert.</p>';
+        if (ownedEmpty) {
+          ownedEmpty.textContent = 'Wystąpił błąd podczas ładowania ofert.';
+          ownedEmpty.style.display = 'block';
+        } else {
+          ownedOffers.innerHTML = '<p>Wystąpił błąd podczas ładowania ofert.</p>';
+        }
+      }
+
+      if (uid) {
+        await loadFavoriteOffers(uid);
       }
     }
+
+    async function loadFavoriteOffers(uid) {
+      if (!favoriteOffers || !favoriteEmpty) return;
+      favoriteOffers.innerHTML = '';
+      favoriteEmpty.textContent = 'Ładuję ulubione…';
+      favoriteEmpty.style.display = 'block';
+
+      try {
+        const userRef = doc(db, 'users', uid);
+        const snap = await getDoc(userRef);
+        if (!snap.exists()) {
+          favoriteEmpty.textContent = 'Nie dodałeś jeszcze ulubionych działek.';
+          return;
+        }
+        const data = snap.data();
+        const favorites = sanitizeFavoriteList(data.favorites);
+        if (!favorites.length) {
+          favoriteEmpty.textContent = 'Nie dodałeś jeszcze ulubionych działek.';
+          return;
+        }
+
+        favoriteEmpty.style.display = 'none';
+        favorites
+          .slice()
+          .sort((a, b) => {
+            const timeA = toDate(a?.savedAt)?.getTime() || 0;
+            const timeB = toDate(b?.savedAt)?.getTime() || 0;
+            return timeB - timeA;
+          })
+          .forEach(favorite => {
+            const card = createFavoriteCard(favorite);
+            favoriteOffers.appendChild(card);
+          });
+      } catch (err) {
+        console.error('loadFavoriteOffers', err);
+        favoriteEmpty.textContent = 'Nie udało się załadować ulubionych.';
+      }
+    }
+
+    function createFavoriteCard(favorite) {
+      const offerId = favorite?.offerId;
+      const plotIndex = Number.isFinite(favorite?.plotIndex) ? favorite.plotIndex : Number(favorite?.plotIndex) || 0;
+      const title = favorite?.title || (favorite?.plotNumber ? `Działka ${favorite.plotNumber}` : `Działka ${plotIndex + 1}`);
+      const city = favorite?.city || 'Nie podano';
+      const area = Number(favorite?.area || 0);
+      const price = Number(favorite?.price || 0);
+      const areaText = Number.isFinite(area) && area > 0 ? `${area.toLocaleString('pl-PL')} m²` : '';
+      const priceText = Number.isFinite(price) && price > 0 ? `${price.toLocaleString('pl-PL')} zł` : '';
+      const ppm = Number.isFinite(price) && Number.isFinite(area) && area > 0 ? Math.round(price / area) : null;
+      const ppmText = Number.isFinite(ppm) ? `${ppm.toLocaleString('pl-PL')} zł/m²` : '';
+      const savedAtText = formatDateTime(favorite?.savedAt);
+      const detailsUrl = offerId ? `details.html?id=${offerId}&plot=${plotIndex}` : '#';
+
+      const card = document.createElement('div');
+      card.className = 'offer-card';
+      card.innerHTML = `
+        <h3 class="offer-title">${title}</h3>
+        <div class="offer-details">
+          <p><strong>Lokalizacja:</strong> ${city}</p>
+          ${favorite?.contactName ? `<p><strong>Kontakt:</strong> ${favorite.contactName}</p>` : ''}
+          ${favorite?.contactPhone ? `<p><strong>Telefon:</strong> ${favorite.contactPhone}</p>` : ''}
+          ${areaText ? `<p><strong>Powierzchnia:</strong> ${areaText}</p>` : ''}
+          ${priceText ? `<p><strong>Cena:</strong> ${priceText}${ppmText ? ` <span class="favorite-ppm">(${ppmText})</span>` : ''}</p>` : ''}
+          ${savedAtText ? `<p class="favorite-meta"><strong>Zapisano:</strong> ${savedAtText}</p>` : ''}
+        </div>
+        <div class="offer-actions">
+          <a class="btn btn-accent btn-sm" ${offerId ? `target="_blank" href="${detailsUrl}"` : 'href="#" aria-disabled="true" style="pointer-events:none;opacity:.6;"'}>
+            <i class="fas fa-info-circle"></i> Szczegóły
+          </a>
+          <button class="btn btn-secondary btn-sm favorite-remove" type="button">
+            <i class="fas fa-times"></i> Usuń
+          </button>
+        </div>
+      `;
+
+      card.addEventListener('click', (event) => {
+        if (event.target.closest('.offer-actions')) return;
+        if (offerId) {
+          window.open(detailsUrl, '_blank');
+        }
+      });
+
+      const removeBtn = card.querySelector('.favorite-remove');
+      removeBtn?.addEventListener('click', async (event) => {
+        event.preventDefault();
+        await removeFavorite(offerId, plotIndex, title);
+      });
+
+      return card;
+    }
+
+    async function removeFavorite(offerId, plotIndex, title) {
+      if (!auth.currentUser || !offerId) return;
+      const label = title || 'wybraną działkę';
+      if (!(await showConfirmModal(`Czy na pewno chcesz usunąć "${label}" z ulubionych?`))) return;
+      try {
+        const userRef = doc(db, 'users', auth.currentUser.uid);
+        const snap = await getDoc(userRef);
+        if (!snap.exists()) {
+          showToast('Nie znaleziono listy ulubionych.', 'error');
+          return;
+        }
+        const data = snap.data();
+        const favorites = sanitizeFavoriteList(data.favorites);
+        const updated = favorites.filter(item => !(item && item.offerId === offerId && item.plotIndex === plotIndex));
+        await setDoc(userRef, { favorites: updated }, { merge: true });
+        showToast('Usunięto z ulubionych.', 'success');
+        await loadFavoriteOffers(auth.currentUser.uid);
+      } catch (err) {
+        console.error('removeFavorite', err);
+        showToast('Nie udało się usunąć z ulubionych.', 'error');
+      }
+    }
+
     async function deletePlot(offerId, plotIndex, title) {
       if (!(await showConfirmModal(`Czy na pewno chcesz usunąć działkę "${title}"?`))) return;
       try {


### PR DESCRIPTION
## Summary
- enable logged-in users to save another user's plot to a personal favourites list and persist it in Firestore
- surface a “Moje ulubione” section in the dashboard with styled favourite cards and removal support
- update the details save button styling and supporting CSS for the new favourites experience
- sanitize favourites data when loading, saving, and removing entries so Firestore never receives unsupported sentinel values

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c9bc5cdc58832ba10287fe13987058