### PR TITLE
Adjust plot number formatting and update empty placeholders

### DIFF
--- a/details.html
+++ b/details.html
@@ -140,11 +140,11 @@
 
           <div class="price-box" aria-live="polite">
             <div class="price-line">
-              <span id="priceValueText" class="price-amount">—</span>
+              <span id="priceValueText" class="price-amount">Pole do wypełnienia</span>
             </div>
             <div class="price-meta">
-              <span>cena za m²: <strong id="pricePerSqm">—</strong></span>
-              <span id="priceUpdatedAt">Aktualizacja: —</span>
+              <span>cena za m²: <strong id="pricePerSqm">Pole do wypełnienia</strong></span>
+              <span id="priceUpdatedAt">Aktualizacja: Pole do wypełnienia</span>
             </div>
           </div>
         </div>
@@ -152,19 +152,19 @@
         <div class="property-stats">
           <div class="stat-card">
             <h4>Numer działki</h4>
-            <p id="plotNumber">—</p>
+            <p id="plotNumber">Pole do wypełnienia</p>
           </div>
           <div class="stat-card">
             <h4>Numer księgi wieczystej</h4>
-            <p id="landRegister">—</p>
+            <p id="landRegister">Pole do wypełnienia</p>
           </div>
           <div class="stat-card">
             <h4>Powierzchnia</h4>
-            <p id="plotAreaStat">—</p>
+            <p id="plotAreaStat">Pole do wypełnienia</p>
           </div>
           <div class="stat-card">
             <h4>Status</h4>
-            <p id="plotStatus">—</p>
+            <p id="plotStatus">Pole do wypełnienia</p>
           </div>
         </div>
       </section>
@@ -206,9 +206,9 @@
           <div class="plan-badges" id="planBadges"></div>
           <div class="plan-info-grid">
             <dl><dt>Przeznaczenie</dt><dd id="planDesignation">Brak informacji</dd></dl>
-            <dl><dt>Maks. wysokość</dt><dd id="planHeight">—</dd></dl>
-            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity">—</dd></dl>
-            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen">—</dd></dl>
+            <dl><dt>Maks. wysokość</dt><dd id="planHeight">Pole do wypełnienia</dd></dl>
+            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity">Pole do wypełnienia</dd></dl>
+            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen">Pole do wypełnienia</dd></dl>
           </div>
           <div class="plan-notes" id="planNotes">Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.</div>
         </aside>


### PR DESCRIPTION
## Summary
- format the displayed plot number to use only the segment after the final dot
- introduce a shared placeholder constant for empty fields on the details page and apply it across the UI
- update default markup texts on details.html to show "Pole do wypełnienia" for empty values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccf8bf6b50832bacd52128c33df0db