### PR TITLE
Adjust plot number formatting and move placeholders to edit view

### DIFF
--- a/assets/details.js
+++ b/assets/details.js
@@ -163,29 +163,42 @@ function pickValue(...values) {
 
 function formatPrice(value) {
   const formatted = formatCurrency(value);
-  return formatted ? `${formatted}` : '—';
+  return formatted ? `${formatted}` : '';
 }
 
 function formatPerSqm(price, area) {
   if (!Number.isFinite(price) || !Number.isFinite(area) || area <= 0) {
-    return '—';
+    return '';
   }
   const result = Math.round(price / area);
   const formatted = formatNumber(result);
-  return formatted ? `${formatted} zł/m²` : '—';
+  return formatted ? `${formatted} zł/m²` : '';
 }
 
 function formatAreaText(value) {
   const formatted = formatArea(value);
-  return formatted ? formatted : '—';
+  return formatted ? formatted : '';
 }
 
-function setTextContent(element, value, fallback = '—') {
+function formatPlotNumber(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const text = String(value).trim();
+  if (!text) {
+    return null;
+  }
+  const segments = text.split('.');
+  const suffix = segments[segments.length - 1].trim();
+  return suffix || text;
+}
+
+function setTextContent(element, value, fallback = '') {
   if (!element) return;
   element.textContent = textContentOrFallback(value, fallback);
 }
 
-function setMultilineText(element, value, fallback = '—') {
+function setMultilineText(element, value, fallback = '') {
   if (!element) return;
   const text = value === null || value === undefined || value === ''
     ? fallback
@@ -736,7 +749,9 @@ function setArea(area) {
 
 function renderPriceMetadata(priceUpdatedAt) {
   const formatted = formatDateTime(priceUpdatedAt);
-  elements.priceUpdatedAt.textContent = formatted ? `Aktualizacja: ${formatted}` : 'Aktualizacja: —';
+  elements.priceUpdatedAt.textContent = formatted
+    ? `Aktualizacja: ${formatted}`
+    : 'Aktualizacja:';
   elements.pricePerSqm.textContent = formatPerSqm(state.price, state.area);
 }
 
@@ -804,18 +819,19 @@ function renderOffer(data, plot) {
 
   renderPriceMetadata(pickValue(plot.priceUpdatedAt, data.updatedAt, data.timestamp));
 
-  setTextContent(elements.plotNumber, pickValue(plot.plotNumber, plot.Id, plot.number), '—');
-  setTextContent(elements.landRegister, pickValue(plot.landRegister, plot.kwNumber, plot.landRegistry, plot.numer_kw), '—');
-  setTextContent(elements.plotStatus, pickValue(plot.status, plot.offerStatus, data.status), '—');
+  const plotNumber = formatPlotNumber(pickValue(plot.plotNumber, plot.Id, plot.number));
+  setTextContent(elements.plotNumber, plotNumber);
+  setTextContent(elements.landRegister, pickValue(plot.landRegister, plot.kwNumber, plot.landRegistry, plot.numer_kw));
+  setTextContent(elements.plotStatus, pickValue(plot.status, plot.offerStatus, data.status));
 
   setMultilineText(elements.locationAddress, pickValue(plot.locationAddress, data.address, plot.address), 'Dodaj adres działki');
   setMultilineText(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access), 'Opisz komunikację, dostęp do drogi, najbliższe punkty orientacyjne.');
 
   renderPlanBadges(pickValue(plot.planBadges, data.planBadges));
   setTextContent(elements.planDesignation, pickValue(plot.planDesignation, plot.planUsage, data.planDesignation), 'Brak informacji');
-  setTextContent(elements.planHeight, pickValue(plot.planHeight, data.planHeight), '—');
-  setTextContent(elements.planIntensity, pickValue(plot.planIntensity, data.planIntensity), '—');
-  setTextContent(elements.planGreen, pickValue(plot.planGreen, data.planGreen), '—');
+  setTextContent(elements.planHeight, pickValue(plot.planHeight, data.planHeight));
+  setTextContent(elements.planIntensity, pickValue(plot.planIntensity, data.planIntensity));
+  setTextContent(elements.planGreen, pickValue(plot.planGreen, data.planGreen));
   setMultilineText(elements.planNotes, pickValue(plot.planNotes, data.planNotes), 'Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.');
 
   updateMapImages(collectMapImages(plot, data, state.plotIndex, state.offerId));
@@ -1190,7 +1206,7 @@ function buildFavoriteEntry() {
   const contactEmail = pickValue(plot.contactEmail, offer.contactEmail, offer.email);
   const ownerUid = pickValue(plot.ownerUid, plot.ownerId, plot.userUid, offer.ownerUid, offer.userUid, offer.uid, offer.ownerId, offer.createdBy);
   const ownerEmail = pickValue(plot.ownerEmail, offer.ownerEmail, offer.userEmail, offer.email);
-  const plotNumber = pickValue(plot.plotNumber, plot.Id, plot.number);
+  const plotNumber = formatPlotNumber(pickValue(plot.plotNumber, plot.Id, plot.number));
 
   return {
     offerId: state.offerId,
@@ -1204,7 +1220,7 @@ function buildFavoriteEntry() {
     contactName: contactName ? String(contactName).trim() : null,
     contactPhone: contactPhone ? String(contactPhone).trim() : null,
     contactEmail: contactEmail ? String(contactEmail).trim() : null,
-    plotNumber: plotNumber ? String(plotNumber).trim() : null,
+    plotNumber: plotNumber ? plotNumber : null,
     savedAt: Date.now()
   };
 }

--- a/assets/edit.js
+++ b/assets/edit.js
@@ -54,6 +54,8 @@ const state = {
   hasLoaded: false
 };
 
+const EMPTY_FIELD_PLACEHOLDER = 'Pole do wypełnienia';
+
 const elements = {
   loadingState: document.getElementById('loadingState'),
   errorState: document.getElementById('errorState'),
@@ -133,21 +135,21 @@ function pickValue(...values) {
 
 function formatPerSqm(price, area) {
   if (!Number.isFinite(price) || !Number.isFinite(area) || area <= 0) {
-    return '—';
+    return EMPTY_FIELD_PLACEHOLDER;
   }
   const ppm = Math.round(price / area);
   const formatted = formatNumber(ppm);
-  return formatted ? `${formatted} zł/m²` : '—';
+  return formatted ? `${formatted} zł/m²` : EMPTY_FIELD_PLACEHOLDER;
 }
 
 function formatPrice(value) {
   const formatted = formatCurrency(value);
-  return formatted ? `${formatted}` : '—';
+  return formatted ? `${formatted}` : EMPTY_FIELD_PLACEHOLDER;
 }
 
 function formatAreaText(value) {
   const formatted = formatArea(value);
-  return formatted ? formatted : '—';
+  return formatted ? formatted : EMPTY_FIELD_PLACEHOLDER;
 }
 
 function extractPlotNumberSegment(value) {
@@ -187,7 +189,9 @@ function updatePricePerSqm() {
 
 function renderPriceUpdatedAt(value) {
   const formatted = formatDateTime(value);
-  elements.priceUpdatedAt.textContent = formatted ? `Aktualizacja: ${formatted}` : 'Aktualizacja: —';
+  elements.priceUpdatedAt.textContent = formatted
+    ? `Aktualizacja: ${formatted}`
+    : `Aktualizacja: ${EMPTY_FIELD_PLACEHOLDER}`;
 }
 
 function ensureSelectOption(select, value) {
@@ -717,8 +721,8 @@ function renderEditor(data, plot) {
   renderPriceUpdatedAt(pickValue(plot.priceUpdatedAt, data.updatedAt, data.timestamp));
 
   const plotNumberValue = pickValue(plot.plotNumber, plot.Id, plot.number);
-  elements.plotNumber.textContent = textContentOrFallback(extractPlotNumberSegment(plotNumberValue), '—');
-  elements.landRegister.textContent = textContentOrFallback(pickValue(plot.landRegister, plot.kwNumber, plot.landRegistry, plot.numer_kw), '—');
+  elements.plotNumber.textContent = textContentOrFallback(extractPlotNumberSegment(plotNumberValue), EMPTY_FIELD_PLACEHOLDER);
+  elements.landRegister.textContent = textContentOrFallback(pickValue(plot.landRegister, plot.kwNumber, plot.landRegistry, plot.numer_kw), EMPTY_FIELD_PLACEHOLDER);
   const statusValue = pickValue(plot.status, plot.offerStatus, data.status, '');
   setSelectValue(elements.plotOwnershipSelect, statusValue, '');
   if (!elements.plotOwnershipSelect?.value) {
@@ -734,9 +738,9 @@ function renderEditor(data, plot) {
   state.planBadges = cloneDeep(pickValue(plot.planBadges, data.planBadges));
   renderPlanBadges(state.planBadges);
   elements.planDesignation.textContent = textContentOrFallback(pickValue(plot.planDesignation, plot.planUsage, data.planDesignation), 'Brak informacji');
-  elements.planHeight.textContent = textContentOrFallback(pickValue(plot.planHeight, data.planHeight), '—');
-  elements.planIntensity.textContent = textContentOrFallback(pickValue(plot.planIntensity, data.planIntensity), '—');
-  elements.planGreen.textContent = textContentOrFallback(pickValue(plot.planGreen, data.planGreen), '—');
+  elements.planHeight.textContent = textContentOrFallback(pickValue(plot.planHeight, data.planHeight), EMPTY_FIELD_PLACEHOLDER);
+  elements.planIntensity.textContent = textContentOrFallback(pickValue(plot.planIntensity, data.planIntensity), EMPTY_FIELD_PLACEHOLDER);
+  elements.planGreen.textContent = textContentOrFallback(pickValue(plot.planGreen, data.planGreen), EMPTY_FIELD_PLACEHOLDER);
   elements.planNotes.textContent = sanitizeMultilineText(pickValue(plot.planNotes, data.planNotes) || '');
 
   state.utilities = mergeUtilities(data.utilities, plot.utilities);

--- a/details.html
+++ b/details.html
@@ -140,11 +140,11 @@
 
           <div class="price-box" aria-live="polite">
             <div class="price-line">
-              <span id="priceValueText" class="price-amount">—</span>
+              <span id="priceValueText" class="price-amount"></span>
             </div>
             <div class="price-meta">
-              <span>cena za m²: <strong id="pricePerSqm">—</strong></span>
-              <span id="priceUpdatedAt">Aktualizacja: —</span>
+              <span>cena za m²: <strong id="pricePerSqm"></strong></span>
+              <span id="priceUpdatedAt">Aktualizacja:</span>
             </div>
           </div>
         </div>
@@ -152,19 +152,19 @@
         <div class="property-stats">
           <div class="stat-card">
             <h4>Numer działki</h4>
-            <p id="plotNumber">—</p>
+            <p id="plotNumber"></p>
           </div>
           <div class="stat-card">
             <h4>Numer księgi wieczystej</h4>
-            <p id="landRegister">—</p>
+            <p id="landRegister"></p>
           </div>
           <div class="stat-card">
             <h4>Powierzchnia</h4>
-            <p id="plotAreaStat">—</p>
+            <p id="plotAreaStat"></p>
           </div>
           <div class="stat-card">
             <h4>Status</h4>
-            <p id="plotStatus">—</p>
+            <p id="plotStatus"></p>
           </div>
         </div>
       </section>
@@ -206,9 +206,9 @@
           <div class="plan-badges" id="planBadges"></div>
           <div class="plan-info-grid">
             <dl><dt>Przeznaczenie</dt><dd id="planDesignation">Brak informacji</dd></dl>
-            <dl><dt>Maks. wysokość</dt><dd id="planHeight">—</dd></dl>
-            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity">—</dd></dl>
-            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen">—</dd></dl>
+            <dl><dt>Maks. wysokość</dt><dd id="planHeight"></dd></dl>
+            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity"></dd></dl>
+            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen"></dd></dl>
           </div>
           <div class="plan-notes" id="planNotes">Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.</div>
         </aside>

--- a/edit.html
+++ b/edit.html
@@ -133,7 +133,7 @@
               <span class="meta-chip"><i class="fas fa-map-marker-alt"></i>
                 <span id="propertyLocation" contenteditable="true">Polska</span></span>
               <span class="meta-chip"><i class="fas fa-ruler-combined"></i>
-                <span id="propertyArea">0 m²</span></span>
+                <span id="propertyArea">Pole do wypełnienia</span></span>
               <span class="meta-chip meta-chip--select"><i class="fas fa-layer-group"></i>
                 <select id="propertyTypeSelect" aria-label="Rodzaj działki">
                   <option value="">Rodzaj</option>
@@ -151,11 +151,11 @@
 
           <div class="price-box" aria-live="polite">
             <div class="price-line">
-              <span id="priceValueText" class="price-amount" contenteditable="true">—</span>
+              <span id="priceValueText" class="price-amount" contenteditable="true">Pole do wypełnienia</span>
             </div>
             <div class="price-meta">
-              <span>cena za m²: <strong id="pricePerSqm">—</strong></span>
-              <span id="priceUpdatedAt">Aktualizacja: —</span>
+              <span>cena za m²: <strong id="pricePerSqm">Pole do wypełnienia</strong></span>
+              <span id="priceUpdatedAt">Aktualizacja: Pole do wypełnienia</span>
             </div>
           </div>
         </div>
@@ -163,16 +163,16 @@
         <div class="property-stats">
           <div class="stat-card">
             <h4>Numer działki</h4>
-            <p id="plotNumber">—</p>
+            <p id="plotNumber">Pole do wypełnienia</p>
           </div>
           <div class="stat-card">
             <h4>Numer księgi wieczystej</h4>
-            <p id="landRegister" contenteditable="true">—</p>
+            <p id="landRegister" contenteditable="true">Pole do wypełnienia</p>
             <p class="field-hint">Przykład: WA3M/00095878/5</p>
           </div>
           <div class="stat-card">
             <h4>Powierzchnia</h4>
-            <p id="plotAreaStat">—</p>
+            <p id="plotAreaStat">Pole do wypełnienia</p>
           </div>
           <div class="stat-card">
             <h4>Status własności</h4>
@@ -221,9 +221,9 @@
           <div class="plan-badges" id="planBadges"></div>
           <div class="plan-info-grid">
             <dl><dt>Przeznaczenie</dt><dd id="planDesignation" contenteditable="true">Brak informacji</dd></dl>
-            <dl><dt>Maks. wysokość</dt><dd id="planHeight" contenteditable="true">—</dd></dl>
-            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity" contenteditable="true">—</dd></dl>
-            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen" contenteditable="true">—</dd></dl>
+            <dl><dt>Maks. wysokość</dt><dd id="planHeight" contenteditable="true">Pole do wypełnienia</dd></dl>
+            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity" contenteditable="true">Pole do wypełnienia</dd></dl>
+            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen" contenteditable="true">Pole do wypełnienia</dd></dl>
           </div>
           <div class="plan-notes" id="planNotes" contenteditable="true">Uzupełnij najważniejsze zapisy z planu miejscowego lub studium.</div>
         </aside>


### PR DESCRIPTION
## Summary
- keep the plot number formatting so only the segment after the last dot is shown
- limit the "Pole do wypełnienia" placeholder usage to the edit experience while leaving details fields empty when data is missing
- update the details and edit markup along with their scripts to reflect the new placeholder behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccf8bf6b50832bacd52128c33df0db