### PR TITLE
Remove unused proj4 script from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
   <link rel="canonical" href="https://grunteo.pl/" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.8.0/proj4.js"></script>
   <link rel="icon" type="image/svg+xml" href="https://grunteo.pl/brand/logo-mark.svg" />
   <link rel="apple-touch-icon" sizes="180x180" href="https://grunteo.pl/brand/apple-touch-icon.png" />
   <link rel="icon" type="image/png" sizes="32x32" href="https://grunteo.pl/brand/favicon-32x32.png" />


### PR DESCRIPTION
## Summary
- remove the proj4.js CDN include from the homepage since the script is unused there

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3dcd2908c832ba1e85f67493a82a5