### PR TITLE
Reintroduce analytics snippets and update RODO notice

### DIFF
--- a/Kontakt.html
+++ b/Kontakt.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kontakt — Grunteo</title>
@@ -37,17 +29,27 @@
   <link rel="stylesheet" href="assets/main.css" />
   <link rel="stylesheet" href="assets/header.css" />
   <link rel="stylesheet" href="assets/contact.css" />
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 <body class="contact-page">
   <div class="top-navbar">
@@ -461,5 +463,32 @@
       });
     });
   </script>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
 </body>
 </html>

--- a/RODO.html
+++ b/RODO.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Informacja o przetwarzaniu danych osobowych (RODO) — Grunteo</title>
@@ -37,17 +29,27 @@
   <link rel="stylesheet" href="assets/main.css" />
   <link rel="stylesheet" href="assets/header.css" />
   <link rel="stylesheet" href="assets/legal.css" />
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 <body class="legal-page">
   <div class="top-navbar">
@@ -224,6 +226,27 @@
             <li>w oparciu o uzasadniony interes – do momentu jego realizacji lub skutecznego sprzeciwu;</li>
             <li>w przypadku zgody – do momentu jej wycofania.</li>
           </ul>
+          <div class="legal-note">
+            Dane dotyczące oferowanych działek (w tym treść ogłoszeń, historia zmian i metadane) przechowujemy w bazie danych
+            permanentnie, nawet jeżeli użytkownik samodzielnie usunie ogłoszenie z panelu. Informacje te służą celom dowodowym,
+            bezpieczeństwu oraz zachowaniu ciągłości świadczonych usług.
+          </div>
+        </section>
+
+        <section class="legal-section" id="tracking-tools">
+          <h2>Narzędzia monitoringu na stronie</h2>
+          <p class="legal-paragraph">
+            W kodzie serwisu znajdują się fragmenty oznaczone komentarzami
+            <code>&lt;!-- Google tag (gtag.js) --&gt;</code> oraz <code>&lt;!-- Hotjar Tracking Code for grunteo.pl --&gt;</code>. Aktywujemy je
+            dopiero po wyrażeniu zgody na pliki cookies analityczne, aby prowadzić statystyki odwiedzin i badania doświadczeń
+            użytkowników.
+          </p>
+          <p class="legal-paragraph">
+            Google Analytics oraz Hotjar mogą otrzymywać informacje o sposobie korzystania z serwisu (np. identyfikatory urządzeń,
+            przybliżone dane lokalizacyjne, zdarzenia w aplikacji). Zakres przekazywanych danych opisany jest szczegółowo w polityce
+            prywatności tych dostawców. W każdej chwili możesz zmienić wybór w banerze cookies lub poprzez pływający przycisk
+            ustawień.
+          </p>
         </section>
 
         <section class="legal-section" id="transfer">
@@ -365,5 +388,31 @@
       });
     });
   </script>
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
 </body>
 </html>

