### PR TITLE
Remove new-tab behaviour across site

### DIFF
--- a/details.html
+++ b/details.html
@@ -318,19 +318,19 @@
           <div class="share-actions" role="group" aria-label="Udostępnij ofertę">
             <span class="share-actions-label">Udostępnij poprzez:</span>
             <div class="share-buttons">
-              <a href="#" id="shareMessenger" class="share-btn messenger" target="_blank" rel="noopener noreferrer" aria-label="Wyślij na Messengerze">
+              <a href="#" id="shareMessenger" class="share-btn messenger" rel="noopener noreferrer" aria-label="Wyślij na Messengerze">
                 <i class="fab fa-facebook-messenger" aria-hidden="true"></i>
                 <span>Messenger</span>
               </a>
-              <a href="#" id="shareWhatsapp" class="share-btn whatsapp" target="_blank" rel="noopener noreferrer" aria-label="Wyślij na WhatsAppie">
+              <a href="#" id="shareWhatsapp" class="share-btn whatsapp" rel="noopener noreferrer" aria-label="Wyślij na WhatsAppie">
                 <i class="fab fa-whatsapp" aria-hidden="true"></i>
                 <span>WhatsApp</span>
               </a>
-              <a href="#" id="shareX" class="share-btn x" target="_blank" rel="noopener noreferrer" aria-label="Udostępnij na X">
+              <a href="#" id="shareX" class="share-btn x" rel="noopener noreferrer" aria-label="Udostępnij na X">
                 <i class="fab fa-x-twitter" aria-hidden="true"></i>
                 <span>X</span>
               </a>
-              <a href="#" id="shareFacebook" class="share-btn facebook" target="_blank" rel="noopener noreferrer" aria-label="Udostępnij na Facebooku">
+              <a href="#" id="shareFacebook" class="share-btn facebook" rel="noopener noreferrer" aria-label="Udostępnij na Facebooku">
                 <i class="fab fa-facebook-f" aria-hidden="true"></i>
                 <span>Facebook</span>
               </a>

--- a/dodaj.html
+++ b/dodaj.html
@@ -542,7 +542,7 @@
 
           <div class="form-check mb-2">
             <input class="form-check-input" type="checkbox" id="termsConsent" required />
-            <label class="form-check-label" for="termsConsent">Zapoznałem się z <a href="RODO.html" target="_blank" rel="noopener">RODO</a> i <a href="polityka-prywatnosci.html" target="_blank" rel="noopener">Polityką prywatności</a> oraz akceptuję ich treść *</label>
+            <label class="form-check-label" for="termsConsent">Zapoznałem się z <a href="RODO.html" rel="noopener">RODO</a> i <a href="polityka-prywatnosci.html" rel="noopener">Polityką prywatności</a> oraz akceptuję ich treść *</label>
           </div>
 
           <div class="form-check mb-3">
@@ -555,7 +555,7 @@
       </form>
 
       <div class="privacy-text">
-        Za przetwarzanie danych osobowych podanych w formularzu odpowiada Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Współadministratorem pozostaje Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Zasady przetwarzania opisaliśmy w <a href="RODO.html" target="_blank" rel="noopener">Informacji RODO</a> oraz <a href="polityka-prywatnosci.html" target="_blank" rel="noopener">Polityce prywatności</a>. Masz prawo odwołać zgody w dowolnym momencie.
+        Za przetwarzanie danych osobowych podanych w formularzu odpowiada Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Współadministratorem pozostaje Grunteo, ul. Edwarda Suchardy 4, 50-362 Wrocław. Zasady przetwarzania opisaliśmy w <a href="RODO.html" rel="noopener">Informacji RODO</a> oraz <a href="polityka-prywatnosci.html" rel="noopener">Polityce prywatności</a>. Masz prawo odwołać zgody w dowolnym momencie.
       </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -1026,7 +1026,7 @@ window.showConfirmModal = showConfirmModal;
                   </p>` : ''}
                 </div>
                 <div class="offer-actions">
-                  <a class="btn btn-accent btn-sm" target="_blank" href="${detailsUrl}">
+                  <a class="btn btn-accent btn-sm" href="${detailsUrl}">
                     <i class="fas fa-info-circle"></i> Szczegóły
                   </a>
                   <button class="btn btn-primary btn-sm" onclick="window.location.href='edit.html?id=${offerId}&plot=${originalIndex}'">
@@ -1138,7 +1138,7 @@ window.showConfirmModal = showConfirmModal;
           ${savedAtText ? `<p class="favorite-meta"><strong>Zapisano:</strong> ${savedAtText}</p>` : ''}
         </div>
         <div class="offer-actions">
-          <a class="btn btn-accent btn-sm" ${offerId ? `target="_blank" href="${detailsUrl}"` : 'href="#" aria-disabled="true" style="pointer-events:none;opacity:.6;"'}>
+          <a class="btn btn-accent btn-sm" ${offerId ? `href="${detailsUrl}"` : 'href="#" aria-disabled="true" style="pointer-events:none;opacity:.6;"'}>
             <i class="fas fa-info-circle"></i> Szczegóły
           </a>
           <button class="btn btn-secondary btn-sm favorite-remove" type="button">
@@ -1150,7 +1150,7 @@ window.showConfirmModal = showConfirmModal;
       card.addEventListener('click', (event) => {
         if (event.target.closest('.offer-actions')) return;
         if (offerId) {
-          window.open(detailsUrl, '_blank');
+          window.location.href = detailsUrl;
         }
       });
 

--- a/oferty.html
+++ b/oferty.html
@@ -980,7 +980,6 @@ window.showConfirmModal = showConfirmModal;
         <div class="mini-actions center">
           <a
             class="btn-mini"
-            target="_blank"
             href="${detailsUrl}"
             data-preserve-map-state="true"
             ${offerId ? `data-offer-id="${offerId}"` : ''}
@@ -1502,7 +1501,6 @@ window.showConfirmModal = showConfirmModal;
         <div class="offer-actions center">
           <a
             class="btn btn-accent btn-sm"
-            target="_blank"
             href="${detailsUrl}"
             data-preserve-map-state="true"
             ${o.id ? `data-offer-id="${o.id}"` : ''}
@@ -2001,7 +1999,6 @@ async function loadUserOffers(email, uid) {
           <div class="offer-actions">
             <a
               class="btn btn-accent btn-sm"
-              target="_blank"
               href="${detailsUrl}"
               data-preserve-map-state="true"
               ${offerId ? `data-offer-id="${offerId}"` : ''}


### PR DESCRIPTION
## Summary
- open offer details and saved listings in the same tab instead of creating new browser windows
- update share and privacy links to avoid forcing a new tab when clicked

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3b3d40100832bb06e58c11ac5a366