### PR TITLE
Remove tag counts from offers filters

### DIFF
--- a/oferty.html
+++ b/oferty.html
@@ -1232,13 +1232,6 @@ window.showConfirmModal = showConfirmModal;
     const countValue = displayCounts?.get(tag);
     const numericCount = Number.isFinite(countValue) ? countValue : (Number(tagMetrics.get(tag)) || 0);
 
-    if (Number.isFinite(numericCount)) {
-      const countSpan = document.createElement('span');
-      countSpan.className = 'tag-chip__count';
-      countSpan.textContent = `(${numericCount})`;
-      chip.appendChild(countSpan);
-    }
-
     const compatibleCount = Number.isFinite(countValue) ? countValue : 0;
     const isCompatible = filterState.selectedTags.size > 0 && !isActive && compatibleCount > 0;
     chip.classList.toggle('is-compatible', isCompatible);
@@ -1325,7 +1318,7 @@ window.showConfirmModal = showConfirmModal;
     if (toggleTagsBtn) {
       if (shouldShowToggle) {
         toggleTagsBtn.hidden = false;
-        toggleTagsBtn.textContent = tagsExpanded ? 'Ukryj tagi' : `Pokaż wszystkie tagi (${availableTags.length})`;
+        toggleTagsBtn.textContent = tagsExpanded ? 'Ukryj tagi' : 'Pokaż wszystkie tagi';
         toggleTagsBtn.setAttribute('aria-expanded', tagsExpanded ? 'true' : 'false');
         toggleTagsBtn.dataset.state = tagsExpanded ? 'expanded' : 'collapsed';
       } else {


### PR DESCRIPTION
## Summary
- hide numeric counters on offer tag chips so only tag labels render
- adjust the "Pokaż wszystkie tagi" toggle button to omit the total tag count

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d66ed9eaa0832ba624c6ec6ee71dd9