### PR TITLE
Add mobile browse offers button to dashboard

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -402,6 +402,10 @@
   font-size:1.5rem;
 }
 
+.user-header .mobile-browse-offers {
+  display:none;
+}
+
 @media (max-width:992px){
   .main-layout {
     flex-direction:column;
@@ -438,6 +442,14 @@
   }
   .user-header { flex-direction:column; gap:1rem; align-items:flex-start; }
   .user-header h2 { font-size:1.3rem; }
+  .user-header .mobile-browse-offers,
+  .user-header #dashboardAddOffer {
+    width:100%;
+    justify-content:center;
+  }
+  .user-header .mobile-browse-offers {
+    display:flex;
+  }
 }
 
 .toast-container {

--- a/index.html
+++ b/index.html
@@ -388,6 +388,9 @@ window.showConfirmModal = showConfirmModal;
   <div class="container user-dashboard" id="userDashboard" style="display:none;">
     <div class="user-header">
       <h2>Moje oferty</h2>
+      <a href="oferty.html" class="btn btn-secondary mobile-browse-offers">
+        <i class="fas fa-search me-1"></i> Przeglądaj oferty
+      </a>
       <a href="dodaj.html" class="btn btn-primary" id="dashboardAddOffer">
         <i class="fas fa-plus me-1"></i> Dodaj ofertę
       </a>


### PR DESCRIPTION
## Summary
- add a "Przeglądaj oferty" link to the dashboard header above the mobile add offer button
- ensure the new link displays only on small screens and stretches both dashboard actions to full width for mobile usability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf1048c150832b968efda1a1c1549b