### PR TITLE
Improve auth initialization persistence handling

### DIFF
--- a/dodaj.html
+++ b/dodaj.html
@@ -43,10 +43,18 @@
 
   <!-- Firebase SDK (APP, Firestore, Analytics, Auth) -->
   <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+    import { initializeApp, getApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
     import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-analytics.js";
     import { getFirestore, collection, addDoc, getDoc, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-    import { getAuth } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+    import {
+      initializeAuth,
+      getAuth,
+      setPersistence,
+      indexedDBLocalPersistence,
+      browserLocalPersistence,
+      browserSessionPersistence,
+      inMemoryPersistence
+    } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
     const firebaseConfig = {
       apiKey: "AIzaSyBdhMIiqetOfDGP85ERxtgwn3AXR50pBcE",
@@ -57,10 +65,65 @@
       appId: "1:829161895559:web:d832541aac05b35847ea22"
     };
 
-    const app = initializeApp(firebaseConfig);
+    const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
     getAnalytics(app);
     const db = getFirestore(app);
-    const auth = getAuth(app);
+
+    const globalScope = typeof window !== 'undefined' ? window : globalThis;
+    const persistenceState = globalScope.__firebaseAuthPersistence || { configured: false, label: null };
+    if (!globalScope.__firebaseAuthPersistence) {
+      globalScope.__firebaseAuthPersistence = persistenceState;
+    }
+
+    const persistenceOptions = [
+      { label: 'indexedDB', value: indexedDBLocalPersistence },
+      { label: 'local',     value: browserLocalPersistence },
+      { label: 'session',   value: browserSessionPersistence },
+      { label: 'memory',    value: inMemoryPersistence }
+    ];
+
+    const markPersistence = (label) => {
+      persistenceState.configured = true;
+      persistenceState.label = label;
+    };
+
+    function setupAuth() {
+      try {
+        const authInstance = initializeAuth(app, {
+          persistence: persistenceOptions.map((option) => option.value)
+        });
+        markPersistence(persistenceOptions[0].label);
+        return { auth: authInstance, skipPersistence: true };
+      } catch (error) {
+        if (error?.code !== 'auth/already-initialized') {
+          console.warn('[auth] initializeAuth nie powiodło się, używam getAuth().', error);
+        }
+        return {
+          auth: getAuth(app),
+          skipPersistence: persistenceState.configured
+        };
+      }
+    }
+
+    async function configurePersistence(authInstance, skipPersistence) {
+      if (skipPersistence) {
+        return persistenceState.label;
+      }
+      for (const option of persistenceOptions) {
+        try {
+          await setPersistence(authInstance, option.value);
+          markPersistence(option.label);
+          return option.label;
+        } catch (error) {
+          console.warn(`[auth] Nie udało się ustawić persystencji ${option.label}.`, error);
+        }
+      }
+      return null;
+    }
+
+    const { auth, skipPersistence } = setupAuth();
+    auth.languageCode = 'pl';
+    await configurePersistence(auth, skipPersistence);
 
     // Udostępniamy do zwykłych skryptów
     window.db = db;
@@ -252,19 +315,48 @@
         getAuth, onAuthStateChanged, signOut,
         signInWithEmailAndPassword, createUserWithEmailAndPassword, updateProfile,
         GoogleAuthProvider, signInWithPopup, signInWithRedirect,
-        setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
+        setPersistence, indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
       import { getFirestore, doc, setDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
       const auth = getAuth();
       const db = getFirestore();
 
-      async function useBestPersistence() {
-        try { await setPersistence(auth, browserLocalPersistence); }
-        catch { try { await setPersistence(auth, browserSessionPersistence); }
-          catch { await setPersistence(auth, inMemoryPersistence); } }
+      const globalScope = typeof window !== 'undefined' ? window : globalThis;
+      const persistenceState = globalScope.__firebaseAuthPersistence || { configured: false, label: null };
+      if (!globalScope.__firebaseAuthPersistence) {
+        globalScope.__firebaseAuthPersistence = persistenceState;
       }
-      await useBestPersistence();
+
+      const persistenceOptions = [
+        { label: 'indexedDB', value: indexedDBLocalPersistence },
+        { label: 'local',     value: browserLocalPersistence },
+        { label: 'session',   value: browserSessionPersistence },
+        { label: 'memory',    value: inMemoryPersistence }
+      ];
+
+      const markPersistence = (label) => {
+        persistenceState.configured = true;
+        persistenceState.label = label;
+      };
+
+      async function ensurePersistence(skipIfConfigured = true) {
+        if (skipIfConfigured && persistenceState.configured) {
+          return persistenceState.label;
+        }
+        for (const option of persistenceOptions) {
+          try {
+            await setPersistence(auth, option.value);
+            markPersistence(option.label);
+            return option.label;
+          } catch (error) {
+            console.warn(`[auth] Nie udało się ustawić persystencji ${option.label}.`, error);
+          }
+        }
+        return null;
+      }
+
+      await ensurePersistence();
 
       const googleProvider = new GoogleAuthProvider();
       googleProvider.setCustomParameters({ prompt: 'select_account' });

--- a/index.html
+++ b/index.html
@@ -574,12 +574,13 @@ window.showConfirmModal = showConfirmModal;
 
   <!-- Firebase + logika aplikacji -->
   <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+    import { initializeApp, getApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
     import {
+      initializeAuth,
       getAuth, onAuthStateChanged, signOut,
       signInWithEmailAndPassword, createUserWithEmailAndPassword, updateProfile,
       GoogleAuthProvider, signInWithPopup, signInWithRedirect,
-      setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
+      setPersistence, indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
     import {
       getFirestore, collection, query, where, getDocs, doc, setDoc, getDoc
@@ -596,18 +597,64 @@ window.showConfirmModal = showConfirmModal;
     };
 
     // --- Init ---
-    const app  = initializeApp(firebaseConfig);
-    const auth = getAuth(app);
+    const app  = getApps().length ? getApp() : initializeApp(firebaseConfig);
     const db   = getFirestore(app);
-    auth.languageCode = 'pl';
 
-    // Persystencja
-    async function useBestPersistence() {
-      try { await setPersistence(auth, browserLocalPersistence); }
-      catch { try { await setPersistence(auth, browserSessionPersistence); }
-      catch { await setPersistence(auth, inMemoryPersistence); } }
+    const globalScope = typeof window !== 'undefined' ? window : globalThis;
+    const persistenceState = globalScope.__firebaseAuthPersistence || { configured: false, label: null };
+    if (!globalScope.__firebaseAuthPersistence) {
+      globalScope.__firebaseAuthPersistence = persistenceState;
     }
-    await useBestPersistence();
+
+    const persistenceOptions = [
+      { label: 'indexedDB', value: indexedDBLocalPersistence },
+      { label: 'local',     value: browserLocalPersistence },
+      { label: 'session',   value: browserSessionPersistence },
+      { label: 'memory',    value: inMemoryPersistence }
+    ];
+
+    const markPersistence = (label) => {
+      persistenceState.configured = true;
+      persistenceState.label = label;
+    };
+
+    function setupAuth() {
+      try {
+        const authInstance = initializeAuth(app, {
+          persistence: persistenceOptions.map((option) => option.value)
+        });
+        markPersistence(persistenceOptions[0].label);
+        return { auth: authInstance, skipPersistence: true };
+      } catch (error) {
+        if (error?.code !== 'auth/already-initialized') {
+          console.warn('[auth] initializeAuth nie powiodło się, używam getAuth().', error);
+        }
+        return {
+          auth: getAuth(app),
+          skipPersistence: persistenceState.configured
+        };
+      }
+    }
+
+    async function configurePersistence(authInstance, skipPersistence) {
+      if (skipPersistence) {
+        return persistenceState.label;
+      }
+      for (const option of persistenceOptions) {
+        try {
+          await setPersistence(authInstance, option.value);
+          markPersistence(option.label);
+          return option.label;
+        } catch (error) {
+          console.warn(`[auth] Nie udało się ustawić persystencji ${option.label}.`, error);
+        }
+      }
+      return null;
+    }
+
+    const { auth, skipPersistence } = setupAuth();
+    auth.languageCode = 'pl';
+    await configurePersistence(auth, skipPersistence);
 
     const REGISTER_PROMPT_KEY = 'grunteo.registerPrompt';
 

--- a/oferty.html
+++ b/oferty.html
@@ -1341,10 +1341,11 @@ window.showConfirmModal = showConfirmModal;
 <script type="module">
   import { initializeApp, getApp, getApps } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
   import {
+    initializeAuth,
     getAuth, onAuthStateChanged, signOut,
     signInWithEmailAndPassword, createUserWithEmailAndPassword, updateProfile, sendEmailVerification,
     GoogleAuthProvider, signInWithPopup, signInWithRedirect,
-    setPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
+    setPersistence, indexedDBLocalPersistence, browserLocalPersistence, browserSessionPersistence, inMemoryPersistence
   } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
   import {
     getFirestore, doc, setDoc, getDoc, updateDoc,
@@ -1363,13 +1364,63 @@ window.showConfirmModal = showConfirmModal;
 
   // --- INIT ---
   const app  = getApps().length ? getApp() : initializeApp(firebaseConfig);
-  const auth = getAuth(app);
   const db   = getFirestore(app);
-  auth.languageCode = 'pl';
 
-  try { await setPersistence(auth, browserLocalPersistence); }
-  catch { try { await setPersistence(auth, browserSessionPersistence); }
-  catch { await setPersistence(auth, inMemoryPersistence); } }
+  const globalScope = typeof window !== 'undefined' ? window : globalThis;
+  const persistenceState = globalScope.__firebaseAuthPersistence || { configured: false, label: null };
+  if (!globalScope.__firebaseAuthPersistence) {
+    globalScope.__firebaseAuthPersistence = persistenceState;
+  }
+
+  const persistenceOptions = [
+    { label: 'indexedDB', value: indexedDBLocalPersistence },
+    { label: 'local',     value: browserLocalPersistence },
+    { label: 'session',   value: browserSessionPersistence },
+    { label: 'memory',    value: inMemoryPersistence }
+  ];
+
+  const markPersistence = (label) => {
+    persistenceState.configured = true;
+    persistenceState.label = label;
+  };
+
+  function setupAuth() {
+    try {
+      const authInstance = initializeAuth(app, {
+        persistence: persistenceOptions.map((option) => option.value)
+      });
+      markPersistence(persistenceOptions[0].label);
+      return { auth: authInstance, skipPersistence: true };
+    } catch (error) {
+      if (error?.code !== 'auth/already-initialized') {
+        console.warn('[auth] initializeAuth nie powiodło się, używam getAuth().', error);
+      }
+      return {
+        auth: getAuth(app),
+        skipPersistence: persistenceState.configured
+      };
+    }
+  }
+
+  async function configurePersistence(authInstance, skipPersistence) {
+    if (skipPersistence) {
+      return persistenceState.label;
+    }
+    for (const option of persistenceOptions) {
+      try {
+        await setPersistence(authInstance, option.value);
+        markPersistence(option.label);
+        return option.label;
+      } catch (error) {
+        console.warn(`[auth] Nie udało się ustawić persystencji ${option.label}.`, error);
+      }
+    }
+    return null;
+  }
+
+  const { auth, skipPersistence } = setupAuth();
+  auth.languageCode = 'pl';
+  await configurePersistence(auth, skipPersistence);
 
   const REGISTER_PROMPT_KEY = 'grunteo.registerPrompt';
 


### PR DESCRIPTION
## Summary
- initialize Firebase Auth with prioritized persistence during setup, falling back to getAuth only when needed
- share global persistence state so repeated scripts skip redundant configuration and keep sessions stable across tabs
- update home, add-offer, and offers pages to use the unified persistence handling before wiring auth listeners

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d18bdbcf8c832bab3d7c812204de99