### PR TITLE
Dodaj dodatkowe warstwy map w kartach szczegółów i edycji

### DIFF
--- a/assets/details.js
+++ b/assets/details.js
@@ -143,7 +143,9 @@ const MAP_MODES = {
   media: { type: 'image', key: 'media' },
   teren: { type: 'image', key: 'teren' },
   mpzp: { type: 'image', key: 'mpzp' },
-  studium: { type: 'image', key: 'studium' }
+  mpzpskan: { type: 'image', key: 'mpzpskan' },
+  studium: { type: 'image', key: 'studium' },
+  uzytkigruntowe: { type: 'image', key: 'uzytkigruntowe' }
 };
 
 const MAP_LAYER_BASE_URLS = {
@@ -151,7 +153,9 @@ const MAP_LAYER_BASE_URLS = {
   media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri%2BGESUT/MARGE_Cyclosm_Esri%2BGESUT',
   teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID%2BGrunty/MARGE_GRID%2BGrunty',
   mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP%2BGrunty/MARGE_MPZP%2BGrunty',
-  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty'
+  mpzpskan: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP_rastrowe%2BGrunty/MARGE_MPZP_rastrowe%2BGrunty',
+  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty',
+  uzytkigruntowe: 'https://grunteo.s3.eu-west-3.amazonaws.com/Uzytki%2BGrunty/MARGE_Uzytki%2BGrunty'
 };
 
 const MAP_LAYER_ALIASES = {
@@ -159,7 +163,9 @@ const MAP_LAYER_ALIASES = {
   media: ['media', 'uzbrojenie', 'utilities', 'gesut', 'cyclosm'],
   teren: ['teren', 'terrain', 'grid', 'ground', 'siatka'],
   mpzp: ['mpzp', 'plan', 'zoning', 'miejscowyplan'],
-  studium: ['studium', 'study', 'uwarunkowania', 'kierunki']
+  mpzpskan: ['mpzpskan', 'mpzpraster', 'mpzprastrowe', 'mpzpscan', 'planraster', 'planrasterowy', 'planzdjecie', 'skanmpzp', 'skanplanu'],
+  studium: ['studium', 'study', 'uwarunkowania', 'kierunki'],
+  uzytkigruntowe: ['uzytkigruntowe', 'uzytki', 'uzytkirolne', 'landuse', 'landusage', 'pokryciegruntu']
 };
 
 function pickValue(...values) {
@@ -353,11 +359,61 @@ function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '')
       offer.mpzpMap,
       offer.planMap
     ],
+    mpzpskan: [
+      plot.mapMpzpSkan,
+      plot.mapMpzpScan,
+      plot.mapMpzpRaster,
+      plot.mapMpzpRastrowe,
+      plot.mapMPZPSkan,
+      plot.mapMPZPScan,
+      plot.mapMPZPRaster,
+      plot.mpzpSkan,
+      plot.mpzpScan,
+      plot.mpzpRaster,
+      plot.planRaster,
+      plot.planScan,
+      plot.planSkan,
+      offer.mapMpzpSkan,
+      offer.mapMpzpScan,
+      offer.mapMpzpRaster,
+      offer.mapMpzpRastrowe,
+      offer.mapMPZPSkan,
+      offer.mapMPZPScan,
+      offer.mapMPZPRaster,
+      offer.mpzpSkan,
+      offer.mpzpScan,
+      offer.mpzpRaster,
+      offer.planRaster,
+      offer.planScan,
+      offer.planSkan
+    ],
     studium: [
       plot.mapStudium,
       plot.studiumMap,
       offer.mapStudium,
       offer.studiumMap
+    ],
+    uzytkigruntowe: [
+      plot.mapUzytki,
+      plot.mapUzytkiGruntowe,
+      plot.mapUzytkiGruntu,
+      plot.mapUzytkiRolne,
+      plot.uzytkiMap,
+      plot.uzytkiGruntoweMap,
+      plot.mapLandUse,
+      plot.landUseMap,
+      plot.landuseMap,
+      plot.mapLandcover,
+      offer.mapUzytki,
+      offer.mapUzytkiGruntowe,
+      offer.mapUzytkiGruntu,
+      offer.mapUzytkiRolne,
+      offer.uzytkiMap,
+      offer.uzytkiGruntoweMap,
+      offer.mapLandUse,
+      offer.landUseMap,
+      offer.landuseMap,
+      offer.mapLandcover
     ]
   };
 

