### PR TITLE
Align edit map modes with details view

### DIFF
--- a/assets/edit.css
+++ b/assets/edit.css
@@ -285,8 +285,15 @@
 
 @media (max-width: 768px) {
   .edit-toolbar {
-    position: static;
+    top: calc(var(--nav-top) + 12px);
+    margin: 0 0 1.5rem;
+    padding: .65rem;
+    background: rgba(255, 255, 255, .95);
+    border-radius: 14px;
+    box-shadow: var(--shadow-md);
     justify-content: stretch;
+    z-index: 12;
+    backdrop-filter: blur(6px);
   }
 
   .edit-toolbar .btn {

--- a/assets/edit.js
+++ b/assets/edit.js
@@ -51,6 +51,8 @@ const state = {
   map: null,
   marker: null,
   polygon: null,
+  mapImages: {},
+  currentMapMode: 'base',
   hasLoaded: false
 };
 
@@ -93,6 +95,9 @@ const elements = {
   contactPhoneLink: document.getElementById('contactPhoneLink'),
   contactEmailLink: document.getElementById('contactEmailLink'),
   mapElement: document.getElementById('propertyMap'),
+  mapImageContainer: document.getElementById('mapImageContainer'),
+  mapImageElement: document.getElementById('mapImage'),
+  mapImagePlaceholder: document.getElementById('mapImagePlaceholder'),
   mapModeButtons: Array.from(document.querySelectorAll('.map-mode-btn')),
   authButtons: document.getElementById('authButtons'),
   userMenu: document.getElementById('userMenu'),
@@ -112,10 +117,33 @@ const elements = {
   googleLoginBtn: document.getElementById('googleLoginBtnLogin')
 };
 
+elements.mapImageElement?.addEventListener('error', handleMapImageError);
+
+const MAP_MODE_DEFAULT = 'base';
+
 const MAP_MODES = {
-  base: 'hybrid',
-  mpzp: 'satellite',
-  studium: 'terrain'
+  base: { type: 'map', mapType: 'hybrid' },
+  lokalizacja: { type: 'image', key: 'lokalizacja' },
+  media: { type: 'image', key: 'media' },
+  teren: { type: 'image', key: 'teren' },
+  mpzp: { type: 'image', key: 'mpzp' },
+  studium: { type: 'image', key: 'studium' }
+};
+
+const MAP_LAYER_BASE_URLS = {
+  lokalizacja: 'https://grunteo.s3.eu-west-3.amazonaws.com/Orto_Esri%2BGrunty/MARGE_Orto_Esri%2BGrunty',
+  media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri%2BGESUT/MARGE_Cyclosm_Esri%2BGESUT',
+  teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID%2BGrunty/MARGE_GRID%2BGrunty',
+  mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP%2BGrunty/MARGE_MPZP%2BGrunty',
+  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty'
+};
+
+const MAP_LAYER_ALIASES = {
+  lokalizacja: ['lokalizacja', 'location', 'localization', 'orto', 'orthophoto', 'aerial'],
+  media: ['media', 'uzbrojenie', 'utilities', 'gesut', 'cyclosm'],
+  teren: ['teren', 'terrain', 'grid', 'ground', 'siatka'],
+  mpzp: ['mpzp', 'plan', 'zoning', 'miejscowyplan'],
+  studium: ['studium', 'study', 'uwarunkowania', 'kierunki']
 };
 
 const TAG_SUGGESTION_LIMIT = 18;
@@ -187,6 +215,201 @@ function extractPlotNumberSegment(value) {
   if (lastDotIndex === -1) return str;
   const segment = str.slice(lastDotIndex + 1).trim();
   return segment || str;
+}
+
+function normalizeLayerKey(key) {
+  return String(key || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function resolveImageUrl(value) {
+  if (!value) return '';
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    if (/^(https?:)?\/\//i.test(trimmed) || trimmed.startsWith('data:') || trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../')) {
+      return trimmed;
+    }
+    try {
+      const url = new URL(trimmed, window.location.origin);
+      return url.toString();
+    } catch (error) {
+      return '';
+    }
+  }
+  if (typeof value === 'object' && value?.url) {
+    return resolveImageUrl(value.url);
+  }
+  return '';
+}
+
+function matchLayerKey(value) {
+  const normalized = normalizeLayerKey(value);
+  if (!normalized) return '';
+  if (MAP_LAYER_ALIASES[normalized]) return normalized;
+  for (const [target, aliases] of Object.entries(MAP_LAYER_ALIASES)) {
+    if (normalized === target) return target;
+    for (const alias of aliases) {
+      if (normalized === alias || normalized.includes(alias) || alias.includes(normalized)) {
+        return target;
+      }
+    }
+  }
+  return '';
+}
+
+function extractLayerImages(source) {
+  const result = {};
+  if (!source) return result;
+  if (Array.isArray(source)) {
+    source.forEach(item => Object.assign(result, extractLayerImages(item)));
+    return result;
+  }
+  if (typeof source !== 'object') return result;
+  const candidateKey = source.key ?? source.type ?? source.layer ?? source.name ?? source.label;
+  const candidateUrl = source.url ?? source.href ?? source.src ?? source.value ?? source.link;
+  const matchedKey = matchLayerKey(candidateKey);
+  const resolvedUrl = resolveImageUrl(candidateUrl);
+  if (matchedKey && resolvedUrl) {
+    result[matchedKey] = resolvedUrl;
+  }
+  Object.entries(source).forEach(([key, value]) => {
+    const layerKey = matchLayerKey(key);
+    if (!layerKey) return;
+    const url = resolveImageUrl(value);
+    if (url) {
+      result[layerKey] = url;
+    }
+  });
+  return result;
+}
+
+function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '') {
+  const sources = [
+    plot.mapImages,
+    plot.mapTiles,
+    plot.mapLayers,
+    plot.planImages,
+    plot.planTiles,
+    plot.mapPreviews,
+    plot.mapGallery,
+    offer.mapImages,
+    offer.mapTiles,
+    offer.mapLayers,
+    offer.planImages,
+    offer.planTiles,
+    offer.mapPreviews,
+    offer.mapGallery
+  ];
+  const result = {};
+  sources.forEach(source => Object.assign(result, extractLayerImages(source)));
+
+  const directFields = {
+    lokalizacja: [
+      plot.mapLokalizacja,
+      plot.lokalizacjaMap,
+      plot.mapLocation,
+      plot.locationMap,
+      offer.mapLokalizacja,
+      offer.lokalizacjaMap,
+      offer.mapLocation,
+      offer.locationMap
+    ],
+    media: [
+      plot.mapMedia,
+      plot.mediaMap,
+      plot.mapUzbrojenie,
+      plot.mapGesut,
+      offer.mapMedia,
+      offer.mediaMap,
+      offer.mapUzbrojenie,
+      offer.mapGesut
+    ],
+    teren: [
+      plot.mapTeren,
+      plot.terrainMap,
+      plot.mapGrid,
+      plot.gridMap,
+      offer.mapTeren,
+      offer.terrainMap,
+      offer.mapGrid,
+      offer.gridMap
+    ],
+    mpzp: [
+      plot.mapMpzp,
+      plot.mapMPZP,
+      plot.mpzpMap,
+      plot.planMap,
+      offer.mapMpzp,
+      offer.mapMPZP,
+      offer.mpzpMap,
+      offer.planMap
+    ],
+    studium: [
+      plot.mapStudium,
+      plot.studiumMap,
+      offer.mapStudium,
+      offer.studiumMap
+    ]
+  };
+
+  Object.entries(directFields).forEach(([key, values]) => {
+    if (result[key]) return;
+    for (const value of values) {
+      const url = resolveImageUrl(value);
+      if (url) {
+        result[key] = url;
+        break;
+      }
+    }
+  });
+
+  const candidateIds = [
+    typeof fallbackId === 'string' ? fallbackId.trim() : fallbackId,
+    plot.mapImageId,
+    plot.mapId,
+    plot.imageId,
+    plot.imagesId,
+    plot.plotId,
+    plot.Id,
+    plot.id,
+    offer.mapImageId,
+    offer.mapId,
+    offer.plotId,
+    offer.Id,
+    offer.id
+  ];
+
+  const trimmedId = candidateIds
+    .map(value => {
+      if (value === undefined || value === null) return '';
+      const text = typeof value === 'string' ? value : String(value);
+      return text.trim();
+    })
+    .find(value => value && /^[A-Za-z0-9_-]+$/.test(value)) || '';
+  const indexNumber = Number.isFinite(plotIndex) && plotIndex >= 0 ? plotIndex : 0;
+  const indexSuffix = `_${String(indexNumber).padStart(3, '0')}`;
+
+  if (trimmedId) {
+    const expectedSuffix = `_${trimmedId}${indexSuffix}.png`;
+    Object.entries(MAP_LAYER_BASE_URLS).forEach(([key, baseUrl]) => {
+      const expectedUrl = `${baseUrl}${expectedSuffix}`;
+      const currentUrl = typeof result[key] === 'string' ? result[key].trim() : '';
+      if (!currentUrl) {
+        result[key] = expectedUrl;
+        return;
+      }
+      const normalizedCurrent = currentUrl.split('?')[0];
+      if (!normalizedCurrent.endsWith(expectedSuffix)) {
+        result[key] = expectedUrl;
+      }
+    });
+  }
+
+  return result;
 }
 
 function setPriceEdit(price) {
@@ -762,6 +985,8 @@ function renderEditor(data, plot) {
   applyMultilinePlaceholder(elements.locationAddress, pickValue(plot.locationAddress, data.address, plot.address));
   applyMultilinePlaceholder(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access));
 
+  updateMapImages(collectMapImages(plot, data, state.plotIndex, state.offerId));
+
   state.planBadges = cloneDeep(pickValue(plot.planBadges, data.planBadges));
   renderPlanBadges(state.planBadges);
   applyPlaceholder(elements.planDesignation, pickValue(plot.planDesignation, plot.planUsage, data.planDesignation));
@@ -811,21 +1036,132 @@ function setupMapModeButtons() {
   elements.mapModeButtons.forEach(btn => {
     btn.addEventListener('click', () => {
       if (btn.classList.contains('active')) return;
-      elements.mapModeButtons.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
       setMapMode(btn.dataset.mode);
     });
   });
 }
 
-function setMapMode(mode) {
-  if (!state.map) return;
-  const type = MAP_MODES[mode] || MAP_MODES.base;
-  state.map.setMapTypeId(type === 'hybrid'
-    ? google.maps.MapTypeId.HYBRID
+function getMapModeLabel(mode) {
+  const button = elements.mapModeButtons.find(btn => btn.dataset.mode === mode);
+  return button ? button.textContent.trim() : '';
+}
+
+function setActiveMapButton(mode) {
+  elements.mapModeButtons.forEach(btn => {
+    if (btn.dataset.mode === mode) {
+      btn.classList.add('active');
+    } else {
+      btn.classList.remove('active');
+    }
+  });
+}
+
+function showMapCanvas(mapType) {
+  if (elements.mapImageContainer) {
+    elements.mapImageContainer.classList.add('hidden');
+  }
+  if (elements.mapImageElement) {
+    elements.mapImageElement.src = '';
+    elements.mapImageElement.alt = '';
+    elements.mapImageElement.classList.add('hidden');
+    elements.mapImageElement.classList.remove('is-interactive');
+    delete elements.mapImageElement.dataset.layerLabel;
+  }
+  if (elements.mapImagePlaceholder) {
+    elements.mapImagePlaceholder.classList.add('hidden');
+  }
+  if (elements.mapElement) {
+    elements.mapElement.classList.remove('hidden');
+  }
+  if (!state.map || typeof google === 'undefined' || !google?.maps) return;
+  const type = typeof mapType === 'string' ? mapType.toLowerCase() : 'hybrid';
+  const mapTypeId = type === 'terrain'
+    ? google.maps.MapTypeId.TERRAIN
     : type === 'satellite'
       ? google.maps.MapTypeId.SATELLITE
-      : google.maps.MapTypeId.TERRAIN);
+      : google.maps.MapTypeId.HYBRID;
+  state.map.setMapTypeId(mapTypeId);
+  if (google.maps.event && typeof google.maps.event.trigger === 'function') {
+    const center = typeof state.map.getCenter === 'function' ? state.map.getCenter() : null;
+    google.maps.event.trigger(state.map, 'resize');
+    if (center && typeof state.map.setCenter === 'function') {
+      state.map.setCenter(center);
+    }
+  }
+}
+
+function showMapImage(key, label) {
+  if (!elements.mapImageContainer || !elements.mapImageElement) return;
+  const url = key ? state.mapImages[key] : '';
+  const hasUrl = typeof url === 'string' && url.trim().length > 0;
+
+  if (elements.mapElement) {
+    elements.mapElement.classList.add('hidden');
+  }
+  elements.mapImageContainer.classList.remove('hidden');
+
+  if (hasUrl) {
+    elements.mapImageElement.src = url;
+    elements.mapImageElement.alt = label ? `Warstwa „${label}”` : 'Podgląd warstwy mapy';
+    elements.mapImageElement.dataset.layerLabel = label || '';
+    elements.mapImageElement.classList.remove('hidden');
+    elements.mapImagePlaceholder?.classList.add('hidden');
+  } else {
+    elements.mapImageElement.src = '';
+    elements.mapImageElement.alt = '';
+    delete elements.mapImageElement.dataset.layerLabel;
+    elements.mapImageElement.classList.add('hidden');
+    if (elements.mapImagePlaceholder) {
+      const name = label ? `warstwy „${label}”` : 'tej warstwy';
+      elements.mapImagePlaceholder.textContent = `Brak obrazu dla ${name}.`;
+      elements.mapImagePlaceholder.classList.remove('hidden');
+    }
+  }
+}
+
+function handleMapImageError() {
+  if (!elements.mapImageElement) return;
+  const label = elements.mapImageElement.dataset?.layerLabel || getMapModeLabel(state.currentMapMode);
+  showMapImage('', label);
+}
+
+function updateMapImages(images) {
+  const nextImages = images && typeof images === 'object' && !Array.isArray(images)
+    ? { ...images }
+    : {};
+  state.mapImages = nextImages;
+  elements.mapModeButtons.forEach(btn => {
+    const mode = btn.dataset.mode;
+    const config = MAP_MODES[mode];
+    if (config?.type === 'image') {
+      const hasImage = Boolean(state.mapImages[config.key]);
+      btn.classList.toggle('is-disabled', !hasImage);
+      if (!hasImage) {
+        btn.setAttribute('title', 'Brak obrazu dla tej warstwy');
+      } else {
+        btn.removeAttribute('title');
+      }
+    } else {
+      btn.classList.remove('is-disabled');
+      btn.removeAttribute('title');
+    }
+  });
+  if (!state.currentMapMode) {
+    state.currentMapMode = MAP_MODE_DEFAULT;
+  }
+  setMapMode(state.currentMapMode);
+}
+
+function setMapMode(mode) {
+  const targetMode = MAP_MODES[mode] ? mode : MAP_MODE_DEFAULT;
+  const config = MAP_MODES[targetMode] || MAP_MODES[MAP_MODE_DEFAULT];
+  state.currentMapMode = targetMode;
+  setActiveMapButton(targetMode);
+  if (config.type === 'image') {
+    showMapImage(config.key, getMapModeLabel(targetMode));
+  } else {
+    showMapCanvas(config.mapType);
+  }
 }
 
 function ensureProjDefinition() {
@@ -952,6 +1288,8 @@ async function renderMap(plot) {
       state.map.fitBounds(bounds, { top: 32, right: 32, bottom: 32, left: 32 });
     }
   }
+
+  setMapMode(state.currentMapMode || MAP_MODE_DEFAULT);
 }
 
 function openModal(modal) {

--- a/edit.html
+++ b/edit.html
@@ -196,12 +196,19 @@
           <div class="map-toolbar">
             <h3>Mapa i lokalizacja</h3>
             <div class="map-modes" role="group" aria-label="Warstwy mapy">
-              <button class="map-mode-btn active" data-mode="base">Mapa</button>
-              <button class="map-mode-btn" data-mode="mpzp">MPZP</button>
-              <button class="map-mode-btn" data-mode="studium">Studium</button>
+              <button class="map-mode-btn active" data-mode="base" type="button">Mapa</button>
+              <button class="map-mode-btn" data-mode="lokalizacja" type="button">Lokalizacja</button>
+              <button class="map-mode-btn" data-mode="media" type="button">Media</button>
+              <button class="map-mode-btn" data-mode="teren" type="button">Teren</button>
+              <button class="map-mode-btn" data-mode="mpzp" type="button">MPZP</button>
+              <button class="map-mode-btn" data-mode="studium" type="button">Studium</button>
             </div>
           </div>
           <div id="propertyMap" role="region" aria-label="Mapa działki"></div>
+          <div id="mapImageContainer" class="map-image hidden" aria-live="polite">
+            <img id="mapImage" class="map-image-picture hidden" alt="Podgląd warstwy mapy" loading="lazy">
+            <p id="mapImagePlaceholder" class="map-image-placeholder hidden">Brak obrazu dla wybranej warstwy.</p>
+          </div>
           <div class="location-details">
             <div class="location-card">
               <h4>Adres</h4>


### PR DESCRIPTION
## Summary
- add the missing map layer buttons and preview container to the edit view so it mirrors the details page
- port the map image resolution and switching logic to edit.js to display static layers like MPZP, Studium, Media and Teren
- keep the save button visible on mobile by making the toolbar sticky with a translucent background

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd25daa630832b80f8cbce9604b672