### PR TITLE
Add offers cache configuration script

### DIFF
--- a/assets/offers-cache-config.js
+++ b/assets/offers-cache-config.js
@@ -1,0 +1,35 @@
+(function configureOffersCache(global) {
+  const OFFERS_CACHE_KEY = 'grunteo::offers-cache::v1';
+
+  // Aktualizuj wartość w polu `revisionHint` za każdym razem, gdy publikujesz nowe oferty.
+  // Możesz wpisać tutaj np. znacznik czasu ostatniej modyfikacji (ISO 8601).
+  const OFFERS_CACHE_SETTINGS = {
+    revisionHint: '2024-06-10T00:00:00Z',
+    // ttlMs: 5 * 60 * 1000, // odkomentuj i ustaw liczbę milisekund, aby nadpisać domyślny TTL (15 minut)
+    ttlMs: null
+  };
+
+  if (typeof OFFERS_CACHE_SETTINGS.revisionHint === 'string' && OFFERS_CACHE_SETTINGS.revisionHint.trim()) {
+    global.__OFFERS_REVISION_HINT__ = OFFERS_CACHE_SETTINGS.revisionHint.trim();
+  }
+
+  if (Number.isFinite(OFFERS_CACHE_SETTINGS.ttlMs) && OFFERS_CACHE_SETTINGS.ttlMs > 0) {
+    global.__OFFERS_CACHE_TTL_MS__ = OFFERS_CACHE_SETTINGS.ttlMs;
+  }
+
+  global.bumpOffersRevisionHint = function bumpOffersRevisionHint(nextHint) {
+    const resolvedHint = typeof nextHint === 'string' && nextHint.trim()
+      ? nextHint.trim()
+      : new Date().toISOString();
+
+    global.__OFFERS_REVISION_HINT__ = resolvedHint;
+
+    try {
+      global.localStorage?.removeItem(OFFERS_CACHE_KEY);
+    } catch (error) {
+      console.warn('Nie udało się wyczyścić cache ofert przy bumpOffersRevisionHint:', error);
+    }
+
+    return resolvedHint;
+  };
+})(window);

--- a/oferty.html
+++ b/oferty.html
@@ -39,6 +39,7 @@
   <link rel="stylesheet" href="assets/main.css" />
   <link rel="stylesheet" href="assets/header.css" />
   <link rel="stylesheet" href="assets/oferty.css" />
+  <script src="assets/offers-cache-config.js"></script>
   <!-- Google tag (gtag.js) -->
   <script type="text/plain" data-cookie-consent="analytics" data-cookie-src="https://www.googletagmanager.com/gtag/js?id=G-VH07LRZ8GK" data-cookie-async="true"></script>
   <script type="text/plain" data-cookie-consent="analytics">


### PR DESCRIPTION
## Summary
- add a configurable offers cache script with revision hint and optional TTL override
- include the new cache configuration on the offers page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c7c6ccb8832bac127d764f79bf5c