### PR TITLE
Improve Firebase auth persistence fallbacks

### DIFF
--- a/dodaj.html
+++ b/dodaj.html
@@ -252,18 +252,32 @@
         getAuth, onAuthStateChanged, signOut,
         signInWithEmailAndPassword, createUserWithEmailAndPassword, updateProfile,
         GoogleAuthProvider, signInWithPopup, signInWithRedirect,
-        setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
+        setPersistence, indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
       import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
       const auth = getAuth();
       const db = getFirestore();
 
+      const persistenceOptions = [
+        { label: 'indexedDB', value: indexedDBLocalPersistence },
+        { label: 'local',     value: browserLocalPersistence },
+        { label: 'session',   value: browserSessionPersistence },
+        { label: 'memory',    value: inMemoryPersistence }
+      ];
+
       async function useBestPersistence() {
-        try { await setPersistence(auth, browserLocalPersistence); }
-        catch { try { await setPersistence(auth, browserSessionPersistence); }
-          catch { await setPersistence(auth, inMemoryPersistence); } }
+        for (const option of persistenceOptions) {
+          try {
+            await setPersistence(auth, option.value);
+            return option.label;
+          } catch (error) {
+            console.warn(`[auth] Nie udało się ustawić persystencji ${option.label}.`, error);
+          }
+        }
+        return null;
       }
+
       await useBestPersistence();
 
       const googleProvider = new GoogleAuthProvider();

--- a/index.html
+++ b/index.html
@@ -579,7 +579,7 @@ window.showConfirmModal = showConfirmModal;
       getAuth, onAuthStateChanged, signOut,
       signInWithEmailAndPassword, createUserWithEmailAndPassword, updateProfile,
       GoogleAuthProvider, signInWithPopup, signInWithRedirect,
-      setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
+      setPersistence, indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
     import {
       getFirestore, collection, query, where, getDocs, doc, setDoc, getDoc
@@ -602,11 +602,25 @@ window.showConfirmModal = showConfirmModal;
     auth.languageCode = 'pl';
 
     // Persystencja
+    const persistenceOptions = [
+      { label: 'indexedDB', value: indexedDBLocalPersistence },
+      { label: 'local',     value: browserLocalPersistence },
+      { label: 'session',   value: browserSessionPersistence },
+      { label: 'memory',    value: inMemoryPersistence }
+    ];
+
     async function useBestPersistence() {
-      try { await setPersistence(auth, browserLocalPersistence); }
-      catch { try { await setPersistence(auth, browserSessionPersistence); }
-      catch { await setPersistence(auth, inMemoryPersistence); } }
+      for (const option of persistenceOptions) {
+        try {
+          await setPersistence(auth, option.value);
+          return option.label;
+        } catch (error) {
+          console.warn(`[auth] Nie udało się ustawić persystencji ${option.label}.`, error);
+        }
+      }
+      return null;
     }
+
     await useBestPersistence();
 
     const REGISTER_PROMPT_KEY = 'grunteo.registerPrompt';

--- a/oferty.html
+++ b/oferty.html
@@ -1344,7 +1344,7 @@ window.showConfirmModal = showConfirmModal;
     getAuth, onAuthStateChanged, signOut,
     signInWithEmailAndPassword, createUserWithEmailAndPassword, updateProfile, sendEmailVerification,
     GoogleAuthProvider, signInWithPopup, signInWithRedirect,
-    setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
+    setPersistence, indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
   } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
   import {
     getFirestore, doc, setDoc, getDoc, updateDoc,
@@ -1367,9 +1367,26 @@ window.showConfirmModal = showConfirmModal;
   const db   = getFirestore(app);
   auth.languageCode = 'pl';
 
-  try { await setPersistence(auth, browserLocalPersistence); }
-  catch { try { await setPersistence(auth, browserSessionPersistence); }
-  catch { await setPersistence(auth, inMemoryPersistence); } }
+  const persistenceOptions = [
+    { label: 'indexedDB', value: indexedDBLocalPersistence },
+    { label: 'local',     value: browserLocalPersistence },
+    { label: 'session',   value: browserSessionPersistence },
+    { label: 'memory',    value: inMemoryPersistence }
+  ];
+
+  async function useBestPersistence() {
+    for (const option of persistenceOptions) {
+      try {
+        await setPersistence(auth, option.value);
+        return option.label;
+      } catch (error) {
+        console.warn(`[auth] Nie udało się ustawić persystencji ${option.label}.`, error);
+      }
+    }
+    return null;
+  }
+
+  await useBestPersistence();
 
   const REGISTER_PROMPT_KEY = 'grunteo.registerPrompt';
 


### PR DESCRIPTION
## Summary
- extend Firebase authentication scripts to prefer indexedDB persistence before falling back to session or in-memory storage
- ensure shared property utilities initialize auth with the same persistence priority for pages that reuse the common module

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d18bdbcf8c832bab3d7c812204de99