--- a/assets/cookies.js
+++ b/assets/cookies.js
@@ -1,0 +1,191 @@
+(function(){
+  const CONSENT_KEY = 'grunteo-cookie-consent';
+  const GA_ID = 'G-VH07LRZ8GK';
+  const CONSENT_STATES = {
+    ACCEPTED: 'accepted',
+    NECESSARY: 'necessary'
+  };
+
+  const storage = {
+    get(){
+      try{
+        return localStorage.getItem(CONSENT_KEY);
+      }catch(err){
+        return null;
+      }
+    },
+    set(value){
+      try{
+        localStorage.setItem(CONSENT_KEY, value);
+      }catch(err){
+        /* ignore */
+      }
+    }
+  };
+
+  const ensureConsentDefaults = () => {
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+    window['ga-disable-' + GA_ID] = true;
+    window.gtag('consent', 'default', {
+      ad_storage: 'denied',
+      analytics_storage: 'denied',
+      functionality_storage: 'granted',
+      security_storage: 'granted'
+    });
+  };
+
+  const loadScript = (src, attrs = {}) => {
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = src;
+      Object.entries(attrs).forEach(([key, value]) => {
+        if (value === true){
+          script.setAttribute(key, '');
+        }else if (value !== false && value != null){
+          script.setAttribute(key, value);
+        }
+      });
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  };
+
+  const activateDeferredScripts = async () => {
+    const placeholders = Array.from(document.querySelectorAll('script[data-cookie-consent="analytics"]'));
+    if (!placeholders.length) return;
+
+    const external = placeholders.filter(node => node.dataset.cookieSrc);
+    const inline = placeholders.filter(node => !node.dataset.cookieSrc);
+
+    await Promise.all(external.map(node => {
+      if (node.dataset.cookieLoaded === 'true') return Promise.resolve();
+      node.dataset.cookieLoaded = 'true';
+      const asyncAttr = node.dataset.cookieAsync !== 'false';
+      return loadScript(node.dataset.cookieSrc, { async: asyncAttr }).catch(() => undefined);
+    }));
+
+    inline.forEach(node => {
+      if (node.dataset.cookieLoaded === 'true') return;
+      node.dataset.cookieLoaded = 'true';
+      const script = document.createElement('script');
+      script.type = 'text/javascript';
+      if (node.dataset.cookieId){
+        script.id = node.dataset.cookieId;
+      }
+      script.text = node.textContent;
+      document.head.appendChild(script);
+    });
+  };
+
+  const initAnalytics = () => {
+    if (window.__grunteoAnalyticsLoaded) return;
+    window.__grunteoAnalyticsLoaded = true;
+
+    activateDeferredScripts();
+  };
+
+  const applyConsentState = (state) => {
+    const banner = document.querySelector('[data-cookie-banner]');
+    const manageTrigger = document.querySelector('[data-cookie-preferences]');
+
+    if (manageTrigger){
+      if (state){
+        manageTrigger.hidden = false;
+      }else{
+        manageTrigger.hidden = true;
+      }
+    }
+
+    if (state === CONSENT_STATES.ACCEPTED){
+      window['ga-disable-' + GA_ID] = false;
+      window.gtag('consent', 'update', {
+        ad_storage: 'granted',
+        analytics_storage: 'granted'
+      });
+      initAnalytics();
+      if (manageTrigger){
+        manageTrigger.setAttribute('aria-expanded', 'false');
+      }
+    }else{
+      window['ga-disable-' + GA_ID] = true;
+      window.gtag('consent', 'update', {
+        ad_storage: 'denied',
+        analytics_storage: 'denied'
+      });
+      if (typeof window.hj === 'function'){
+        window.hj('event', 'consent_withdrawn');
+      }
+      if (manageTrigger){
+        manageTrigger.setAttribute('aria-expanded', 'false');
+      }
+    }
+  };
+
+  const hideBanner = () => {
+    const banner = document.querySelector('[data-cookie-banner]');
+    if (!banner) return;
+    banner.classList.add('cookie-banner--hidden');
+    banner.setAttribute('aria-hidden', 'true');
+    banner.setAttribute('aria-modal', 'false');
+    const manageTrigger = document.querySelector('[data-cookie-preferences]');
+    manageTrigger?.setAttribute('aria-expanded', 'false');
+  };
+
+  const showBanner = () => {
+    const banner = document.querySelector('[data-cookie-banner]');
+    if (!banner) return;
+    banner.classList.remove('cookie-banner--hidden');
+    banner.setAttribute('aria-hidden', 'false');
+    banner.setAttribute('aria-modal', 'true');
+    banner.focus({ preventScroll: true });
+    const manageTrigger = document.querySelector('[data-cookie-preferences]');
+    manageTrigger?.setAttribute('aria-expanded', 'true');
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    ensureConsentDefaults();
+
+    const banner = document.querySelector('[data-cookie-banner]');
+    if (!banner) return;
+
+    const acceptBtn = banner.querySelector('[data-cookie-accept]');
+    const declineBtn = banner.querySelector('[data-cookie-decline]');
+    const manageTrigger = document.querySelector('[data-cookie-preferences]');
+
+    const storedState = storage.get();
+    if (storedState){
+      hideBanner();
+      applyConsentState(storedState);
+    }else{
+      banner.setAttribute('aria-hidden', 'false');
+      banner.setAttribute('aria-modal', 'true');
+    }
+
+    acceptBtn?.addEventListener('click', () => {
+      storage.set(CONSENT_STATES.ACCEPTED);
+      hideBanner();
+      applyConsentState(CONSENT_STATES.ACCEPTED);
+    });
+
+    declineBtn?.addEventListener('click', () => {
+      storage.set(CONSENT_STATES.NECESSARY);
+      hideBanner();
+      applyConsentState(CONSENT_STATES.NECESSARY);
+    });
+
+    manageTrigger?.addEventListener('click', () => {
+      showBanner();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !banner.classList.contains('cookie-banner--hidden')){
+        hideBanner();
+        if (manageTrigger){
+          manageTrigger.focus();
+        }
+      }
+    });
+  });
+})();

