### PR TITLE
Add parcel boundary overlay to details map

### DIFF
--- a/details.html
+++ b/details.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="assets/main.css">
   <link rel="stylesheet" href="assets/header.css">
   <link rel="stylesheet" href="assets/details.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.8.0/proj4.js"></script>
 </head>
 <body class="property-page" style="padding-top: calc(var(--topbar-height) + var(--header-height));">
   <div class="top-navbar">


### PR DESCRIPTION
## Summary
- load proj4 on the details page so parcel geometries can be transformed to WGS84
- parse ULdK geometry data and render a polygon overlay on the Google map
- center and fit the map to the parcel bounds while keeping the marker in place

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c654873c832b800cf23d5a1b2f14