### PR TITLE
Adjust mobile logo width

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -96,7 +96,10 @@ header{
     align-items:center;
     gap:.5rem;
   }
-  .logo img{height:60px;}
+  .logo img{
+    width:200px;
+    height:auto;
+  }
   .logo span{white-space:nowrap;}
 }
 

--- a/assets/main.css
+++ b/assets/main.css
@@ -268,7 +268,10 @@ footer{background:var(--darker);color:#fff;padding:2.5rem 0 1.25rem}
     text-align:left;          /* dla tekstu */
     gap:.25rem;
   }
-  .footer-logo img{height:60px;}
+  .footer-logo img{
+    width:200px;
+    height:auto;
+  }
 
   /* menu startuje spod headera (ustawione przez zmienne) */
   .hero{padding:calc(var(--header-height) + 12px) 0 2rem;}


### PR DESCRIPTION
## Summary
- set the header logo image to 200px wide on mobile viewports
- ensure the footer logo uses the same 200px width on phones

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb1cd4b210832b96518565642cc49f