--- a/assets/main.css
+++ b/assets/main.css
@@ -198,6 +198,134 @@ body.home-page .offer-card .offer-actions{
 .info-content h2{margin-bottom:1.25rem;}
 .info-list{list-style:none;margin-bottom:1.75rem;}
 .info-list li{margin-bottom:.625rem;display:flex;align-items:center;gap:.625rem;font-size:.95rem;}
+
+/* ====== Cookie banner ====== */
+.cookie-banner{
+  position:fixed;
+  left:50%;
+  bottom:1.5rem;
+  transform:translateX(-50%);
+  width:min(720px,calc(100% - 2.5rem));
+  display:flex;
+  gap:1.25rem;
+  align-items:flex-start;
+  padding:1.35rem 1.6rem;
+  background:#fff;
+  border:1px solid #dbe8f7;
+  border-radius:18px;
+  box-shadow:var(--shadow-lg);
+  z-index:1400;
+  transition:var(--transition);
+}
+.cookie-banner--hidden{
+  opacity:0;
+  visibility:hidden;
+  pointer-events:none;
+  transform:translate(-50%,20px);
+}
+.cookie-banner__icon{
+  width:52px;
+  height:52px;
+  border-radius:14px;
+  background:var(--gradient-primary);
+  color:#fff;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:1.4rem;
+  box-shadow:var(--shadow-md);
+  flex-shrink:0;
+}
+.cookie-banner__content{flex:1;}
+.cookie-banner__title{
+  margin:0 0 .4rem;
+  font-size:1.15rem;
+  color:var(--darker);
+}
+.cookie-banner__text{
+  margin:0 0 1.1rem;
+  color:#4a5d75;
+  font-size:.92rem;
+}
+.cookie-banner__text a{
+  color:var(--primary-dark);
+  font-weight:600;
+}
+.cookie-banner__actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:.6rem;
+  align-items:center;
+}
+.cookie-banner__btn{flex:0 0 auto;}
+.cookie-banner__link{
+  display:inline-flex;
+  align-items:center;
+  gap:.45rem;
+  font-size:.85rem;
+  font-weight:600;
+  color:var(--dark);
+}
+.cookie-banner__link i{color:var(--primary);}
+.cookie-preferences{
+  position:fixed;
+  right:1.5rem;
+  bottom:1.5rem;
+  display:inline-flex;
+  align-items:center;
+  gap:.5rem;
+  padding:.55rem 1rem;
+  border-radius:999px;
+  border:1px solid #dbe8f7;
+  background:#fff;
+  color:var(--dark);
+  font-weight:600;
+  font-size:.85rem;
+  box-shadow:var(--shadow-md);
+  cursor:pointer;
+  transition:var(--transition);
+  z-index:1300;
+}
+.cookie-preferences i{color:var(--primary);}
+.cookie-preferences:hover{
+  transform:translateY(-2px);
+  box-shadow:var(--shadow-lg);
+}
+.cookie-banner:not(.cookie-banner--hidden)~.cookie-preferences{
+  opacity:0;
+  visibility:hidden;
+  pointer-events:none;
+}
+.cookie-preferences[hidden]{display:none;}
+
+@media (max-width:768px){
+  .cookie-banner{
+    flex-direction:column;
+    align-items:stretch;
+    text-align:left;
+    padding:1.2rem 1.35rem;
+  }
+  .cookie-banner__icon{margin-bottom:.6rem;}
+  .cookie-banner__actions{flex-direction:column;align-items:stretch;}
+  .cookie-banner__btn{width:100%;}
+  .cookie-banner__link{justify-content:center;}
+  .cookie-preferences{
+    right:1rem;
+    bottom:1rem;
+  }
+}
+
+@media (max-width:520px){
+  .cookie-banner{
+    width:calc(100% - 1.6rem);
+    left:50%;
+    transform:translate(-50%,0);
+    bottom:.9rem;
+  }
+  .cookie-banner--hidden{
+    transform:translate(-50%,15px);
+  }
+}
 .info-list li::before{
   content:'✓';display:flex;align-items:center;justify-content:center;width:20px;height:20px;
   background:var(--success);color:#fff;border-radius:50%;font-size:.7rem;

--- a/details.html
+++ b/details.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grunteo - Szczegóły działki</title>
@@ -38,17 +30,27 @@
   <link rel="stylesheet" href="assets/header.css" />
   <link rel="stylesheet" href="assets/details.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.8.0/proj4.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 <body class="property-page" style="padding-top: calc(var(--topbar-height) + var(--header-height));">
   <div class="top-navbar">
@@ -412,5 +414,31 @@
   </footer>
 
   <script type="module" src="assets/details.js"></script>
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
 </body>
 </html>

--- a/dodaj.html
+++ b/dodaj.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grunteo - Dodaj darmowe ogłoszenie</title>
@@ -75,17 +67,27 @@
   <link rel="stylesheet" href="assets/header.css">
   <link rel="stylesheet" href="assets/dodaj.css">
   <link rel="stylesheet" href="assets/form.css">
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 
   <body style="padding-top: calc(var(--topbar-height) + var(--header-height));" onload="loadGoogleMaps()">
@@ -1141,5 +1143,32 @@
 	
 	
   </script>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
 </body>
 </html>

--- a/edit.html
+++ b/edit.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grunteo - Edycja działki</title>
@@ -39,17 +31,27 @@
   <link rel="stylesheet" href="assets/details.css" />
   <link rel="stylesheet" href="assets/edit.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.8.0/proj4.js"></script>
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 <body class="property-page" style="padding-top: calc(var(--topbar-height) + var(--header-height));">
   <div class="top-navbar">
@@ -410,5 +412,31 @@
   </footer>
 
   <script type="module" src="assets/edit.js"></script>
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grunteo - Dodaj darmowe ogłoszenie</title>
@@ -38,17 +30,27 @@
   <link rel="stylesheet" href="assets/main.css" />
   <link rel="stylesheet" href="assets/header.css" />
   <link rel="stylesheet" href="assets/oferty.css" />
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 <body class="home-page">
 
@@ -1150,5 +1152,32 @@ window.showConfirmModal = showConfirmModal;
 
     window.deletePlot = deletePlot;
     </script>
+
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
   </body>
   </html>

--- a/oferty.html
+++ b/oferty.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grunteo - Dodaj darmowe ogłoszenie</title>
@@ -38,17 +30,27 @@
   <link rel="stylesheet" href="assets/main.css" />
   <link rel="stylesheet" href="assets/header.css" />
   <link rel="stylesheet" href="assets/oferty.css" />
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 <body>
   <div class="top-navbar">
@@ -1611,6 +1613,32 @@ window.deletePlot = deletePlot;
   });
 </script>
 
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
 
 </body>
 </html>

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -271,7 +271,7 @@
           <h3>Kategorie cookies, które możemy wykorzystywać</h3>
           <ul class="legal-list">
             <li><strong>Niezbędne.</strong> Umożliwiają podstawowe działanie serwisu i zapis ustawień. Bez nich niektóre funkcje nie będą działać poprawnie.</li>
