### PR TITLE
Adjust map toolbar layout for mobile

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -816,6 +816,13 @@ body.lightbox-open {
 
   .map-modes {
     align-self: flex-start;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .map-mode-btn {
+    flex: 1 1 calc(50% - .5rem);
+    text-align: center;
   }
 
   .property-stats {


### PR DESCRIPTION
## Summary
- allow the map mode buttons to wrap within the toolbar on small screens
- balance button widths for two-column layout to avoid stretching the map card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccf4613244832b8ac7f204e2a6a9f1