### PR TITLE
Add clickable tag suggestions in edit form

### DIFF
--- a/assets/edit.css
+++ b/assets/edit.css
@@ -152,6 +152,46 @@
   align-self: center;
 }
 
+.tag-suggestions-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.tag-suggestions-title {
+  margin: 0;
+  font-size: .9rem;
+  color: var(--gray);
+}
+
+.tag-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+}
+
+.tag-chip--suggestion {
+  border: 1px solid rgba(30,111,186,.28);
+  background: #f8fafc;
+  color: var(--primary);
+  cursor: pointer;
+  font: inherit;
+  appearance: none;
+  transition: transform .15s ease, box-shadow .15s ease, background .15s ease, border-color .15s ease;
+}
+
+.tag-chip--suggestion:hover,
+.tag-chip--suggestion:focus-visible {
+  background: #e6f2ff;
+  border-color: rgba(30,111,186,.45);
+  box-shadow: 0 0 0 2px rgba(30,111,186,.16);
+  transform: translateY(-1px);
+}
+
+.tag-chip--suggestion:focus-visible {
+  outline: none;
+}
+
 .tag-chip.removable {
   background: #e6f2ff;
   color: var(--darker);

--- a/assets/property-common.js
+++ b/assets/property-common.js
@@ -5,7 +5,9 @@ import {
   getDoc,
   updateDoc,
   serverTimestamp,
-  setDoc
+  setDoc,
+  collection,
+  getDocs
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import {
   getAuth,
@@ -34,7 +36,7 @@ export function initFirebase() {
   return firebaseCache;
 }
 
-export { doc, getDoc, updateDoc, serverTimestamp, setDoc, onAuthStateChanged };
+export { doc, getDoc, updateDoc, serverTimestamp, setDoc, onAuthStateChanged, collection, getDocs };
 
 export function parseQueryParams() {
   const params = new URLSearchParams(window.location.search);

--- a/edit.html
+++ b/edit.html
@@ -251,12 +251,16 @@
           <h2 id="tagsTitle">Parametry dodatkowe</h2>
         </div>
         <div class="tags-card">
-          <p class="tag-hint">Tagiem będzie wyszukiwana Twoja działka. Przykłady: #Blisko-latagi, #Budowlana, #Inwestycyjna, #Rolna, #Blisko-las, #Dojazd-asfaltowy, #Dostępne-media, #Pod-OZE.</p>
+          <p class="tag-hint">Tagiem będzie wyszukiwana Twoja działka. Przykłady: #Budowlana, #Inwestycyjna, #Rolna, #Blisko-las, #Dojazd-asfaltowy, #Dostępne-media, #Pod-OZE.</p>
           <div class="tags-list" id="tagsList"></div>
           <p class="tags-empty" id="tagsEmpty" hidden>Brak dodatkowych parametrów.</p>
           <div class="tag-form">
             <input type="text" id="tagInput" placeholder="Dodaj własny znacznik, np. #Budowlana">
             <button class="btn btn-primary" type="button" id="addTagBtn"><i class="fas fa-plus"></i> Dodaj</button>
+          </div>
+          <div class="tag-suggestions-wrapper" id="tagSuggestionsWrapper" hidden>
+            <p class="tag-suggestions-title">Popularne tagi (kliknij, aby dodać):</p>
+            <div class="tag-suggestions" id="tagSuggestionsList"></div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- fetch unique tags from Firestore and expose them as clickable suggestions in the edit view
- render styled suggestion chips below the additional parameters form
- remove the outdated #Blisko-latagi example and export Firestore helpers for tag loading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e80185c4832b9af7e1cdd257dafb