### PR TITLE
Add per-plot map imagery layers to property details

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -200,11 +200,52 @@ main.property-wrapper {
   box-shadow: 0 6px 14px rgba(30,111,186,.18);
 }
 
+.map-mode-btn.is-disabled,
+.map-mode-btn:disabled {
+  color: rgba(30,111,186,.45);
+  opacity: .6;
+}
+
+.map-mode-btn:disabled {
+  cursor: not-allowed;
+}
+
 #propertyMap {
   width: 100%;
   height: 360px;
   border-radius: 16px;
   background: #dbe8f7;
+}
+
+.map-image {
+  width: 100%;
+  height: 360px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #f0f6ff, #dbe8f7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(30,111,186,.08);
+}
+
+.map-image-picture {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  background: #fff;
+}
+
+.map-image-placeholder {
+  margin: 0;
+  padding: 1rem 1.5rem;
+  text-align: center;
+  color: var(--gray);
+  font-size: .95rem;
+  line-height: 1.4;
 }
 
 .location-details {
@@ -689,6 +730,10 @@ main.property-wrapper {
   }
 
   #propertyMap {
+    height: 300px;
+  }
+
+  .map-image {
     height: 300px;
   }
 

--- a/assets/details.js
+++ b/assets/details.js
@@ -123,11 +123,11 @@ const MAP_MODES = {
 };
 
 const MAP_LAYER_BASE_URLS = {
-  lokalizacja: 'https://grunteo.s3.eu-west-3.amazonaws.com/Orto_Esri%2BGrunty/MARGE_Orto_Esri%2BGrunty',
-  media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri%2BGESUT/MARGE_Cyclosm_Esri%2BGESUT',
-  teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID%2BGrunty/MARGE_GRID%2BGrunty',
-  mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP%2BGrunty/MARGE_MPZP%2BGrunty',
-  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty'
+  lokalizacja: 'https://grunteo.s3.eu-west-3.amazonaws.com/Orto_Esri+Grunty/MARGE_Orto_Esri+Grunty',
+  media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri+GESUT/MARGE_Cyclosm_Esri+GESUT',
+  teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID+Grunty/MARGE_GRID+Grunty',
+  mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP+Grunty/MARGE_MPZP+Grunty',
+  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium+Grunty/MARGE_Studium+Grunty'
 };
 
 const MAP_LAYER_ALIASES = {
@@ -252,7 +252,7 @@ function extractLayerImages(source) {
   return result;
 }
 
-function collectMapImages(plot = {}, offer = {}, plotIndex = 0) {
+function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '') {
   const sources = [
     plot.mapImages,
     plot.mapTiles,
@@ -344,7 +344,8 @@ function collectMapImages(plot = {}, offer = {}, plotIndex = 0) {
     offer.mapId,
     offer.plotId,
     offer.Id,
-    offer.id
+    offer.id,
+    fallbackId
   );
 
   const trimmedId = typeof plotImageId === 'string' ? plotImageId.trim() : plotImageId ? String(plotImageId).trim() : '';
@@ -703,7 +704,7 @@ function renderOffer(data, plot) {
   setTextContent(elements.planGreen, pickValue(plot.planGreen, data.planGreen), '—');
   setMultilineText(elements.planNotes, pickValue(plot.planNotes, data.planNotes), 'Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.');
 
-  updateMapImages(collectMapImages(plot, data, state.plotIndex));
+  updateMapImages(collectMapImages(plot, data, state.plotIndex, state.offerId));
 
   const utilities = mergeUtilities(data.utilities, plot.utilities);
   renderUtilities(utilities);

--- a/assets/details.js
+++ b/assets/details.js
@@ -333,7 +333,7 @@ function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '')
   });
 
   const candidateIds = [
-    fallbackId,
+    typeof fallbackId === 'string' ? fallbackId.trim() : fallbackId,
     plot.mapImageId,
     plot.mapId,
     plot.imageId,
@@ -359,9 +359,18 @@ function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '')
   const indexSuffix = `_${String(indexNumber).padStart(3, '0')}`;
 
   if (trimmedId) {
+    const expectedSuffix = `_${trimmedId}${indexSuffix}.png`;
     Object.entries(MAP_LAYER_BASE_URLS).forEach(([key, baseUrl]) => {
-      if (result[key]) return;
-      result[key] = `${baseUrl}_${trimmedId}${indexSuffix}.png`;
+      const expectedUrl = `${baseUrl}${expectedSuffix}`;
+      const currentUrl = typeof result[key] === 'string' ? result[key].trim() : '';
+      if (!currentUrl) {
+        result[key] = expectedUrl;
+        return;
+      }
+      const normalizedCurrent = currentUrl.split('?')[0];
+      if (!normalizedCurrent.endsWith(expectedSuffix)) {
+        result[key] = expectedUrl;
+      }
     });
   }
 

--- a/assets/details.js
+++ b/assets/details.js
@@ -123,11 +123,11 @@ const MAP_MODES = {
 };
 
 const MAP_LAYER_BASE_URLS = {
-  lokalizacja: 'https://grunteo.s3.eu-west-3.amazonaws.com/Orto_Esri+Grunty/MARGE_Orto_Esri+Grunty',
-  media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri+GESUT/MARGE_Cyclosm_Esri+GESUT',
-  teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID+Grunty/MARGE_GRID+Grunty',
-  mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP+Grunty/MARGE_MPZP+Grunty',
-  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium+Grunty/MARGE_Studium+Grunty'
+  lokalizacja: 'https://grunteo.s3.eu-west-3.amazonaws.com/Orto_Esri%2BGrunty/MARGE_Orto_Esri%2BGrunty',
+  media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri%2BGESUT/MARGE_Cyclosm_Esri%2BGESUT',
+  teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID%2BGrunty/MARGE_GRID%2BGrunty',
+  mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP%2BGrunty/MARGE_MPZP%2BGrunty',
+  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty'
 };
 
 const MAP_LAYER_ALIASES = {

--- a/assets/details.js
+++ b/assets/details.js
@@ -332,7 +332,8 @@ function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '')
     }
   });
 
