### PR TITLE
Prevent cookie banner from showing after consent

### DIFF
--- a/assets/cookies.js
+++ b/assets/cookies.js
@@ -144,6 +144,11 @@
     manageTrigger?.setAttribute('aria-expanded', 'true');
   };
 
+  const storedConsentState = storage.get();
+  if (storedConsentState){
+    hideBanner();
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     ensureConsentDefaults();
 
@@ -154,10 +159,8 @@
     const declineBtn = banner.querySelector('[data-cookie-decline]');
     const manageTrigger = document.querySelector('[data-cookie-preferences]');
 
-    const storedState = storage.get();
-    if (storedState){
-      hideBanner();
-      applyConsentState(storedState);
+    if (storedConsentState){
+      applyConsentState(storedConsentState);
     }else{
       banner.setAttribute('aria-hidden', 'false');
       banner.setAttribute('aria-modal', 'true');


### PR DESCRIPTION
## Summary
- hide the cookie banner immediately on load when a stored consent state is found
- reuse the stored consent state during initialization so previously accepted users keep analytics enabled without flashing the banner

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cc8d89ba78832b86b6fdfaa86b5323