--- a/assets/edit.js
+++ b/assets/edit.js
@@ -151,7 +151,9 @@ const MAP_MODES = {
   media: { type: 'image', key: 'media' },
   teren: { type: 'image', key: 'teren' },
   mpzp: { type: 'image', key: 'mpzp' },
-  studium: { type: 'image', key: 'studium' }
+  mpzpskan: { type: 'image', key: 'mpzpskan' },
+  studium: { type: 'image', key: 'studium' },
+  uzytkigruntowe: { type: 'image', key: 'uzytkigruntowe' }
 };
 
 const MAP_LAYER_BASE_URLS = {
@@ -159,7 +161,9 @@ const MAP_LAYER_BASE_URLS = {
   media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri%2BGESUT/MARGE_Cyclosm_Esri%2BGESUT',
   teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID%2BGrunty/MARGE_GRID%2BGrunty',
   mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP%2BGrunty/MARGE_MPZP%2BGrunty',
-  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty'
+  mpzpskan: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP_rastrowe%2BGrunty/MARGE_MPZP_rastrowe%2BGrunty',
+  studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty',
+  uzytkigruntowe: 'https://grunteo.s3.eu-west-3.amazonaws.com/Uzytki%2BGrunty/MARGE_Uzytki%2BGrunty'
 };
 
 const MAP_LAYER_ALIASES = {
@@ -167,7 +171,9 @@ const MAP_LAYER_ALIASES = {
   media: ['media', 'uzbrojenie', 'utilities', 'gesut', 'cyclosm'],
   teren: ['teren', 'terrain', 'grid', 'ground', 'siatka'],
   mpzp: ['mpzp', 'plan', 'zoning', 'miejscowyplan'],
-  studium: ['studium', 'study', 'uwarunkowania', 'kierunki']
+  mpzpskan: ['mpzpskan', 'mpzpraster', 'mpzprastrowe', 'mpzpscan', 'planraster', 'planrasterowy', 'planzdjecie', 'skanmpzp', 'skanplanu'],
+  studium: ['studium', 'study', 'uwarunkowania', 'kierunki'],
+  uzytkigruntowe: ['uzytkigruntowe', 'uzytki', 'uzytkirolne', 'landuse', 'landusage', 'pokryciegruntu']
 };
 
 const TAG_SUGGESTION_LIMIT = 18;
@@ -378,11 +384,61 @@ function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '')
       offer.mpzpMap,
       offer.planMap
     ],
