### PR TITLE
Add filtering and sorting controls to offers page

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -38,21 +38,41 @@
 }
 
 .filters-panel {
-  background:#fff;
-  border-radius:10px;
-  box-shadow:0 4px 12px rgba(0,0,0,0.08);
-  padding:18px 20px;
-  margin-bottom:20px;
+  --filters-surface: rgba(255,255,255,0.94);
+  --filters-border: rgba(148,163,184,0.25);
+  --filters-shadow: 0 18px 40px rgba(15,23,42,0.08);
+  background:var(--filters-surface);
+  border-radius:16px;
+  border:1px solid var(--filters-border);
+  box-shadow:var(--filters-shadow);
+  padding:20px 22px;
+  margin-bottom:22px;
   display:flex;
   flex-direction:column;
-  gap:1rem;
+  gap:1.15rem;
+  position:sticky;
+  top:0;
+  z-index:5;
+  backdrop-filter:blur(14px);
+  -webkit-backdrop-filter:blur(14px);
+}
+
+@supports not ((backdrop-filter: blur(1px))) {
+  .filters-panel {
+    backdrop-filter:none;
+    -webkit-backdrop-filter:none;
+  }
 }
 
 .filters-row {
   display:flex;
   flex-wrap:wrap;
   align-items:center;
-  gap:0.75rem;
+  gap:0.75rem 1rem;
+}
+
+.filters-row.sort-row {
+  align-items:flex-start;
 }
 
 .filters-row.tags-row {
@@ -61,100 +81,205 @@
 
 .filters-label {
   font-weight:600;
-  color:#2d3748;
-  margin-right:0.5rem;
+  font-size:0.75rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:#64748b;
+  min-width:85px;
 }
 
 .sort-buttons {
   display:flex;
   flex-wrap:wrap;
-  gap:0.5rem;
+  gap:0.55rem;
 }
 
 .sort-chip {
-  border:1px solid #cbd5e0;
-  background:#fff;
-  color:#2d3748;
-  padding:0.45rem 0.85rem;
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:0.4rem;
+  border:1px solid rgba(148,163,184,0.55);
+  background:linear-gradient(135deg,#f8fafc 0%,#edf2f7 100%);
+  color:#1f2937;
+  padding:0.45rem 1.05rem;
   border-radius:999px;
-  font-size:0.9rem;
-  font-weight:500;
+  font-size:0.85rem;
+  font-weight:600;
   cursor:pointer;
-  transition:background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition:border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease, color 0.18s ease, background 0.18s ease;
+  box-shadow:0 1px 0 rgba(148,163,184,0.25), 0 6px 16px rgba(148,163,184,0.15);
 }
 
 .sort-chip:hover {
   border-color:#2b6cb0;
-  color:#2b6cb0;
+  color:#1a365d;
+  transform:translateY(-1px);
+}
+
+.sort-chip:focus-visible {
+  outline:3px solid rgba(56,120,224,0.35);
+  outline-offset:2px;
 }
 
 .sort-chip[data-active="true"] {
-  background:#2b6cb0;
-  border-color:#2b6cb0;
+  background:linear-gradient(135deg,#2b6cb0 0%,#2c5282 100%);
+  border-color:rgba(43,108,176,0.95);
   color:#fff;
-  box-shadow:0 6px 14px rgba(43,108,176,0.25);
+  box-shadow:0 10px 22px rgba(43,108,176,0.28);
 }
 
 .sort-chip::after {
   content:'';
-  margin-left:0.35rem;
-  font-size:0.85em;
+  width:0.65rem;
+  height:0.65rem;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%231f2937' stroke-width='1.8' stroke-linecap='round'%3E%3Cpath d='M3 7.5l3-3 3 3'/%3E%3C/svg%3E");
+  background-repeat:no-repeat;
+  background-position:center;
+  transition:transform 0.18s ease, filter 0.18s ease, opacity 0.18s ease;
+  opacity:0;
+  transform:translateY(-1px) rotate(0deg);
 }
 
-.sort-chip[data-active="true"][data-direction="asc"]::after { content:'\2191'; }
-.sort-chip[data-active="true"][data-direction="desc"]::after { content:'\2193'; }
+.sort-chip[data-active="true"]::after {
+  filter:invert(1);
+  opacity:1;
+}
+
+.sort-chip[data-active="true"][data-direction="asc"]::after {
+  transform:translateY(-1px) rotate(0deg);
+}
+
+.sort-chip[data-active="true"][data-direction="desc"]::after {
+  transform:translateY(-1px) rotate(180deg);
+}
 
 .tags-wrapper {
+  position:relative;
   display:flex;
   flex-wrap:wrap;
   gap:0.5rem;
   flex:1;
+  padding-right:0.5rem;
+  transition:max-height 0.3s ease;
+  max-height:none;
 }
 
-.tag-chip {
-  border:1px solid #e2e8f0;
-  background:#f8fafc;
-  color:#2d3748;
-  border-radius:999px;
-  padding:0.35rem 0.75rem;
-  font-size:0.85rem;
-  font-weight:500;
-  cursor:pointer;
-  transition:background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+.tags-wrapper.is-collapsed {
+  max-height:5.6rem;
+  overflow:hidden;
 }
 
-.tag-chip:hover {
-  background:#e2e8f0;
+.tags-wrapper::after {
+  content:"";
+  position:absolute;
+  pointer-events:none;
+  right:0;
+  top:0;
+  bottom:0;
+  width:3.2rem;
+  background:linear-gradient(270deg,var(--filters-surface) 5%,rgba(255,255,255,0));
+  opacity:0;
+  transition:opacity 0.25s ease;
 }
 
-.tag-chip.is-active {
-  background:#2b6cb0;
-  border-color:#2b6cb0;
-  color:#fff;
-  box-shadow:0 6px 14px rgba(43,108,176,0.25);
+.tags-wrapper.is-collapsed::after {
+  opacity:1;
+}
+
+.tags-wrapper.is-empty::after {
+  display:none;
 }
 
 .tags-wrapper[data-expanded="false"] .tag-chip--hidden {
   display:none;
 }
 
-.toggle-tags-btn {
-  border:0;
-  background:transparent;
-  color:#2b6cb0;
+.tag-chip {
+  display:inline-flex;
+  align-items:center;
+  gap:0.35rem;
+  border:1px solid rgba(148,163,184,0.45);
+  background:#f8fafc;
+  color:#1f2937;
+  border-radius:999px;
+  padding:0.38rem 0.85rem;
+  font-size:0.8rem;
   font-weight:600;
+  line-height:1.2;
   cursor:pointer;
-  padding:0.35rem 0.5rem;
+  transition:background 0.18s ease, color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.tag-chip:hover {
+  border-color:#2b6cb0;
+  color:#1a365d;
+  transform:translateY(-1px);
+}
+
+.tag-chip:focus-visible {
+  outline:3px solid rgba(56,120,224,0.35);
+  outline-offset:2px;
+}
+
+.tag-chip.is-active {
+  background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%);
+  border-color:rgba(37,99,235,0.9);
+  color:#fff;
+  box-shadow:0 12px 24px rgba(37,99,235,0.28);
+}
+
+.tag-chip.is-active::after {
+  content:'\2713';
+  font-size:0.75rem;
+}
+
+.toggle-tags-btn {
+  display:inline-flex;
+  align-items:center;
+  gap:0.35rem;
+  border:1px solid rgba(37,99,235,0.25);
+  background:rgba(59,130,246,0.08);
+  color:#1d4ed8;
+  font-weight:700;
+  font-size:0.75rem;
+  letter-spacing:0.06em;
+  text-transform:uppercase;
+  cursor:pointer;
+  padding:0.45rem 0.95rem;
+  border-radius:999px;
   margin-left:auto;
-  transition:color 0.2s ease;
+  transition:background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
 }
 
 .toggle-tags-btn:hover {
-  color:#1a4f7a;
+  background:rgba(37,99,235,0.12);
+  border-color:rgba(37,99,235,0.45);
+  transform:translateY(-1px);
+}
+
+.toggle-tags-btn:focus-visible {
+  outline:3px solid rgba(56,120,224,0.35);
+  outline-offset:2px;
+}
+
+.toggle-tags-btn::after {
+  content:"";
+  width:0.6rem;
+  height:0.6rem;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%231d4ed8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat:no-repeat;
+  background-position:center;
+  transition:transform 0.2s ease;
+}
+
+.toggle-tags-btn[data-state="expanded"]::after {
+  transform:rotate(180deg);
 }
 
 .tag-placeholder {
-  color:#718096;
+  color:#6b7280;
   font-size:0.85rem;
 }
 
@@ -218,7 +343,11 @@
   .filters-row { flex-direction:column; align-items:flex-start; gap:0.6rem; }
   .filters-label { margin-right:0; }
   .sort-buttons { width:100%; }
-  .toggle-tags-btn { margin-left:0; padding-left:0; }
+  .toggle-tags-btn {
+    margin-left:0;
+    width:100%;
+    justify-content:center;
+  }
   .user-header { flex-direction:column; gap:1rem; align-items:flex-start; }
   .user-header h2 { font-size:1.3rem; }
 }

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -57,6 +57,14 @@
   -webkit-backdrop-filter:blur(14px);
 }
 
+.filters-title {
+  margin:0;
+  font-size:1rem;
+  font-weight:700;
+  letter-spacing:0.01em;
+  color:#1f2937;
+}
+
 @supports not ((backdrop-filter: blur(1px))) {
   .filters-panel {
     backdrop-filter:none;
@@ -77,6 +85,14 @@
 
 .filters-row.tags-row {
   align-items:flex-start;
+}
+
+.tags-area {
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  gap:0.65rem;
+  min-width:0;
 }
 
 .filters-label {
@@ -156,44 +172,43 @@
 }
 
 .tags-wrapper {
-  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:0.75rem;
+  flex:1;
+}
+
+.tags-preview {
   display:flex;
   flex-wrap:wrap;
   gap:0.5rem;
-  flex:1;
-  padding-right:0.5rem;
-  transition:max-height 0.3s ease;
-  max-height:none;
+  align-items:center;
 }
 
-.tags-wrapper.is-collapsed {
-  max-height:5.6rem;
-  overflow:hidden;
+.tags-summary {
+  display:inline-flex;
+  align-items:center;
+  padding:0.25rem 0.65rem;
+  border-radius:999px;
+  background:rgba(148,163,184,0.16);
+  color:#475569;
+  font-size:0.75rem;
+  font-weight:600;
+  letter-spacing:0.02em;
+  flex-shrink:0;
 }
 
-.tags-wrapper::after {
-  content:"";
-  position:absolute;
-  pointer-events:none;
-  right:0;
-  top:0;
-  bottom:0;
-  width:3.2rem;
-  background:linear-gradient(270deg,var(--filters-surface) 5%,rgba(255,255,255,0));
-  opacity:0;
-  transition:opacity 0.25s ease;
-}
-
-.tags-wrapper.is-collapsed::after {
-  opacity:1;
-}
-
-.tags-wrapper.is-empty::after {
-  display:none;
-}
-
-.tags-wrapper[data-expanded="false"] .tag-chip--hidden {
-  display:none;
+.tags-dropdown {
+  display:flex;
+  flex-direction:column;
+  gap:0.45rem;
+  padding:0.75rem;
+  border-radius:12px;
+  border:1px solid rgba(148,163,184,0.35);
+  background:rgba(248,250,252,0.92);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,0.55);
+  max-height:220px;
+  overflow-y:auto;
 }
 
 .tag-chip {
@@ -210,6 +225,27 @@
   line-height:1.2;
   cursor:pointer;
   transition:background 0.18s ease, color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.tag-chip--preview {
+  white-space:nowrap;
+}
+
+.tag-chip--list {
+  width:100%;
+  justify-content:flex-start;
+  border-radius:12px;
+  padding:0.45rem 0.85rem;
+  background:linear-gradient(135deg,#f8fafc 0%,#f1f5f9 100%);
+}
+
+.tag-chip--list::after {
+  content:attr(data-count-label);
+  margin-left:auto;
+  padding-left:0.75rem;
+  font-size:0.72rem;
+  font-weight:600;
+  color:#1d4ed8;
 }
 
 .tag-chip:hover {
@@ -249,7 +285,7 @@
   cursor:pointer;
   padding:0.45rem 0.95rem;
   border-radius:999px;
-  margin-left:auto;
+  align-self:flex-start;
   transition:background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
 }
 

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -37,6 +37,127 @@
   margin-bottom:20px;
 }
 
+.filters-panel {
+  background:#fff;
+  border-radius:10px;
+  box-shadow:0 4px 12px rgba(0,0,0,0.08);
+  padding:18px 20px;
+  margin-bottom:20px;
+  display:flex;
+  flex-direction:column;
+  gap:1rem;
+}
+
+.filters-row {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:0.75rem;
+}
+
+.filters-row.tags-row {
+  align-items:flex-start;
+}
+
+.filters-label {
+  font-weight:600;
+  color:#2d3748;
+  margin-right:0.5rem;
+}
+
+.sort-buttons {
+  display:flex;
+  flex-wrap:wrap;
+  gap:0.5rem;
+}
+
+.sort-chip {
+  border:1px solid #cbd5e0;
+  background:#fff;
+  color:#2d3748;
+  padding:0.45rem 0.85rem;
+  border-radius:999px;
+  font-size:0.9rem;
+  font-weight:500;
+  cursor:pointer;
+  transition:background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sort-chip:hover {
+  border-color:#2b6cb0;
+  color:#2b6cb0;
+}
+
+.sort-chip[data-active="true"] {
+  background:#2b6cb0;
+  border-color:#2b6cb0;
+  color:#fff;
+  box-shadow:0 6px 14px rgba(43,108,176,0.25);
+}
+
+.sort-chip::after {
+  content:'';
+  margin-left:0.35rem;
+  font-size:0.85em;
+}
+
+.sort-chip[data-active="true"][data-direction="asc"]::after { content:'\2191'; }
+.sort-chip[data-active="true"][data-direction="desc"]::after { content:'\2193'; }
+
+.tags-wrapper {
+  display:flex;
+  flex-wrap:wrap;
+  gap:0.5rem;
+  flex:1;
+}
+
+.tag-chip {
+  border:1px solid #e2e8f0;
+  background:#f8fafc;
+  color:#2d3748;
+  border-radius:999px;
+  padding:0.35rem 0.75rem;
+  font-size:0.85rem;
+  font-weight:500;
+  cursor:pointer;
+  transition:background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tag-chip:hover {
+  background:#e2e8f0;
+}
+
+.tag-chip.is-active {
+  background:#2b6cb0;
+  border-color:#2b6cb0;
+  color:#fff;
+  box-shadow:0 6px 14px rgba(43,108,176,0.25);
+}
+
+.tags-wrapper[data-expanded="false"] .tag-chip--hidden {
+  display:none;
+}
+
+.toggle-tags-btn {
+  border:0;
+  background:transparent;
+  color:#2b6cb0;
+  font-weight:600;
+  cursor:pointer;
+  padding:0.35rem 0.5rem;
+  margin-left:auto;
+  transition:color 0.2s ease;
+}
+
+.toggle-tags-btn:hover {
+  color:#1a4f7a;
+}
+
+.tag-placeholder {
+  color:#718096;
+  font-size:0.85rem;
+}
+
 .offers-section .section-title { margin-bottom:1rem; }
 .offers-section .section-title h2 { margin-bottom:0.5rem; font-size:1.5rem; }
 
@@ -86,12 +207,18 @@
     height:auto;
     padding:10px;
   }
+  .filters-panel { padding:16px; }
 }
 
 @media (max-width:576px){
   .main-layout { margin-top:100px; }
   .map-container { height:40vh; }
   .offers-section { padding:15px; }
+  .filters-panel { padding:15px; gap:0.75rem; }
+  .filters-row { flex-direction:column; align-items:flex-start; gap:0.6rem; }
+  .filters-label { margin-right:0; }
+  .sort-buttons { width:100%; }
+  .toggle-tags-btn { margin-left:0; padding-left:0; }
   .user-header { flex-direction:column; gap:1rem; align-items:flex-start; }
   .user-header h2 { font-size:1.3rem; }
 }

--- a/oferty.html
+++ b/oferty.html
@@ -192,6 +192,7 @@ window.showConfirmModal = showConfirmModal;
     <div class="content-container">
       <!-- Panel filtrów ofert -->
       <div class="filters-panel" id="filtersPanel">
+        <h3 class="filters-title">Filtruj działki</h3>
         <div class="filters-row sort-row">
           <span class="filters-label">Sortuj:</span>
           <div class="sort-buttons">
@@ -205,12 +206,14 @@ window.showConfirmModal = showConfirmModal;
         </div>
         <div class="filters-row tags-row">
           <span class="filters-label">Tagi:</span>
-          <div class="tags-wrapper" id="tagFiltersList" data-expanded="false">
-            <span class="tag-placeholder">Ładuję tagi…</span>
+          <div class="tags-area">
+            <div class="tags-wrapper" id="tagFiltersList" data-expanded="false">
+              <span class="tag-placeholder">Ładuję tagi…</span>
+            </div>
+            <button type="button" class="toggle-tags-btn" id="toggleTagsBtn" aria-expanded="false" aria-controls="tagFiltersList" hidden>
+              Pokaż listę tagów
+            </button>
           </div>
-          <button type="button" class="toggle-tags-btn" id="toggleTagsBtn" aria-expanded="false" aria-controls="tagFiltersList" hidden>
-            Pokaż więcej
-          </button>
         </div>
       </div>
       <!-- Panel z ofertami publicznymi -->
@@ -385,13 +388,14 @@ window.showConfirmModal = showConfirmModal;
   let markerCluster;
   let allOffers = [];
   let availableTags = [];
+  let tagMetrics = new Map();
   const filterState = {
     sortKey: null,
     sortDir: 'asc',
     selectedTags: new Set()
   };
   let tagsExpanded = false;
-  const TAG_PREVIEW_COUNT = 6;
+  const TAG_PREVIEW_COUNT = 5;
 
   const tagFiltersList = document.getElementById('tagFiltersList');
   const toggleTagsBtn = document.getElementById('toggleTagsBtn');
@@ -577,6 +581,31 @@ window.showConfirmModal = showConfirmModal;
     });
   }
 
+  function createTagChip(tag) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'tag-chip';
+    if (filterState.selectedTags.has(tag)) {
+      btn.classList.add('is-active');
+    }
+    btn.setAttribute('aria-pressed', filterState.selectedTags.has(tag) ? 'true' : 'false');
+    btn.textContent = tag;
+    btn.dataset.tag = tag;
+    btn.addEventListener('click', () => toggleTagFilter(tag));
+    return btn;
+  }
+
+  function formatTagCount(count) {
+    if (!Number.isFinite(count)) return '';
+    if (count === 1) return '1 oferta';
+    const mod10 = count % 10;
+    const mod100 = count % 100;
+    if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+      return `${count} oferty`;
+    }
+    return `${count} ofert`;
+  }
+
   function renderTagFilters() {
     if (!tagFiltersList) return;
 
@@ -587,58 +616,113 @@ window.showConfirmModal = showConfirmModal;
     }
 
     tagFiltersList.innerHTML = '';
+    tagFiltersList.classList.remove('is-empty');
 
     if (!availableTags.length) {
       const placeholder = document.createElement('span');
       placeholder.className = 'tag-placeholder';
       placeholder.textContent = 'Brak tagów w ofertach';
       tagFiltersList.appendChild(placeholder);
-      tagFiltersList.dataset.expanded = 'true';
+      tagFiltersList.dataset.expanded = 'false';
       tagFiltersList.dataset.state = 'empty';
-      tagFiltersList.classList.remove('is-collapsed', 'is-expanded');
       tagFiltersList.classList.add('is-empty');
       if (toggleTagsBtn) {
         toggleTagsBtn.hidden = true;
         toggleTagsBtn.setAttribute('aria-expanded', 'false');
-        toggleTagsBtn.dataset.state = 'collapsed';
+        toggleTagsBtn.dataset.state = 'empty';
       }
       return;
     }
 
-    tagFiltersList.dataset.expanded = tagsExpanded ? 'true' : 'false';
-    tagFiltersList.dataset.state = tagsExpanded ? 'expanded' : 'collapsed';
-    tagFiltersList.classList.remove('is-empty');
-    tagFiltersList.classList.toggle('is-expanded', tagsExpanded);
-    tagFiltersList.classList.toggle('is-collapsed', !tagsExpanded);
+    const previewWrap = document.createElement('div');
+    previewWrap.className = 'tags-preview';
+    tagFiltersList.appendChild(previewWrap);
 
-    availableTags.forEach((tag, index) => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'tag-chip';
-      if (!tagsExpanded && index >= TAG_PREVIEW_COUNT) {
-        btn.classList.add('tag-chip--hidden');
+    const configureChip = (chip, tag) => {
+      const stats = tagMetrics.get(tag);
+      if (stats?.count) {
+        const countLabel = formatTagCount(stats.count);
+        chip.dataset.countLabel = countLabel;
+        chip.title = `${tag} • ${countLabel}`;
+      } else {
+        chip.removeAttribute('data-count-label');
+        chip.title = tag;
       }
-      if (filterState.selectedTags.has(tag)) {
-        btn.classList.add('is-active');
+    };
+
+    const selectedTags = Array.from(filterState.selectedTags).filter(tag => availableTags.includes(tag));
+    const previewLimit = Math.max(TAG_PREVIEW_COUNT, selectedTags.length);
+    const previewTags = [];
+    const dropdownTags = [];
+    const seenTags = new Set();
+
+    selectedTags.forEach(tag => {
+      if (!seenTags.has(tag)) {
+        previewTags.push(tag);
+        seenTags.add(tag);
       }
-      btn.textContent = tag;
-      btn.dataset.tag = tag;
-      btn.addEventListener('click', () => toggleTagFilter(tag));
-      tagFiltersList.appendChild(btn);
     });
 
+    availableTags.forEach(tag => {
+      if (seenTags.has(tag)) return;
+      if (previewTags.length < previewLimit) {
+        previewTags.push(tag);
+        seenTags.add(tag);
+      } else {
+        dropdownTags.push(tag);
+      }
+    });
+
+    previewTags.forEach(tag => {
+      const chip = createTagChip(tag);
+      configureChip(chip, tag);
+      chip.classList.add('tag-chip--preview');
+      previewWrap.appendChild(chip);
+    });
+
+    let dropdownWrap = null;
+    if (dropdownTags.length) {
+      dropdownWrap = document.createElement('div');
+      dropdownWrap.className = 'tags-dropdown';
+      dropdownWrap.hidden = !tagsExpanded;
+      tagFiltersList.appendChild(dropdownWrap);
+
+      dropdownTags.forEach(tag => {
+        const chip = createTagChip(tag);
+        configureChip(chip, tag);
+        chip.classList.add('tag-chip--list');
+        dropdownWrap.appendChild(chip);
+      });
+    }
+
+    const hiddenCount = dropdownTags.length;
+
+    if (!tagsExpanded && hiddenCount > 0) {
+      const summary = document.createElement('span');
+      summary.className = 'tags-summary';
+      summary.textContent = `+${hiddenCount} w liście`;
+      previewWrap.appendChild(summary);
+    }
+
+    if (!hiddenCount) {
+      tagsExpanded = false;
+    }
+
     if (toggleTagsBtn) {
-      const hasMore = availableTags.length > TAG_PREVIEW_COUNT;
-      toggleTagsBtn.hidden = !hasMore;
-      if (hasMore) {
-        toggleTagsBtn.textContent = tagsExpanded ? 'Pokaż mniej' : 'Pokaż więcej';
+      if (hiddenCount > 0) {
+        toggleTagsBtn.hidden = false;
+        toggleTagsBtn.textContent = tagsExpanded ? 'Ukryj listę tagów' : `Pokaż ${hiddenCount} więcej`;
         toggleTagsBtn.setAttribute('aria-expanded', tagsExpanded ? 'true' : 'false');
         toggleTagsBtn.dataset.state = tagsExpanded ? 'expanded' : 'collapsed';
       } else {
+        toggleTagsBtn.hidden = true;
         toggleTagsBtn.setAttribute('aria-expanded', 'false');
-        toggleTagsBtn.dataset.state = 'collapsed';
+        toggleTagsBtn.dataset.state = 'all-visible';
       }
     }
+
+    tagFiltersList.dataset.expanded = tagsExpanded ? 'true' : 'false';
+    tagFiltersList.dataset.state = hiddenCount > 0 ? (tagsExpanded ? 'expanded' : 'collapsed') : 'all-visible';
   }
 
   function toggleTagFilter(tag) {
@@ -705,22 +789,31 @@ window.showConfirmModal = showConfirmModal;
       markers = [];
       allOffers = [];
       availableTags = [];
-      const uniqueTags = new Set();
+      tagMetrics = new Map();
+      const tagStats = new Map();
+      let tagSequence = 0;
 
       snapshot.forEach(docSnap => {
         const data = docSnap.data();
         if (!data.plots || !data.plots.length) return;
 
         data.plots.forEach((plot, index) => {
-          if (plot.mock === false) return;
-
-          const isMockPlot = plot.mock === true;
-
           const lat = plot.lat;
           const lng = plot.lng;
           const geometry = plot.geometry_uldk;
           const offerId = docSnap.id;
-          const tags = isMockPlot ? normalizeTags(plot.tags) : [];
+          const tags = normalizeTags(plot.tags);
+          const uniquePlotTags = Array.from(new Set(tags));
+
+          if (uniquePlotTags.length) {
+            uniquePlotTags.forEach(tag => {
+              tagSequence += 1;
+              const current = tagStats.get(tag) || { count: 0, lastSeen: 0 };
+              current.count += 1;
+              current.lastSeen = tagSequence;
+              tagStats.set(tag, current);
+            });
+          }
 
           const marker = new google.maps.Marker({
             position: { lat, lng },
@@ -761,17 +854,25 @@ window.showConfirmModal = showConfirmModal;
             index,
             marker,
             polygon,
-            tags
+            tags: uniquePlotTags
           };
 
           allOffers.push(entry);
-          if (isMockPlot) {
-            tags.forEach(tag => uniqueTags.add(tag));
-          }
         });
       });
 
-      availableTags = Array.from(uniqueTags).sort((a, b) => a.localeCompare(b, 'pl', { sensitivity: 'base' }));
+      tagMetrics = new Map(tagStats);
+      availableTags = Array.from(tagStats.entries())
+        .sort((a, b) => {
+          if (b[1].lastSeen !== a[1].lastSeen) {
+            return b[1].lastSeen - a[1].lastSeen;
+          }
+          if (b[1].count !== a[1].count) {
+            return b[1].count - a[1].count;
+          }
+          return a[0].localeCompare(b[0], 'pl', { sensitivity: 'base' });
+        })
+        .map(([tag]) => tag);
       tagsExpanded = false;
       renderTagFilters();
       updateSortButtonsUI();

--- a/oferty.html
+++ b/oferty.html
@@ -190,6 +190,29 @@ window.showConfirmModal = showConfirmModal;
     
     <!-- Prawa strona - przewijana zawartość -->
     <div class="content-container">
+      <!-- Panel filtrów ofert -->
+      <div class="filters-panel" id="filtersPanel">
+        <div class="filters-row sort-row">
+          <span class="filters-label">Sortuj:</span>
+          <div class="sort-buttons">
+            <button type="button" class="sort-chip" data-sort-key="price" aria-pressed="false">
+              Cena
+            </button>
+            <button type="button" class="sort-chip" data-sort-key="area" aria-pressed="false">
+              Powierzchnia
+            </button>
+          </div>
+        </div>
+        <div class="filters-row tags-row">
+          <span class="filters-label">Tagi:</span>
+          <div class="tags-wrapper" id="tagFiltersList" data-expanded="false">
+            <span class="tag-placeholder">Ładuję tagi…</span>
+          </div>
+          <button type="button" class="toggle-tags-btn" id="toggleTagsBtn" aria-expanded="false" aria-controls="tagFiltersList" hidden>
+            Pokaż więcej
+          </button>
+        </div>
+      </div>
       <!-- Panel z ofertami publicznymi -->
       <div class="offers-section">
         <div class="section-title">
@@ -361,6 +384,57 @@ window.showConfirmModal = showConfirmModal;
   let markers = [];
   let markerCluster;
   let allOffers = [];
+  let availableTags = [];
+  const filterState = {
+    sortKey: null,
+    sortDir: 'asc',
+    selectedTags: new Set()
+  };
+  let tagsExpanded = false;
+  const TAG_PREVIEW_COUNT = 6;
+
+  const tagFiltersList = document.getElementById('tagFiltersList');
+  const toggleTagsBtn = document.getElementById('toggleTagsBtn');
+  const sortButtons = document.querySelectorAll('[data-sort-key]');
+
+  const clusterRenderer = {
+    render: ({ count, position }) => {
+      return new google.maps.Marker({
+        position,
+        label: { text: String(count), color: 'white', fontSize: '14px', fontWeight: 'bold' },
+        icon: {
+          path: google.maps.SymbolPath.CIRCLE,
+          scale: 20,
+          fillColor: 'red',
+          fillOpacity: 0.85,
+          strokeColor: 'red',
+          strokeWeight: 2
+        }
+      });
+    }
+  };
+
+  toggleTagsBtn?.addEventListener('click', () => {
+    tagsExpanded = !tagsExpanded;
+    renderTagFilters();
+  });
+
+  sortButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const key = btn.dataset.sortKey;
+      if (!key) return;
+      if (filterState.sortKey === key) {
+        filterState.sortDir = filterState.sortDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        filterState.sortKey = key;
+        filterState.sortDir = 'asc';
+      }
+      updateSortButtonsUI();
+      filterOffersByBounds();
+    });
+  });
+
+  updateSortButtonsUI();
 
   // jedno, globalne InfoWindow – NIGDY nie tworzymy wielu
   window.infoWin = null;
@@ -398,6 +472,183 @@ window.showConfirmModal = showConfirmModal;
     `;
   }
 
+  function normalizeTags(rawTags) {
+    if (!Array.isArray(rawTags)) return [];
+    return rawTags
+      .map(tag => (typeof tag === 'string' ? tag.trim() : String(tag || '').trim()))
+      .filter(tag => tag.length);
+  }
+
+  function offerMatchesSelectedTags(offer) {
+    if (!filterState.selectedTags.size) return true;
+    if (!offer.tags || !offer.tags.length) return false;
+    for (const tag of filterState.selectedTags) {
+      if (!offer.tags.includes(tag)) return false;
+    }
+    return true;
+  }
+
+  function getOffersMatchingFilters() {
+    return allOffers.filter(offerMatchesSelectedTags);
+  }
+
+  function sortOffers(offers) {
+    const { sortKey, sortDir } = filterState;
+    if (!sortKey) return offers.slice();
+
+    const dir = sortDir === 'desc' ? -1 : 1;
+    const valueFor = (offer) => {
+      if (sortKey === 'price') {
+        const value = Number(offer.plot?.price);
+        return Number.isFinite(value) ? value : null;
+      }
+      if (sortKey === 'area') {
+        const value = Number(offer.plot?.pow_dzialki_m2_uldk);
+        return Number.isFinite(value) ? value : null;
+      }
+      return null;
+    };
+
+    return offers.slice().sort((a, b) => {
+      const aVal = valueFor(a);
+      const bVal = valueFor(b);
+
+      if (aVal === null && bVal === null) return 0;
+      if (aVal === null) return 1;
+      if (bVal === null) return -1;
+      if (aVal === bVal) return 0;
+      return aVal > bVal ? dir : -dir;
+    });
+  }
+
+  function rebuildCluster(activeMarkers) {
+    if (!map) return;
+    if (markerCluster) {
+      markerCluster.clearMarkers();
+    }
+    markerCluster = new markerClusterer.MarkerClusterer({
+      map,
+      markers: activeMarkers,
+      renderer: clusterRenderer
+    });
+  }
+
+  function updateMarkersForOffers(filteredOffers) {
+    const activeKeys = new Set(filteredOffers.map(o => o.key));
+    const activeMarkers = [];
+    allOffers.forEach(offer => {
+      const isActive = activeKeys.has(offer.key);
+      if (offer.marker) {
+        offer.marker.setVisible(isActive);
+        offer.marker.setMap(isActive ? map : null);
+        if (isActive) {
+          activeMarkers.push(offer.marker);
+        }
+      }
+    });
+    rebuildCluster(activeMarkers);
+  }
+
+  function updatePolygonVisibility(filteredOffers = null) {
+    if (!map) return;
+    const show = map.getZoom() >= 8;
+    const source = filteredOffers ?? getOffersMatchingFilters();
+    const activeKeys = new Set(source.map(o => o.key));
+    allOffers.forEach(offer => {
+      if (!offer.polygon) return;
+      const shouldShow = show && activeKeys.has(offer.key);
+      offer.polygon.setMap(shouldShow ? map : null);
+      offer.polygon.setVisible(!!shouldShow);
+    });
+  }
+
+  function updateSortButtonsUI() {
+    sortButtons.forEach(btn => {
+      const key = btn.dataset.sortKey;
+      const isActive = filterState.sortKey === key;
+      btn.dataset.active = isActive ? 'true' : 'false';
+      if (isActive) {
+        btn.dataset.direction = filterState.sortDir;
+        btn.setAttribute('aria-pressed', 'true');
+      } else {
+        btn.removeAttribute('data-direction');
+        btn.setAttribute('aria-pressed', 'false');
+      }
+    });
+  }
+
+  function renderTagFilters() {
+    if (!tagFiltersList) return;
+
+    for (const tag of Array.from(filterState.selectedTags)) {
+      if (!availableTags.includes(tag)) {
+        filterState.selectedTags.delete(tag);
+      }
+    }
+
+    tagFiltersList.innerHTML = '';
+
+    if (!availableTags.length) {
+      const placeholder = document.createElement('span');
+      placeholder.className = 'tag-placeholder';
+      placeholder.textContent = 'Brak tagów w ofertach';
+      tagFiltersList.appendChild(placeholder);
+      tagFiltersList.dataset.expanded = 'true';
+      if (toggleTagsBtn) {
+        toggleTagsBtn.hidden = true;
+        toggleTagsBtn.setAttribute('aria-expanded', 'false');
+      }
+      return;
+    }
+
+    tagFiltersList.dataset.expanded = tagsExpanded ? 'true' : 'false';
+
+    availableTags.forEach((tag, index) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'tag-chip';
+      if (!tagsExpanded && index >= TAG_PREVIEW_COUNT) {
+        btn.classList.add('tag-chip--hidden');
+      }
+      if (filterState.selectedTags.has(tag)) {
+        btn.classList.add('is-active');
+      }
+      btn.textContent = tag;
+      btn.dataset.tag = tag;
+      btn.addEventListener('click', () => toggleTagFilter(tag));
+      tagFiltersList.appendChild(btn);
+    });
+
+    if (toggleTagsBtn) {
+      const hasMore = availableTags.length > TAG_PREVIEW_COUNT;
+      toggleTagsBtn.hidden = !hasMore;
+      if (hasMore) {
+        toggleTagsBtn.textContent = tagsExpanded ? 'Pokaż mniej' : 'Pokaż więcej';
+        toggleTagsBtn.setAttribute('aria-expanded', tagsExpanded ? 'true' : 'false');
+      } else {
+        toggleTagsBtn.setAttribute('aria-expanded', 'false');
+      }
+    }
+  }
+
+  function toggleTagFilter(tag) {
+    if (!tag) return;
+    if (filterState.selectedTags.has(tag)) {
+      filterState.selectedTags.delete(tag);
+    } else {
+      filterState.selectedTags.add(tag);
+    }
+    renderTagFilters();
+    applyFilters();
+  }
+
+  function applyFilters() {
+    const filtered = getOffersMatchingFilters();
+    updateMarkersForOffers(filtered);
+    filterOffersByBounds(filtered);
+    updatePolygonVisibility(filtered);
+  }
+
   function openInfo(marker, html) {
     if (!window.infoWin) window.infoWin = new google.maps.InfoWindow();
     window.infoWin.setContent(html);
@@ -414,6 +665,7 @@ window.showConfirmModal = showConfirmModal;
     });
 
     google.maps.event.addListener(map, "idle", () => filterOffersByBounds());
+    google.maps.event.addListener(map, "zoom_changed", () => updatePolygonVisibility());
     await loadOffers();
 
     // delikatny zoom kółkiem (opcjonalne)
@@ -432,38 +684,42 @@ window.showConfirmModal = showConfirmModal;
     try {
       const snapshot = await window.getDocs(window.collection(window.db, "propertyListings"));
       const listContainer = document.getElementById("offersList");
-      listContainer && (listContainer.innerHTML = "");
+      if (listContainer) listContainer.innerHTML = "";
 
-      // reset
-      allOffers = [];
-      markers.forEach(m => m.setMap(null));
+      allOffers.forEach(offer => {
+        if (offer.marker) offer.marker.setMap(null);
+        if (offer.polygon) offer.polygon.setMap(null);
+      });
+
+      markers.forEach(marker => marker.setMap(null));
       markers = [];
-      const plotPolygons = [];
+      allOffers = [];
+      availableTags = [];
+      const uniqueTags = new Set();
 
       snapshot.forEach(docSnap => {
         const data = docSnap.data();
         if (!data.plots || !data.plots.length) return;
 
         data.plots.forEach((plot, index) => {
-          // POKAZUJ wszystko oprócz jawnie ukrytych
           if (plot.mock === false) return;
 
-          const lat = plot.lat, lng = plot.lng;
+          const lat = plot.lat;
+          const lng = plot.lng;
           const geometry = plot.geometry_uldk;
           const offerId = docSnap.id;
+          const tags = normalizeTags(plot.tags);
 
-          // marker
           const marker = new google.maps.Marker({
-            position: { lat, lng }, map,
+            position: { lat, lng },
+            map,
             title: data.firstName || "Oferta",
             icon: { url: "https://maps.google.com/mapfiles/ms/icons/red-dot.png" }
           });
           markers.push(marker);
 
-          // klik w marker → InfoWindow + „Szczegóły”
           marker.addListener('click', () => openInfo(marker, infoHTML(plot, data, offerId, index)));
 
-          // polygon (pokazywany od określonego zoomu)
           let polygon = null;
           if (geometry) {
             const coords = parseGeometry(geometry);
@@ -475,77 +731,62 @@ window.showConfirmModal = showConfirmModal;
                 strokeWeight: 3,
                 fillColor: "#FF0000",
                 fillOpacity: 0.15,
-                map: null, visible: false
+                map: null,
+                visible: false
               });
               polygon.addListener('click', (evt) => {
-                // klik w obrys także otwiera JEDNO info okno
                 const fakeMarker = new google.maps.Marker({ position: evt.latLng, map: null });
                 openInfo(fakeMarker, infoHTML(plot, data, offerId, index));
               });
-              plotPolygons.push({ polygon, bounds: getPolygonBounds(coords), marker });
             }
           }
 
-          // zapisz wpis
-          allOffers.push({ id: offerId, data, plot, index, marker, polygon });
+          const entry = {
+            id: offerId,
+            key: `${offerId}__${index}`,
+            data,
+            plot,
+            index,
+            marker,
+            polygon,
+            tags
+          };
+
+          allOffers.push(entry);
+          tags.forEach(tag => uniqueTags.add(tag));
         });
       });
 
-      // klastrowanie
-      if (markerCluster) markerCluster.clearMarkers();
-      markerCluster = new markerClusterer.MarkerClusterer({
-        map, markers,
-        renderer: {
-          render: ({ count, position }) => {
-            return new google.maps.Marker({
-              position,
-              label: { text: String(count), color: "white", fontSize: "14px", fontWeight: "bold" },
-              icon: {
-                path: google.maps.SymbolPath.CIRCLE,
-                scale: 20,
-                fillColor: "red",
-                fillOpacity: 0.85,
-                strokeColor: "red",
-                strokeWeight: 2
-              }
-            });
-          }
-        }
-      });
-
-      // polygony od zoom >= 8
-      google.maps.event.addListener(map, 'zoom_changed', () => {
-        const show = map.getZoom() >= 8;
-        plotPolygons.forEach(p => {
-          if (!p.polygon) return;
-          p.polygon.setMap(show ? map : null);
-          p.polygon.setVisible(!!show);
-        });
-      });
-
-      filterOffersByBounds();
+      availableTags = Array.from(uniqueTags).sort((a, b) => a.localeCompare(b, 'pl', { sensitivity: 'base' }));
+      tagsExpanded = false;
+      renderTagFilters();
+      updateSortButtonsUI();
+      applyFilters();
     } catch (err) {
       console.error("Błąd pobierania ofert:", err);
     }
   }
 
-  // widoczność listy wg granic + SZCZEGÓŁY na środku
-  function filterOffersByBounds() {
+  // widoczność listy wg granic + sortowanie wyników
+  function filterOffersByBounds(filteredOffers = null) {
     if (!map || !allOffers.length) return;
     const bounds = map.getBounds();
     if (!bounds) return;
 
-    const visibleOffers = allOffers.filter(o => bounds.contains(o.marker.getPosition()));
+    const base = Array.isArray(filteredOffers) ? filteredOffers : getOffersMatchingFilters();
     const listContainer = document.getElementById("offersList");
     if (!listContainer) return;
 
+    const visibleOffers = base.filter(o => bounds.contains(o.marker.getPosition()));
+    const sortedOffers = sortOffers(visibleOffers);
+
     listContainer.innerHTML = "";
-    if (!visibleOffers.length) {
+    if (!sortedOffers.length) {
       listContainer.innerHTML = '<p class="no-offers">Brak ofert w widocznym obszarze</p>';
       return;
     }
 
-    visibleOffers.forEach(o => {
+    sortedOffers.forEach(o => {
       const card = document.createElement("div");
       card.className = "offer-card";
       const price = Number(o.plot.price || 0);
@@ -567,9 +808,7 @@ window.showConfirmModal = showConfirmModal;
         </div>
       `;
 
-      // klik w kartę (publiczną) → ogniskuj na mapie + InfoWindow
       card.addEventListener("click", (e) => {
-        // jeśli klik to „Szczegóły” – nie ogniskuj mapy
         if (e.target.closest('a')) return;
         map.panTo(o.marker.getPosition());
         map.setZoom(Math.max(16, map.getZoom()));
@@ -595,12 +834,6 @@ window.showConfirmModal = showConfirmModal;
       });
     } catch (e) { console.error("Błąd parsowania geometrii:", e, geometryString); }
     return coords;
-  }
-
-  function getPolygonBounds(coords) {
-    const bounds = new google.maps.LatLngBounds();
-    coords.forEach(c => bounds.extend(c));
-    return bounds;
   }
 
   // PUBLIC: focus z „Moje Oferty”

--- a/oferty.html
+++ b/oferty.html
@@ -594,14 +594,22 @@ window.showConfirmModal = showConfirmModal;
       placeholder.textContent = 'Brak tagów w ofertach';
       tagFiltersList.appendChild(placeholder);
       tagFiltersList.dataset.expanded = 'true';
+      tagFiltersList.dataset.state = 'empty';
+      tagFiltersList.classList.remove('is-collapsed', 'is-expanded');
+      tagFiltersList.classList.add('is-empty');
       if (toggleTagsBtn) {
         toggleTagsBtn.hidden = true;
         toggleTagsBtn.setAttribute('aria-expanded', 'false');
+        toggleTagsBtn.dataset.state = 'collapsed';
       }
       return;
     }
 
     tagFiltersList.dataset.expanded = tagsExpanded ? 'true' : 'false';
+    tagFiltersList.dataset.state = tagsExpanded ? 'expanded' : 'collapsed';
+    tagFiltersList.classList.remove('is-empty');
+    tagFiltersList.classList.toggle('is-expanded', tagsExpanded);
+    tagFiltersList.classList.toggle('is-collapsed', !tagsExpanded);
 
     availableTags.forEach((tag, index) => {
       const btn = document.createElement('button');
@@ -625,8 +633,10 @@ window.showConfirmModal = showConfirmModal;
       if (hasMore) {
         toggleTagsBtn.textContent = tagsExpanded ? 'Pokaż mniej' : 'Pokaż więcej';
         toggleTagsBtn.setAttribute('aria-expanded', tagsExpanded ? 'true' : 'false');
+        toggleTagsBtn.dataset.state = tagsExpanded ? 'expanded' : 'collapsed';
       } else {
         toggleTagsBtn.setAttribute('aria-expanded', 'false');
+        toggleTagsBtn.dataset.state = 'collapsed';
       }
     }
   }
@@ -704,11 +714,13 @@ window.showConfirmModal = showConfirmModal;
         data.plots.forEach((plot, index) => {
           if (plot.mock === false) return;
 
+          const isMockPlot = plot.mock === true;
+
           const lat = plot.lat;
           const lng = plot.lng;
           const geometry = plot.geometry_uldk;
           const offerId = docSnap.id;
-          const tags = normalizeTags(plot.tags);
+          const tags = isMockPlot ? normalizeTags(plot.tags) : [];
 
           const marker = new google.maps.Marker({
             position: { lat, lng },
@@ -753,7 +765,9 @@ window.showConfirmModal = showConfirmModal;
           };
 
           allOffers.push(entry);
-          tags.forEach(tag => uniqueTags.add(tag));
+          if (isMockPlot) {
+            tags.forEach(tag => uniqueTags.add(tag));
+          }
         });
       });
 


### PR DESCRIPTION
## Summary
- add a collapsible filter bar above the public offers list with sorting actions for price and area
- collect unique plot tags and expose multi-select chips that filter the offers list and map display
- refresh marker clustering, polygon visibility, and list ordering to respect the active filters and sorting state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9c9ac0ee8832badb290f09e31997e