### PR TITLE
Add mobile account links redirecting to account sections

### DIFF
--- a/Kontakt.html
+++ b/Kontakt.html
@@ -92,6 +92,7 @@
       <a href="oferty.html" class="nav-link">Oferty</a>
       <a href="dodaj.html" class="nav-link">Dodaj</a>
       <a href="Kontakt.html" class="nav-link active">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
       <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
     </nav>
   </header>

--- a/RODO.html
+++ b/RODO.html
@@ -92,6 +92,7 @@
       <a href="oferty.html" class="nav-link">Oferty</a>
       <a href="dodaj.html" class="nav-link">Dodaj</a>
       <a href="Kontakt.html" class="nav-link">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
       <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
     </nav>
   </header>

--- a/assets/auth-basic.js
+++ b/assets/auth-basic.js
@@ -227,7 +227,7 @@ async function signInWithGoogleSmart() {
 });
 
 accountBtn?.addEventListener("click", () => {
-  window.location.href = "oferty.html#userDashboard";
+  window.location.href = "index.html#userDashboard";
 });
 
 logoutBtn?.addEventListener("click", async () => {
@@ -248,7 +248,7 @@ function renderMobileAuth(user) {
       <div class="nav-link" style="font-weight:600;">
         <i class="fas fa-user"></i> ${label}
       </div>
-      <a href="oferty.html#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
+      <a href="index.html#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
       <button class="btn btn-secondary" id="mobileLogoutBtn" style="width:100%;">
         <i class="fas fa-sign-out-alt"></i> Wyloguj się
       </button>
@@ -289,9 +289,11 @@ function renderMobileAuth(user) {
     mobileAuthC.style.display = "none";
   });
 
-  mobileAccountLink?.addEventListener("click", () => {
+  mobileAccountLink?.addEventListener("click", (event) => {
+    event.preventDefault();
     navMenu?.classList.remove("active");
     mobileAuthC.style.display = "none";
+    window.location.href = "index.html#userDashboard";
   });
 
   mobileAuthC.style.display = navMenu?.classList.contains("active") ? "flex" : "none";

--- a/details.html
+++ b/details.html
@@ -94,6 +94,7 @@
       <a href="oferty.html" class="nav-link">Oferty</a>
       <a href="dodaj.html" class="nav-link">Dodaj</a>
       <a href="Kontakt.html" class="nav-link">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
       <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
     </nav>
   </header>

--- a/dodaj.html
+++ b/dodaj.html
@@ -129,15 +129,16 @@
         <i class="fas fa-bars"></i>
       </button>
 
-      <nav class="nav-menu">
-        <a href="index.html" class="nav-link">Strona główna</a>
-        <a href="oferty.html" class="nav-link">Oferty</a>
-        <a href="dodaj.html" class="nav-link active">Dodaj</a>
-        <a href="Kontakt.html" class="nav-link">Kontakt</a>
+    <nav class="nav-menu">
+      <a href="index.html" class="nav-link">Strona główna</a>
+      <a href="oferty.html" class="nav-link">Oferty</a>
+      <a href="dodaj.html" class="nav-link active">Dodaj</a>
+      <a href="Kontakt.html" class="nav-link">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
 
-        <!-- Miejsce na elementy auth w menu mobilnym -->
-        <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
-      </nav>
+      <!-- Miejsce na elementy auth w menu mobilnym -->
+      <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
+    </nav>
     </header>
     <!-- Toasts -->
     <div class="toast-container" id="toastContainer" aria-live="polite" aria-atomic="true"></div>
@@ -273,10 +274,17 @@
             <div class="nav-link" style="font-weight:600;">
               <i class="fas fa-user"></i> ${label}
             </div>
+            <a href="index.html#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
             <button class="btn btn-secondary" id="mobileLogoutBtn" style="width:100%;">
               <i class="fas fa-sign-out-alt"></i> Wyloguj się
             </button>
           `;
+          document.getElementById('mobileAccountLink')?.addEventListener('click', (event) => {
+            event.preventDefault();
+            navMenu?.classList.remove('active');
+            mobileAuthC.style.display = 'none';
+            window.location.href = 'index.html#userDashboard';
+          });
           document.getElementById('mobileLogoutBtn')?.addEventListener('click', async () => {
             try { await signOut(auth); } catch(e){ console.error(e); }
             navMenu?.classList.remove('active');
@@ -328,6 +336,10 @@
       closeBtns.forEach(b => b.addEventListener('click', () => closeModal(b.closest('.modal'))));
       window.addEventListener('click', (e) => { if (e.target.classList?.contains('modal')) closeModal(e.target); });
       logoutBtn?.addEventListener('click', async () => { try { await signOut(auth); } catch(e){ console.error(e); } });
+      accountBtn?.addEventListener('click', (event) => {
+        event.preventDefault?.();
+        window.location.href = 'index.html#userDashboard';
+      });
 
       loginForm?.addEventListener('submit', async (e) => {
         e.preventDefault();

--- a/edit.html
+++ b/edit.html
@@ -95,6 +95,7 @@
       <a href="oferty.html" class="nav-link">Oferty</a>
       <a href="dodaj.html" class="nav-link">Dodaj</a>
       <a href="Kontakt.html" class="nav-link">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
       <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
       <a href="oferty.html" class="nav-link">Oferty</a>
       <a href="dodaj.html" class="nav-link">Dodaj</a>
       <a href="Kontakt.html" class="nav-link">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
 
       <!-- Miejsce na elementy auth w menu mobilnym -->
       <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
@@ -707,7 +708,7 @@ window.showConfirmModal = showConfirmModal;
           <div class="nav-link" style="font-weight:600;">
             <i class="fas fa-user"></i> ${label}
           </div>
-          <a href="#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
+          <a href="index.html#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
           <button class="btn btn-secondary" id="mobileLogoutBtn" style="width:100%;">
             <i class="fas fa-sign-out-alt"></i> Wyloguj się
           </button>
@@ -746,9 +747,9 @@ window.showConfirmModal = showConfirmModal;
 
       mobileAccountLink && mobileAccountLink.addEventListener('click', (e) => {
         e.preventDefault();
-        document.getElementById('userDashboard')?.scrollIntoView({behavior:'smooth'});
         navMenu?.classList.remove('active');
         mobileAuthC.style.display = 'none';
+        window.location.href = 'index.html#userDashboard';
       });
 
       // dopasuj widoczność do stanu menu
@@ -791,7 +792,10 @@ window.showConfirmModal = showConfirmModal;
     switchToLog  && switchToLog.addEventListener('click', (e) => { e.preventDefault(); closeModal(registerModal); openModal(loginModal); });
     closeBtns?.forEach(b => b.addEventListener('click', () => closeModal(b.closest('.modal'))));
     window.addEventListener('click', (e) => { if (e.target.classList?.contains('modal')) closeModal(e.target); });
-    accountBtn && accountBtn.addEventListener('click', () => document.getElementById('userDashboard')?.scrollIntoView({behavior:'smooth'}));
+    accountBtn && accountBtn.addEventListener('click', (e) => {
+      e.preventDefault?.();
+      window.location.href = 'index.html#userDashboard';
+    });
 
     // Komunikaty błędów
     const niceAuthError = (err) => {

--- a/oferty.html
+++ b/oferty.html
@@ -94,6 +94,7 @@
       <a href="oferty.html" class="nav-link active">Oferty</a>
       <a href="dodaj.html" class="nav-link">Dodaj</a>
       <a href="Kontakt.html" class="nav-link">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
 
       <!-- Miejsce na elementy auth w menu mobilnym -->
       <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
@@ -1167,7 +1168,7 @@ window.showConfirmModal = showConfirmModal;
         <div class="nav-link" style="font-weight:600;">
           <i class="fas fa-user"></i> ${label}
         </div>
-        <a href="#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
+        <a href="index.html#userDashboard" class="nav-link" id="mobileAccountLink">Moje konto</a>
         <button class="btn btn-secondary" id="mobileLogoutBtn" style="width:100%;">
           <i class="fas fa-sign-out-alt"></i> Wyloguj się
         </button>
@@ -1206,9 +1207,9 @@ window.showConfirmModal = showConfirmModal;
 
     mobileAccountLink && mobileAccountLink.addEventListener('click', (e) => {
       e.preventDefault();
-      document.getElementById('userDashboard')?.scrollIntoView({behavior:'smooth'});
       navMenu?.classList.remove('active');
       mobileAuthC.style.display = 'none';
+      window.location.href = 'index.html#userDashboard';
     });
 
     mobileAuthC.style.display = navMenu?.classList.contains('active') ? 'flex' : 'none';
@@ -1232,8 +1233,9 @@ window.showConfirmModal = showConfirmModal;
     if (e.target.classList?.contains('modal')) closeModal(e.target);
   });
 
-  accountBtn && accountBtn.addEventListener('click', () => {
-    document.getElementById('userDashboard')?.scrollIntoView({ behavior: 'smooth' });
+  accountBtn && accountBtn.addEventListener('click', (event) => {
+    event.preventDefault?.();
+    window.location.href = 'index.html#userDashboard';
   });
 
   // --- ŁADNE BŁĘDY ---

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -92,6 +92,7 @@
       <a href="oferty.html" class="nav-link">Oferty</a>
       <a href="dodaj.html" class="nav-link">Dodaj</a>
       <a href="Kontakt.html" class="nav-link">Kontakt</a>
+      <a href="index.html#userMenu" class="nav-link">Moje konto</a>
       <div class="mobile-auth" id="mobileAuth" style="display:none;"></div>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- add a "Moje konto" entry to the mobile navigation on every page that jumps to the account menu on the home screen
- redirect account button and mobile-auth shortcuts to the "Moje oferty" section on the home page for consistent behaviour

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb16e025d4832b98ac382beb8f91bf