+    mpzpskan: [
+      plot.mapMpzpSkan,
+      plot.mapMpzpScan,
+      plot.mapMpzpRaster,
+      plot.mapMpzpRastrowe,
+      plot.mapMPZPSkan,
+      plot.mapMPZPScan,
+      plot.mapMPZPRaster,
+      plot.mpzpSkan,
+      plot.mpzpScan,
+      plot.mpzpRaster,
+      plot.planRaster,
+      plot.planScan,
+      plot.planSkan,
+      offer.mapMpzpSkan,
+      offer.mapMpzpScan,
+      offer.mapMpzpRaster,
+      offer.mapMpzpRastrowe,
+      offer.mapMPZPSkan,
+      offer.mapMPZPScan,
+      offer.mapMPZPRaster,
+      offer.mpzpSkan,
+      offer.mpzpScan,
+      offer.mpzpRaster,
+      offer.planRaster,
+      offer.planScan,
+      offer.planSkan
+    ],
     studium: [
       plot.mapStudium,
       plot.studiumMap,
       offer.mapStudium,
       offer.studiumMap
+    ],
+    uzytkigruntowe: [
+      plot.mapUzytki,
+      plot.mapUzytkiGruntowe,
+      plot.mapUzytkiGruntu,
+      plot.mapUzytkiRolne,
+      plot.uzytkiMap,
+      plot.uzytkiGruntoweMap,
+      plot.mapLandUse,
+      plot.landUseMap,
+      plot.landuseMap,
+      plot.mapLandcover,
+      offer.mapUzytki,
+      offer.mapUzytkiGruntowe,
+      offer.mapUzytkiGruntu,
+      offer.mapUzytkiRolne,
+      offer.uzytkiMap,
+      offer.uzytkiGruntoweMap,
+      offer.mapLandUse,
+      offer.landUseMap,
+      offer.landuseMap,
+      offer.mapLandcover
     ]
   };
 

--- a/details.html
+++ b/details.html
@@ -172,14 +172,16 @@
       <section class="property-layout" id="mapSection">
         <div class="map-panel">
           <div class="map-toolbar">
-            <h3>Mapa i lokalizacja</h3>
+            <h3>Mapy</h3>
             <div class="map-modes" role="group" aria-label="Warstwy mapy">
               <button class="map-mode-btn active" data-mode="base" type="button">Mapa</button>
               <button class="map-mode-btn" data-mode="lokalizacja" type="button">Lokalizacja</button>
               <button class="map-mode-btn" data-mode="media" type="button">Media</button>
               <button class="map-mode-btn" data-mode="teren" type="button">Teren</button>
               <button class="map-mode-btn" data-mode="mpzp" type="button">MPZP</button>
+              <button class="map-mode-btn" data-mode="mpzpskan" type="button">MPZP (skan planu)</button>
               <button class="map-mode-btn" data-mode="studium" type="button">Studium</button>
+              <button class="map-mode-btn" data-mode="uzytkigruntowe" type="button">Użytki gruntowe</button>
             </div>
           </div>
           <div id="propertyMap" role="region" aria-label="Mapa działki"></div>

--- a/edit.html
+++ b/edit.html
@@ -194,14 +194,16 @@
       <section class="property-layout" id="mapSection">
         <div class="map-panel">
           <div class="map-toolbar">
-            <h3>Mapa i lokalizacja</h3>
+            <h3>Mapy</h3>
             <div class="map-modes" role="group" aria-label="Warstwy mapy">
               <button class="map-mode-btn active" data-mode="base" type="button">Mapa</button>
               <button class="map-mode-btn" data-mode="lokalizacja" type="button">Lokalizacja</button>
               <button class="map-mode-btn" data-mode="media" type="button">Media</button>
               <button class="map-mode-btn" data-mode="teren" type="button">Teren</button>
               <button class="map-mode-btn" data-mode="mpzp" type="button">MPZP</button>
+              <button class="map-mode-btn" data-mode="mpzpskan" type="button">MPZP (skan planu)</button>
               <button class="map-mode-btn" data-mode="studium" type="button">Studium</button>
+              <button class="map-mode-btn" data-mode="uzytkigruntowe" type="button">Użytki gruntowe</button>
             </div>
           </div>
           <div id="propertyMap" role="region" aria-label="Mapa działki"></div>


### PR DESCRIPTION
## Summary
- skrócono nazwę sekcji map do "Mapy" oraz dodano brakujące warstwy w widokach details i edit
- rozszerzono konfigurację warstw map o MPZP (skan planu) i Użytki gruntowe wraz z bazowymi URL-ami
- uzupełniono logikę pozyskiwania obrazów map o nowe aliasy i możliwe pola API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce803b9678832bad5c7722e2cb4d0f