-            <li><strong>Funkcjonalne/analityczne (zewnętrzne).</strong> Pomagają zrozumieć, jak korzystasz z serwisu, abyśmy mogli go ulepszać. Dostawcami mogą być m.in. Google, Salesforce, Hotjar.</li>
+            <li><strong>Funkcjonalne/analityczne (zewnętrzne).</strong> Pomagają zrozumieć, jak korzystasz z serwisu, abyśmy mogli go ulepszać. Dostawcami mogą być m.in. Google, Firebase, Hotjar.</li>
             <li><strong>Reklamowe i pomiarowe.</strong> Ułatwiają personalizację treści i analizę skuteczności kampanii. Mogą je dostarczać m.in. Google, Facebook, LinkedIn.</li>
           </ul>
 

--- a/polityka-prywatnosci.html
+++ b/polityka-prywatnosci.html
@@ -1,15 +1,7 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-VH07LRZ8GK');
-  </script>
+  <!-- Google tag (gtag.js) i Hotjar są inicjowane po akceptacji cookies w assets/cookies.js -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Polityka prywatności i cookies — Grunteo</title>
@@ -37,17 +29,27 @@
   <link rel="stylesheet" href="assets/main.css" />
   <link rel="stylesheet" href="assets/header.css" />
   <link rel="stylesheet" href="assets/legal.css" />
