### PR TITLE
Improve filters panel behavior and tag browsing

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -57,6 +57,17 @@
   -webkit-backdrop-filter:blur(14px);
 }
 
+@media (max-width:1366px){
+  .main-layout {
+    height:auto;
+    min-height:calc(100vh - 120px);
+  }
+  .content-container {
+    height:auto;
+    overflow-y:visible;
+  }
+}
+
 .filters-title {
   margin:0;
   font-size:1rem;
@@ -239,15 +250,6 @@
   background:linear-gradient(135deg,#f8fafc 0%,#f1f5f9 100%);
 }
 
-.tag-chip--list::after {
-  content:attr(data-count-label);
-  margin-left:auto;
-  padding-left:0.75rem;
-  font-size:0.72rem;
-  font-weight:600;
-  color:#1d4ed8;
-}
-
 .tag-chip:hover {
   border-color:#2b6cb0;
   color:#1a365d;
@@ -269,6 +271,33 @@
 .tag-chip.is-active::after {
   content:'\2713';
   font-size:0.75rem;
+}
+
+.tag-chip.is-compatible:not(.is-active) {
+  border-color:rgba(14,165,233,0.55);
+  background:rgba(125,211,252,0.2);
+  color:#0c4a6e;
+  box-shadow:0 0 0 1px rgba(14,165,233,0.18);
+}
+
+.tag-chip.is-compatible:not(.is-active):hover {
+  border-color:rgba(14,165,233,0.75);
+  background:rgba(56,189,248,0.22);
+  color:#0b5aa0;
+}
+
+.tag-chip__label {
+  white-space:nowrap;
+}
+
+.tag-chip__count {
+  font-size:0.72rem;
+  font-weight:600;
+  color:#475569;
+}
+
+.tag-chip--list .tag-chip__count {
+  color:#1d4ed8;
 }
 
 .toggle-tags-btn {

--- a/oferty.html
+++ b/oferty.html
@@ -205,6 +205,9 @@ window.showConfirmModal = showConfirmModal;
             <button type="button" class="sort-chip" data-sort-key="area" aria-pressed="false">
               Powierzchnia
             </button>
+            <button type="button" class="sort-chip" data-sort-key="tagPopularity" aria-pressed="false">
+              Popularność tagów
+            </button>
           </div>
         </div>
         <div class="filters-row tags-row">
@@ -214,7 +217,7 @@ window.showConfirmModal = showConfirmModal;
               <span class="tag-placeholder">Ładuję tagi…</span>
             </div>
             <button type="button" class="toggle-tags-btn" id="toggleTagsBtn" aria-expanded="false" aria-controls="tagFiltersList" hidden>
-              Pokaż listę tagów
+              Pokaż wszystkie tagi
             </button>
           </div>
         </div>
@@ -399,6 +402,8 @@ window.showConfirmModal = showConfirmModal;
   };
   let tagsExpanded = false;
   const TAG_PREVIEW_COUNT = 5;
+  let randomPreviewTags = [];
+  let randomPreviewSignature = '';
 
   const tagFiltersList = document.getElementById('tagFiltersList');
   const toggleTagsBtn = document.getElementById('toggleTagsBtn');
@@ -434,7 +439,7 @@ window.showConfirmModal = showConfirmModal;
         filterState.sortDir = filterState.sortDir === 'asc' ? 'desc' : 'asc';
       } else {
         filterState.sortKey = key;
-        filterState.sortDir = 'asc';
+        filterState.sortDir = key === 'tagPopularity' ? 'desc' : 'asc';
       }
       updateSortButtonsUI();
       filterOffersByBounds();
@@ -513,6 +518,12 @@ window.showConfirmModal = showConfirmModal;
         const value = Number(offer.plot?.pow_dzialki_m2_uldk);
         return Number.isFinite(value) ? value : null;
       }