-  const plotImageId = pickValue(
+  const candidateIds = [
+    fallbackId,
     plot.mapImageId,
     plot.mapId,
     plot.imageId,
@@ -344,11 +345,16 @@ function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '')
     offer.mapId,
     offer.plotId,
     offer.Id,
-    offer.id,
-    fallbackId
-  );
+    offer.id
+  ];
 
-  const trimmedId = typeof plotImageId === 'string' ? plotImageId.trim() : plotImageId ? String(plotImageId).trim() : '';
+  const trimmedId = candidateIds
+    .map(value => {
+      if (value === undefined || value === null) return '';
+      const text = typeof value === 'string' ? value : String(value);
+      return text.trim();
+    })
+    .find(value => value && /^[A-Za-z0-9_-]+$/.test(value)) || '';
   const indexNumber = Number.isFinite(plotIndex) && plotIndex >= 0 ? plotIndex : 0;
   const indexSuffix = `_${String(indexNumber).padStart(3, '0')}`;
 

--- a/assets/details.js
+++ b/assets/details.js
@@ -39,6 +39,8 @@ const state = {
   map: null,
   marker: null,
   polygon: null,
+  mapImages: {},
+  currentMapMode: 'base',
   shareUrl: '',
   favorites: [],
   savingFavorite: false
@@ -85,6 +87,9 @@ const elements = {
   inquiryForm: document.getElementById('inquiryForm'),
   mapSection: document.getElementById('mapSection'),
   mapElement: document.getElementById('propertyMap'),
+  mapImageContainer: document.getElementById('mapImageContainer'),
+  mapImageElement: document.getElementById('mapImage'),
+  mapImagePlaceholder: document.getElementById('mapImagePlaceholder'),
   mapModeButtons: Array.from(document.querySelectorAll('.map-mode-btn')),
   authButtons: document.getElementById('authButtons'),
   userMenu: document.getElementById('userMenu'),
@@ -104,10 +109,23 @@ const elements = {
   googleLoginBtn: document.getElementById('googleLoginBtnLogin')
 };
 
+const MAP_MODE_DEFAULT = 'base';
+
 const MAP_MODES = {
-  base: 'hybrid',
-  mpzp: 'satellite',
-  studium: 'terrain'
+  base: { type: 'map', mapType: 'hybrid' },
+  lokalizacja: { type: 'image', key: 'lokalizacja' },
+  media: { type: 'image', key: 'media' },
+  teren: { type: 'image', key: 'teren' },
+  mpzp: { type: 'image', key: 'mpzp' },
+  studium: { type: 'image', key: 'studium' }
+};
+
+const MAP_LAYER_ALIASES = {
+  lokalizacja: ['lokalizacja', 'location', 'localization', 'orto', 'orthophoto', 'aerial'],
+  media: ['media', 'uzbrojenie', 'utilities', 'gesut', 'cyclosm'],
+  teren: ['teren', 'terrain', 'grid', 'ground', 'siatka'],
+  mpzp: ['mpzp', 'plan', 'zoning', 'miejscowyplan'],
+  studium: ['studium', 'study', 'uwarunkowania', 'kierunki']
 };
 
 function pickValue(...values) {
@@ -153,6 +171,259 @@ function setMultilineText(element, value, fallback = '—') {
     ? fallback
     : sanitizeMultilineText(value);
   element.textContent = text;
+}
+
+function normalizeLayerKey(key) {
+  return String(key || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function resolveImageUrl(value) {
+  if (!value) return '';
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    if (/^(https?:)?\/\//i.test(trimmed) || trimmed.startsWith('data:') || trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../')) {
+      return trimmed;
+    }
+    return '';
+  }
+  if (typeof value === 'object') {
+    const candidate = value.url ?? value.href ?? value.src ?? value.value ?? value.link;
+    if (typeof candidate === 'string') {
+      return resolveImageUrl(candidate);
+    }
+  }
+  return '';
+}
+
+function matchLayerKey(rawKey) {
+  const normalized = normalizeLayerKey(rawKey);
+  if (!normalized) return '';
+  for (const [target, aliases] of Object.entries(MAP_LAYER_ALIASES)) {
+    if (normalized === target) {
+      return target;
+    }
+    for (const alias of aliases) {
+      if (normalized === alias || normalized.includes(alias) || alias.includes(normalized)) {
+        return target;
+      }
+    }
+  }
+  return '';
+}
+
+function extractLayerImages(source) {
+  const result = {};
+  if (!source) return result;
+  if (Array.isArray(source)) {
+    source.forEach(item => Object.assign(result, extractLayerImages(item)));
+    return result;
+  }
+  if (typeof source !== 'object') return result;
+  const candidateKey = source.key ?? source.type ?? source.layer ?? source.name ?? source.label;
+  const candidateUrl = source.url ?? source.href ?? source.src ?? source.value ?? source.link;
+  const matchedKey = matchLayerKey(candidateKey);
+  const resolvedUrl = resolveImageUrl(candidateUrl);
+  if (matchedKey && resolvedUrl) {
+    result[matchedKey] = resolvedUrl;
+  }
+  Object.entries(source).forEach(([key, value]) => {
+    const layerKey = matchLayerKey(key);
+    if (!layerKey) return;
+    const url = resolveImageUrl(value);
+    if (url) {
+      result[layerKey] = url;
+    }
+  });
+  return result;
+}
+
+function collectMapImages(plot = {}, offer = {}) {
+  const sources = [
+    plot.mapImages,
+    plot.mapTiles,
+    plot.mapLayers,
+    plot.planImages,
+    plot.planTiles,
+    plot.mapPreviews,
+    plot.mapGallery,
+    offer.mapImages,
+    offer.mapTiles,
+    offer.mapLayers,
+    offer.planImages,
+    offer.planTiles,
+    offer.mapPreviews,
+    offer.mapGallery
+  ];
+  const result = {};
+  sources.forEach(source => Object.assign(result, extractLayerImages(source)));
+
+  const directFields = {
+    lokalizacja: [
+      plot.mapLokalizacja,
+      plot.lokalizacjaMap,
+      plot.mapLocation,
+      plot.locationMap,
+      offer.mapLokalizacja,
+      offer.lokalizacjaMap,
+      offer.mapLocation,
+      offer.locationMap
+    ],
+    media: [
+      plot.mapMedia,
+      plot.mediaMap,
+      plot.mapUzbrojenie,
+      plot.mapGesut,
+      offer.mapMedia,
+      offer.mediaMap,
+      offer.mapUzbrojenie,
+      offer.mapGesut
+    ],
+    teren: [
+      plot.mapTeren,
+      plot.terrainMap,
+      plot.mapGrid,
+      plot.gridMap,
+      offer.mapTeren,
+      offer.terrainMap,
+      offer.mapGrid,
+      offer.gridMap
+    ],
+    mpzp: [
+      plot.mapMpzp,
+      plot.mapMPZP,
+      plot.mpzpMap,
+      plot.planMap,
+      offer.mapMpzp,
+      offer.mapMPZP,
+      offer.mpzpMap,
+      offer.planMap
+    ],
+    studium: [
+      plot.mapStudium,
+      plot.studiumMap,
+      offer.mapStudium,
+      offer.studiumMap
+    ]
+  };
+
+  Object.entries(directFields).forEach(([key, values]) => {
+    if (result[key]) return;
+    for (const value of values) {
+      const url = resolveImageUrl(value);
+      if (url) {
+        result[key] = url;
+        break;
+      }
+    }
+  });
+
+  return result;
+}
+
+function getMapModeLabel(mode) {
+  const button = elements.mapModeButtons.find(btn => btn.dataset.mode === mode);
+  return button ? button.textContent.trim() : '';
+}
+
+function setActiveMapButton(mode) {
+  elements.mapModeButtons.forEach(btn => {
+    if (btn.dataset.mode === mode) {
+      btn.classList.add('active');
+    } else {
+      btn.classList.remove('active');
+    }
+  });
+}
+
+function showMapCanvas(mapType) {
+  if (elements.mapImageContainer) {
+    elements.mapImageContainer.classList.add('hidden');
+  }
+  if (elements.mapImageElement) {
+    elements.mapImageElement.src = '';
+    elements.mapImageElement.alt = '';
+    elements.mapImageElement.classList.add('hidden');
+  }
+  if (elements.mapImagePlaceholder) {
+    elements.mapImagePlaceholder.classList.add('hidden');
+  }
+  if (elements.mapElement) {
+    elements.mapElement.classList.remove('hidden');
+  }
+  if (!state.map || typeof google === 'undefined' || !google?.maps) return;
+  const type = typeof mapType === 'string' ? mapType.toLowerCase() : 'hybrid';
+  const mapTypeId = type === 'terrain'
+    ? google.maps.MapTypeId.TERRAIN
+    : type === 'satellite'
+      ? google.maps.MapTypeId.SATELLITE
+      : google.maps.MapTypeId.HYBRID;
+  state.map.setMapTypeId(mapTypeId);
+  if (google.maps.event && typeof google.maps.event.trigger === 'function') {
+    const center = typeof state.map.getCenter === 'function' ? state.map.getCenter() : null;
+    google.maps.event.trigger(state.map, 'resize');
+    if (center && typeof state.map.setCenter === 'function') {
+      state.map.setCenter(center);
+    }
+  }
+}
+
+function showMapImage(key, label) {
+  if (!elements.mapImageContainer || !elements.mapImageElement) return;
+  const url = key ? state.mapImages[key] : '';
+  const hasUrl = typeof url === 'string' && url.trim().length > 0;
+
+  if (elements.mapElement) {
+    elements.mapElement.classList.add('hidden');
+  }
+  elements.mapImageContainer.classList.remove('hidden');
+
+  if (hasUrl) {
+    elements.mapImageElement.src = url;
+    elements.mapImageElement.alt = label ? `Warstwa „${label}”` : 'Podgląd warstwy mapy';
+    elements.mapImageElement.classList.remove('hidden');
+    elements.mapImagePlaceholder?.classList.add('hidden');
+  } else {
+    elements.mapImageElement.src = '';
+    elements.mapImageElement.alt = '';
+    elements.mapImageElement.classList.add('hidden');
+    if (elements.mapImagePlaceholder) {
+      const name = label ? `warstwy „${label}”` : 'tej warstwy';
+      elements.mapImagePlaceholder.textContent = `Brak obrazu dla ${name}.`;
+      elements.mapImagePlaceholder.classList.remove('hidden');
+    }
+  }
+}
+
+function updateMapImages(images) {
+  const nextImages = images && typeof images === 'object' && !Array.isArray(images)
+    ? { ...images }
+    : {};
+  state.mapImages = nextImages;
+  elements.mapModeButtons.forEach(btn => {
+    const mode = btn.dataset.mode;
+    const config = MAP_MODES[mode];
+    if (config?.type === 'image') {
+      const hasImage = Boolean(state.mapImages[config.key]);
+      btn.classList.toggle('is-disabled', !hasImage);
+      if (!hasImage) {
+        btn.setAttribute('title', 'Brak obrazu dla tej warstwy');
+      } else {
+        btn.removeAttribute('title');
+      }
+    } else {
+      btn.classList.remove('is-disabled');
+      btn.removeAttribute('title');
+    }
+  });
+  if (!state.currentMapMode) {
+    state.currentMapMode = MAP_MODE_DEFAULT;
+  }
+  setMapMode(state.currentMapMode);
 }
 
 function formatPhoneNumber(phone) {
@@ -394,6 +665,8 @@ function renderOffer(data, plot) {
   setTextContent(elements.planGreen, pickValue(plot.planGreen, data.planGreen), '—');
   setMultilineText(elements.planNotes, pickValue(plot.planNotes, data.planNotes), 'Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.');
 
+  updateMapImages(collectMapImages(plot, data));
+
   const utilities = mergeUtilities(data.utilities, plot.utilities);
   renderUtilities(utilities);
 
@@ -415,21 +688,21 @@ function renderOffer(data, plot) {
 }
 
 function setMapMode(mode) {
-  if (!state.map) return;
-  const type = MAP_MODES[mode] || MAP_MODES.base;
-  state.map.setMapTypeId(type === 'hybrid'
-    ? google.maps.MapTypeId.HYBRID
-    : type === 'satellite'
-      ? google.maps.MapTypeId.SATELLITE
-      : google.maps.MapTypeId.TERRAIN);
+  const targetMode = MAP_MODES[mode] ? mode : MAP_MODE_DEFAULT;
+  const config = MAP_MODES[targetMode] || MAP_MODES[MAP_MODE_DEFAULT];
+  state.currentMapMode = targetMode;
+  setActiveMapButton(targetMode);
+  if (config.type === 'image') {
+    showMapImage(config.key, getMapModeLabel(targetMode));
+  } else {
+    showMapCanvas(config.mapType);
+  }
 }
 
 function setupMapModeButtons() {
   elements.mapModeButtons.forEach(btn => {
     btn.addEventListener('click', () => {
       if (btn.classList.contains('active')) return;
-      elements.mapModeButtons.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
       setMapMode(btn.dataset.mode);
     });
   });
@@ -557,6 +830,8 @@ async function renderMap(plot) {
       state.map.fitBounds(bounds, { top: 32, right: 32, bottom: 32, left: 32 });
     }
   }
+
+  setMapMode(state.currentMapMode || MAP_MODE_DEFAULT);
 }
 
 function setupInquiryForm() {
@@ -1016,6 +1291,7 @@ async function loadProperty() {
     }
     state.offerData = data;
     state.plotData = plot;
+    state.currentMapMode = MAP_MODE_DEFAULT;
     renderOffer(data, plot);
     await renderMap(plot);
     showContent();

--- a/details.html
+++ b/details.html
@@ -174,12 +174,19 @@
           <div class="map-toolbar">
             <h3>Mapa i lokalizacja</h3>
             <div class="map-modes" role="group" aria-label="Warstwy mapy">
-              <button class="map-mode-btn active" data-mode="base">Mapa</button>
-              <button class="map-mode-btn" data-mode="mpzp">MPZP</button>
-              <button class="map-mode-btn" data-mode="studium">Studium</button>
+              <button class="map-mode-btn active" data-mode="base" type="button">Mapa</button>
+              <button class="map-mode-btn" data-mode="lokalizacja" type="button">Lokalizacja</button>
+              <button class="map-mode-btn" data-mode="media" type="button">Media</button>
+              <button class="map-mode-btn" data-mode="teren" type="button">Teren</button>
+              <button class="map-mode-btn" data-mode="mpzp" type="button">MPZP</button>
+              <button class="map-mode-btn" data-mode="studium" type="button">Studium</button>
             </div>
           </div>
           <div id="propertyMap" role="region" aria-label="Mapa działki"></div>
+          <div id="mapImageContainer" class="map-image hidden" aria-live="polite">
+            <img id="mapImage" class="map-image-picture hidden" alt="Podgląd warstwy mapy" loading="lazy">
+            <p id="mapImagePlaceholder" class="map-image-placeholder hidden">Brak obrazu dla wybranej warstwy.</p>
+          </div>
           <div class="location-details">
             <div class="location-card">
               <h4>Adres</h4>


### PR DESCRIPTION
## Summary
- extend the map toolbar on the property details page with buttons for Lokalizacja, Media, Teren, MPZP and Studium alongside the interactive map view
- load per-plot imagery for each layer, toggle between the Google map and static tiles, and add styling/placeholder handling for the new preview container

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc3868492c832baf5fb8ee347ca6f4