+  <!-- Google tag (gtag.js) -->
+  <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
+  <script type="text/plain" data-cookie-consent="analytics">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-VH07LRZ8GK', { 'anonymize_ip': true });
+  </script>
+
   <!-- Hotjar Tracking Code for grunteo.pl -->
-  <script>
+  <script type="text/plain" data-cookie-consent="analytics">
     (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:6523622,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments);};
+      h._hjSettings={hjid:6523622,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
   </script>
+
 </head>
 <body class="legal-page">
   <div class="top-navbar">
@@ -428,5 +430,31 @@
       });
     });
   </script>
+  <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">
+    <div class="cookie-banner__icon" aria-hidden="true">
+      <i class="fas fa-cookie-bite"></i>
+    </div>
+    <div class="cookie-banner__content">
+      <h3 class="cookie-banner__title">Szanujemy Twoją prywatność</h3>
+      <p class="cookie-banner__text">
+        Korzystamy z plików cookies, aby zapewnić prawidłowe działanie serwisu, analizować ruch i rozwijać nasze usługi.
+        Szczegółowe informacje znajdziesz w <a href="RODO.html">Informacji RODO</a> oraz w
+        <a href="polityka-prywatnosci.html">Polityce prywatności i cookies</a>.
+      </p>
+      <div class="cookie-banner__actions">
+        <button type="button" class="btn btn-primary cookie-banner__btn" data-cookie-accept>Akceptuję wszystkie</button>
+        <button type="button" class="btn btn-secondary cookie-banner__btn" data-cookie-decline>Tylko niezbędne</button>
+        <a class="cookie-banner__link" href="polityka-prywatnosci.html#cookies">
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          Zarządzaj ustawieniami
+        </a>
+      </div>
+    </div>
+  </div>
+  <button class="cookie-preferences" type="button" data-cookie-preferences hidden aria-haspopup="dialog" aria-expanded="false">
+    <i class="fas fa-cookie-bite" aria-hidden="true"></i>
+    Ustawienia cookies
+  </button>
+  <script src="assets/cookies.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore the Google tag and Hotjar tracking snippets in every page head while keeping them blocked until consent
- extend the cookie manager to activate deferred analytics scripts and manage the GA disable flag
- expand the RODO notice with analytics tool references and a note about permanent storage of plot listings

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cbf07a3870832bb91b6b137069327f