+      if (sortKey === 'tagPopularity') {
+        const tags = Array.isArray(offer.tags) ? offer.tags : [];
+        if (!tags.length) return null;
+        const total = tags.reduce((acc, tag) => acc + (tagMetrics.get(tag)?.count || 0), 0);
+        return Number.isFinite(total) ? total : null;
+      }
       return null;
     };
 
@@ -588,11 +599,6 @@ window.showConfirmModal = showConfirmModal;
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'tag-chip';
-    if (filterState.selectedTags.has(tag)) {
-      btn.classList.add('is-active');
-    }
-    btn.setAttribute('aria-pressed', filterState.selectedTags.has(tag) ? 'true' : 'false');
-    btn.textContent = tag;
     btn.dataset.tag = tag;
     btn.addEventListener('click', () => toggleTagFilter(tag));
     return btn;
@@ -607,6 +613,98 @@ window.showConfirmModal = showConfirmModal;
       return `${count} oferty`;
     }
     return `${count} ofert`;
+  }
+
+  function pickRandomTags(source, count) {
+    const pool = Array.isArray(source) ? source.slice() : [];
+    for (let i = pool.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    return pool.slice(0, Math.min(count, pool.length));
+  }
+
+  function ensureRandomPreviewTags() {
+    const signature = availableTags.join('|');
+    if (signature !== randomPreviewSignature) {
+      randomPreviewSignature = signature;
+      randomPreviewTags = pickRandomTags(availableTags, TAG_PREVIEW_COUNT);
+    } else {
+      randomPreviewTags = randomPreviewTags.filter(tag => availableTags.includes(tag));
+      const missing = Math.min(TAG_PREVIEW_COUNT, availableTags.length) - randomPreviewTags.length;
+      if (missing > 0) {
+        const pool = availableTags.filter(tag => !randomPreviewTags.includes(tag));
+        randomPreviewTags = randomPreviewTags.concat(pickRandomTags(pool, missing));
+      }
+    }
+    return randomPreviewTags.slice(0, Math.min(TAG_PREVIEW_COUNT, availableTags.length));
+  }
+
+  function formatTagLabel(tag) {
+    if (typeof tag !== 'string') return '';
+    return tag.startsWith('#') ? tag : `#${tag}`;
+  }
+
+  function computeCompatibleTagCounts() {
+    if (!filterState.selectedTags.size) return new Map();
+
+    const selected = Array.from(filterState.selectedTags);
+    const counts = new Map();
+
+    allOffers.forEach(offer => {
+      if (!offer.tags || !offer.tags.length) return;
+      const offerTags = offer.tags;
+      const hasAllSelected = selected.every(tag => offerTags.includes(tag));
+      if (!hasAllSelected) return;
+
+      offerTags.forEach(tag => {
+        if (filterState.selectedTags.has(tag)) return;
+        counts.set(tag, (counts.get(tag) || 0) + 1);
+      });
+    });
+
+    return counts;
+  }
+
+  function configureTagChip(chip, tag, compatibilityCounts = null) {
+    const isActive = filterState.selectedTags.has(tag);
+    chip.classList.toggle('is-active', isActive);
+    chip.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    chip.dataset.tag = tag;
+    chip.innerHTML = '';
+
+    const labelSpan = document.createElement('span');
+    labelSpan.className = 'tag-chip__label';
+    const formattedLabel = formatTagLabel(tag);
+    labelSpan.textContent = formattedLabel;
+    chip.appendChild(labelSpan);
+
+    const stats = tagMetrics.get(tag);
+    if (stats?.count) {
+      const countSpan = document.createElement('span');
+      countSpan.className = 'tag-chip__count';
+      countSpan.textContent = `(${stats.count})`;
+      chip.appendChild(countSpan);
+    }
+
+    const compatibilityCount = compatibilityCounts?.get(tag) || 0;
+    const isCompatible = !isActive && compatibilityCount > 0;
+    chip.classList.toggle('is-compatible', isCompatible);
+    if (isCompatible) {
+      chip.dataset.compatible = 'true';
+    } else {
+      chip.removeAttribute('data-compatible');
+    }
+
+    let tooltip = formattedLabel;
+    if (stats?.count) {
+      tooltip += ` • ${formatTagCount(stats.count)}`;
+    }
+    if (isCompatible) {
+      const suffix = compatibilityCount === 1 ? 'ofercie' : 'ofertach';
+      tooltip += ` • razem z wybranymi w ${compatibilityCount} ${suffix}`;
+    }
+    chip.title = tooltip;
   }
 
   function renderTagFilters() {
@@ -637,84 +735,50 @@ window.showConfirmModal = showConfirmModal;
       return;
     }
 
-    const previewWrap = document.createElement('div');
-    previewWrap.className = 'tags-preview';
-    tagFiltersList.appendChild(previewWrap);
-
-    const configureChip = (chip, tag) => {
-      const stats = tagMetrics.get(tag);
-      if (stats?.count) {
-        const countLabel = formatTagCount(stats.count);
-        chip.dataset.countLabel = countLabel;
-        chip.title = `${tag} • ${countLabel}`;
-      } else {
-        chip.removeAttribute('data-count-label');
-        chip.title = tag;
-      }
-    };
-
     const selectedTags = Array.from(filterState.selectedTags).filter(tag => availableTags.includes(tag));
-    const previewLimit = Math.max(TAG_PREVIEW_COUNT, selectedTags.length);
-    const previewTags = [];
-    const dropdownTags = [];
-    const seenTags = new Set();
+    const compatibilityCounts = computeCompatibleTagCounts();
+
+    const visibleTags = tagsExpanded ? availableTags.slice() : ensureRandomPreviewTags().slice();
+    const visibleSet = new Set(visibleTags);
 
     selectedTags.forEach(tag => {
-      if (!seenTags.has(tag)) {
-        previewTags.push(tag);
-        seenTags.add(tag);
+      if (!visibleSet.has(tag)) {
+        visibleSet.add(tag);
+        visibleTags.push(tag);
       }
     });
 
-    availableTags.forEach(tag => {
-      if (seenTags.has(tag)) return;
-      if (previewTags.length < previewLimit) {
-        previewTags.push(tag);
-        seenTags.add(tag);
-      } else {
-        dropdownTags.push(tag);
-      }
-    });
-
-    previewTags.forEach(tag => {
-      const chip = createTagChip(tag);
-      configureChip(chip, tag);
-      chip.classList.add('tag-chip--preview');
-      previewWrap.appendChild(chip);
-    });
-
-    let dropdownWrap = null;
-    if (dropdownTags.length) {
-      dropdownWrap = document.createElement('div');
-      dropdownWrap.className = 'tags-dropdown';
-      dropdownWrap.hidden = !tagsExpanded;
-      tagFiltersList.appendChild(dropdownWrap);
-
-      dropdownTags.forEach(tag => {
-        const chip = createTagChip(tag);
-        configureChip(chip, tag);
-        chip.classList.add('tag-chip--list');
-        dropdownWrap.appendChild(chip);
-      });
+    const listWrap = document.createElement('div');
+    listWrap.className = 'tags-preview';
+    if (tagsExpanded) {
+      listWrap.dataset.mode = 'expanded';
     }
+    tagFiltersList.appendChild(listWrap);
 
-    const hiddenCount = dropdownTags.length;
+    visibleTags.forEach(tag => {
+      const chip = createTagChip(tag);
+      configureTagChip(chip, tag, compatibilityCounts);
+      listWrap.appendChild(chip);
+    });
+
+    const hiddenCount = Math.max(availableTags.length - visibleSet.size, 0);
 
     if (!tagsExpanded && hiddenCount > 0) {
       const summary = document.createElement('span');
       summary.className = 'tags-summary';
-      summary.textContent = `+${hiddenCount} w liście`;
-      previewWrap.appendChild(summary);
+      summary.textContent = `+${hiddenCount} więcej`;
+      listWrap.appendChild(summary);
     }
 
-    if (!hiddenCount) {
+    const shouldShowToggle = availableTags.length > TAG_PREVIEW_COUNT;
+    if (!shouldShowToggle) {
       tagsExpanded = false;
     }
 
     if (toggleTagsBtn) {
-      if (hiddenCount > 0) {
+      if (shouldShowToggle) {
         toggleTagsBtn.hidden = false;
-        toggleTagsBtn.textContent = tagsExpanded ? 'Ukryj listę tagów' : `Pokaż ${hiddenCount} więcej`;
+        toggleTagsBtn.textContent = tagsExpanded ? 'Ukryj tagi' : `Pokaż wszystkie tagi (${availableTags.length})`;
         toggleTagsBtn.setAttribute('aria-expanded', tagsExpanded ? 'true' : 'false');
         toggleTagsBtn.dataset.state = tagsExpanded ? 'expanded' : 'collapsed';
       } else {
@@ -725,7 +789,7 @@ window.showConfirmModal = showConfirmModal;
     }
 
     tagFiltersList.dataset.expanded = tagsExpanded ? 'true' : 'false';
-    tagFiltersList.dataset.state = hiddenCount > 0 ? (tagsExpanded ? 'expanded' : 'collapsed') : 'all-visible';
+    tagFiltersList.dataset.state = shouldShowToggle ? (tagsExpanded ? 'expanded' : 'collapsed') : 'all-visible';
   }
 
   function toggleTagFilter(tag) {
@@ -794,7 +858,6 @@ window.showConfirmModal = showConfirmModal;
       availableTags = [];
       tagMetrics = new Map();
       const tagStats = new Map();
-      let tagSequence = 0;
 
       snapshot.forEach(docSnap => {
         const data = docSnap.data();
@@ -810,11 +873,19 @@ window.showConfirmModal = showConfirmModal;
 
           if (uniquePlotTags.length) {
             uniquePlotTags.forEach(tag => {
-              tagSequence += 1;
-              const current = tagStats.get(tag) || { count: 0, lastSeen: 0 };
+              const current = tagStats.get(tag) || { count: 0, combos: new Map() };
               current.count += 1;
-              current.lastSeen = tagSequence;
+              if (!current.combos) current.combos = new Map();
               tagStats.set(tag, current);
+            });
+
+            uniquePlotTags.forEach(tag => {
+              const entry = tagStats.get(tag);
+              uniquePlotTags.forEach(otherTag => {
+                if (otherTag === tag) return;
+                const combos = entry.combos;
+                combos.set(otherTag, (combos.get(otherTag) || 0) + 1);
+              });
             });
           }
 
@@ -867,15 +938,14 @@ window.showConfirmModal = showConfirmModal;
       tagMetrics = new Map(tagStats);
       availableTags = Array.from(tagStats.entries())
         .sort((a, b) => {
-          if (b[1].lastSeen !== a[1].lastSeen) {
-            return b[1].lastSeen - a[1].lastSeen;
-          }
           if (b[1].count !== a[1].count) {
             return b[1].count - a[1].count;
           }
           return a[0].localeCompare(b[0], 'pl', { sensitivity: 'base' });
         })
         .map(([tag]) => tag);
+      randomPreviewSignature = '';
+      randomPreviewTags = [];
       tagsExpanded = false;
       renderTagFilters();
       updateSortButtonsUI();


### PR DESCRIPTION
## Summary
- stop the filters column from scrolling independently on laptops by letting the page handle the scroll
- refresh the tag preview to show five random tags with offer counts, provide a one-click show-all button, normalize labels, and highlight tags that co-occur with the selected filters
- add a tag popularity sort option that leverages the tag statistics

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca73ebc15c832b9a73bc4d03bb61bb