### PR TITLE
Allow multiline formatting in property detail fields

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -567,6 +567,93 @@ body.lightbox-open {
   margin-bottom: .25rem;
 }
 
+.plan-notes a,
+.description-text a,
+.location-text a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.plan-notes pre,
+.description-text pre,
+.location-text pre {
+  margin: .75rem 0;
+  padding: .85rem 1rem;
+  border-radius: 10px;
+  background: #f1f5f9;
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.plan-notes code,
+.description-text code,
+.location-text code {
+  padding: .1rem .35rem;
+  border-radius: 6px;
+  background: rgba(30,111,186,.12);
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9em;
+}
+
+.plan-notes blockquote,
+.description-text blockquote,
+.location-text blockquote {
+  margin: .75rem 0;
+  padding-left: 1rem;
+  border-left: 3px solid rgba(30,111,186,.35);
+  color: #334155;
+  font-style: italic;
+}
+
+.plan-notes h1,
+.plan-notes h2,
+.plan-notes h3,
+.plan-notes h4,
+.plan-notes h5,
+.plan-notes h6,
+.description-text h1,
+.description-text h2,
+.description-text h3,
+.description-text h4,
+.description-text h5,
+.description-text h6,
+.location-text h1,
+.location-text h2,
+.location-text h3,
+.location-text h4,
+.location-text h5,
+.location-text h6 {
+  margin: .85rem 0 .35rem;
+  color: var(--darker);
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+.plan-notes h1,
+.description-text h1,
+.location-text h1 { font-size: 1.4rem; }
+.plan-notes h2,
+.description-text h2,
+.location-text h2 { font-size: 1.3rem; }
+.plan-notes h3,
+.description-text h3,
+.location-text h3 { font-size: 1.18rem; }
+.plan-notes h4,
+.description-text h4,
+.location-text h4 { font-size: 1.08rem; }
+.plan-notes h5,
+.description-text h5,
+.location-text h5 { font-size: 1rem; }
+.plan-notes h6,
+.description-text h6,
+.location-text h6 { font-size: .95rem; }
+
 .rt-align-left {
   text-align: left;
 }

--- a/assets/details.css
+++ b/assets/details.css
@@ -671,15 +671,15 @@ body.lightbox-open {
 }
 
 .rt-size-small {
-  font-size: .9rem;
+  font-size: .85rem;
 }
 
 .rt-size-normal {
-  font-size: .95rem;
+  font-size: 1rem;
 }
 
 .rt-size-large {
-  font-size: 1.05rem;
+  font-size: 1.2rem;
 }
 
 .tags-card {

--- a/assets/details.css
+++ b/assets/details.css
@@ -82,6 +82,10 @@ main.property-wrapper {
   font-size: .85rem;
 }
 
+.meta-chip span {
+  white-space: pre-wrap;
+}
+
 .meta-chip i {
   color: var(--primary);
 }
@@ -148,6 +152,7 @@ main.property-wrapper {
   font-size: 1rem;
   font-weight: 600;
   color: var(--darker);
+  white-space: pre-wrap;
 }
 
 .property-layout {
@@ -410,6 +415,7 @@ body.lightbox-open {
   margin: 0;
   color: var(--darker);
   font-size: .95rem;
+  white-space: pre-wrap;
   text-align: justify;
 }
 
@@ -467,6 +473,7 @@ body.lightbox-open {
   font-size: .95rem;
   font-weight: 600;
   color: var(--darker);
+  white-space: pre-wrap;
 }
 
 .plan-notes {

--- a/assets/details.css
+++ b/assets/details.css
@@ -411,7 +411,8 @@ body.lightbox-open {
   font-size: 1rem;
 }
 
-.location-card p {
+.location-card p,
+.location-card .location-text {
   margin: 0;
   color: var(--darker);
   font-size: .95rem;
@@ -542,6 +543,56 @@ body.lightbox-open {
   color: var(--darker);
   line-height: 1.6;
   text-align: justify;
+}
+
+.plan-notes,
+.description-text,
+.location-text {
+  display: block;
+}
+
+.plan-notes ul,
+.plan-notes ol,
+.description-text ul,
+.description-text ol,
+.location-text ul,
+.location-text ol {
+  padding-left: 1.4rem;
+  margin: .4rem 0;
+}
+
+.plan-notes li,
+.description-text li,
+.location-text li {
+  margin-bottom: .25rem;
+}
+
+.rt-align-left {
+  text-align: left;
+}
+
+.rt-align-center {
+  text-align: center;
+}
+
+.rt-align-right {
+  text-align: right;
+}
+
+.rt-align-justify {
+  text-align: justify;
+}
+
+.rt-size-small {
+  font-size: .9rem;
+}
+
+.rt-size-normal {
+  font-size: .95rem;
+}
+
+.rt-size-large {
+  font-size: 1.05rem;
 }
 
 .tags-card {

--- a/assets/details.css
+++ b/assets/details.css
@@ -671,7 +671,7 @@ body.lightbox-open {
 }
 
 .rt-size-small {
-  font-size: .85rem;
+  font-size: .82rem;
 }
 
 .rt-size-normal {
@@ -679,7 +679,7 @@ body.lightbox-open {
 }
 
 .rt-size-large {
-  font-size: 1.2rem;
+  font-size: 1.35rem;
 }
 
 .tags-card {

--- a/assets/details.js
+++ b/assets/details.js
@@ -15,10 +15,12 @@ import {
   showToast,
   textContentOrFallback,
   sanitizeMultilineText,
+  sanitizeRichText,
   ensureArray,
   parseNumberFromText,
   syncMobileMenu,
-  setDoc
+  setDoc,
+  richTextToPlainText
 } from './property-common.js';
 import {
   signInWithEmailAndPassword,
@@ -301,6 +303,17 @@ function setMultilineText(element, value, fallback = '') {
     ? fallback
     : sanitizeMultilineText(value);
   element.textContent = text;
+}
+
+function setRichTextContent(element, value, fallback = '') {
+  if (!element) return;
+  const sanitized = sanitizeRichText(value || '');
+  const plain = richTextToPlainText(sanitized).trim();
+  if (plain) {
+    element.innerHTML = sanitized;
+  } else {
+    element.textContent = fallback;
+  }
 }
 
 function normalizeLayerKey(key) {
@@ -1118,21 +1131,21 @@ function renderOffer(data, plot) {
   setTextContent(elements.plotStatus, pickValue(plot.status, plot.offerStatus, data.status), '');
 
   setMultilineText(elements.locationAddress, pickValue(plot.locationAddress, data.address, plot.address), '');
-  setMultilineText(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access), '');
+  setRichTextContent(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access), '');
 
   renderPlanBadges(pickValue(plot.planBadges, data.planBadges));
   setTextContent(elements.planDesignation, pickValue(plot.planDesignation, plot.planUsage, data.planDesignation), '');
   setTextContent(elements.planHeight, pickValue(plot.planHeight, data.planHeight), '');
   setTextContent(elements.planIntensity, pickValue(plot.planIntensity, data.planIntensity), '');
   setTextContent(elements.planGreen, pickValue(plot.planGreen, data.planGreen), '');
-  setMultilineText(elements.planNotes, pickValue(plot.planNotes, data.planNotes), '');
+  setRichTextContent(elements.planNotes, pickValue(plot.planNotes, data.planNotes), '');
 
   updateMapImages(collectMapImages(plot, data, state.plotIndex, state.offerId));
 
   const utilities = mergeUtilities(data.utilities, plot.utilities);
   renderUtilities(utilities);
 
-  setMultilineText(elements.descriptionText, pickValue(plot.description, data.description), '');
+  setRichTextContent(elements.descriptionText, pickValue(plot.description, data.description), '');
 
   renderTags(pickValue(plot.tags, data.tags));
 

--- a/assets/edit.css
+++ b/assets/edit.css
@@ -318,15 +318,15 @@
 }
 
 .rt-size-small {
-  font-size: .9rem;
+  font-size: .85rem;
 }
 
 .rt-size-normal {
-  font-size: .95rem;
+  font-size: 1rem;
 }
 
 .rt-size-large {
-  font-size: 1.05rem;
+  font-size: 1.2rem;
 }
 
 .rich-text-area ul,

--- a/assets/edit.css
+++ b/assets/edit.css
@@ -318,7 +318,7 @@
 }
 
 .rt-size-small {
-  font-size: .85rem;
+  font-size: .82rem;
 }
 
 .rt-size-normal {
@@ -326,7 +326,7 @@
 }
 
 .rt-size-large {
-  font-size: 1.2rem;
+  font-size: 1.35rem;
 }
 
 .rich-text-area ul,

--- a/assets/edit.css
+++ b/assets/edit.css
@@ -13,6 +13,7 @@
   transition: outline-color .15s ease, background-color .15s ease;
   border-radius: 6px;
   cursor: text;
+  white-space: pre-wrap;
 }
 
 [contenteditable="true"]:hover {

--- a/assets/edit.css
+++ b/assets/edit.css
@@ -202,6 +202,158 @@
   padding-right: .5rem;
 }
 
+.location-card .location-text {
+  color: var(--darker);
+  font-size: .95rem;
+  line-height: 1.6;
+  white-space: normal;
+}
+
+.rich-text-editor {
+  display: flex;
+  flex-direction: column;
+  gap: .6rem;
+}
+
+.rich-text-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem;
+  align-items: center;
+}
+
+.rich-text-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid rgba(30,111,186,.22);
+  background: #fff;
+  color: var(--darker);
+  cursor: pointer;
+  transition: background-color .15s ease, border-color .15s ease, color .15s ease, box-shadow .15s ease;
+}
+
+.rich-text-btn i {
+  font-size: .8rem;
+}
+
+.rich-text-btn:hover,
+.rich-text-btn:focus-visible {
+  background: #e6f2ff;
+  border-color: rgba(30,111,186,.45);
+  color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(30,111,186,.18);
+}
+
+.rich-text-btn:focus-visible {
+  outline: none;
+}
+
+.rich-text-select {
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid rgba(30,111,186,.22);
+  padding: 0 .8rem;
+  font-size: .9rem;
+  color: var(--darker);
+  cursor: pointer;
+  background: #fff;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.rich-text-select:focus {
+  outline: none;
+  border-color: rgba(30,111,186,.45);
+  box-shadow: 0 0 0 2px rgba(30,111,186,.18);
+}
+
+.rich-text-divider {
+  width: 1px;
+  height: 24px;
+  background: rgba(30,111,186,.18);
+}
+
+.rich-text-area[contenteditable="true"] {
+  min-height: 160px;
+  padding: .9rem 1rem;
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid rgba(30,111,186,.18);
+  white-space: normal;
+  line-height: 1.6;
+  font-size: .95rem;
+  color: var(--darker);
+  box-shadow: inset 0 1px 2px rgba(15,23,42,.04);
+}
+
+.location-card .rich-text-area[contenteditable="true"] {
+  min-height: 140px;
+}
+
+.plan-panel .rich-text-area[contenteditable="true"] {
+  min-height: 140px;
+}
+
+.rich-text-area[contenteditable="true"]:focus {
+  background: rgba(30,111,186,.05);
+}
+
+.rt-align-left {
+  text-align: left;
+}
+
+.rt-align-center {
+  text-align: center;
+}
+
+.rt-align-right {
+  text-align: right;
+}
+
+.rt-align-justify {
+  text-align: justify;
+}
+
+.rt-size-small {
+  font-size: .9rem;
+}
+
+.rt-size-normal {
+  font-size: .95rem;
+}
+
+.rt-size-large {
+  font-size: 1.05rem;
+}
+
+.rich-text-area ul,
+.rich-text-area ol {
+  padding-left: 1.4rem;
+  margin: .4rem 0;
+}
+
+.rich-text-area li {
+  margin-bottom: .25rem;
+}
+
+@media (max-width: 768px) {
+  .rich-text-toolbar {
+    gap: .3rem;
+  }
+
+  .rich-text-btn,
+  .rich-text-select {
+    height: 32px;
+  }
+
+  .rich-text-btn {
+    width: 32px;
+  }
+}
+
 .tag-chip .tag-remove {
   display: inline-flex;
   align-items: center;

--- a/assets/edit.css
+++ b/assets/edit.css
@@ -339,6 +339,61 @@
   margin-bottom: .25rem;
 }
 
+.rich-text-area a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.rich-text-area pre {
+  margin: .75rem 0;
+  padding: .85rem 1rem;
+  border-radius: 10px;
+  background: #f1f5f9;
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.rich-text-area code {
+  padding: .1rem .35rem;
+  border-radius: 6px;
+  background: rgba(30,111,186,.12);
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9em;
+}
+
+.rich-text-area blockquote {
+  margin: .75rem 0;
+  padding-left: 1rem;
+  border-left: 3px solid rgba(30,111,186,.35);
+  color: #334155;
+  font-style: italic;
+}
+
+.rich-text-area h1,
+.rich-text-area h2,
+.rich-text-area h3,
+.rich-text-area h4,
+.rich-text-area h5,
+.rich-text-area h6 {
+  margin: .85rem 0 .35rem;
+  color: var(--darker);
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+.rich-text-area h1 { font-size: 1.45rem; }
+.rich-text-area h2 { font-size: 1.35rem; }
+.rich-text-area h3 { font-size: 1.2rem; }
+.rich-text-area h4 { font-size: 1.1rem; }
+.rich-text-area h5 { font-size: 1rem; }
+.rich-text-area h6 { font-size: .95rem; }
+
 @media (max-width: 768px) {
   .rich-text-toolbar {
     gap: .3rem;

--- a/assets/edit.js
+++ b/assets/edit.js
@@ -750,15 +750,6 @@ function selectAllText(element) {
   selection.addRange(range);
 }
 
-function preventNewline(element) {
-  if (!element?.isContentEditable) return;
-  element.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-    }
-  });
-}
-
 function attachEditorListeners() {
   if (elements.priceValueText) {
     elements.priceValueText.addEventListener('focus', () => {
@@ -832,7 +823,6 @@ function attachEditorListeners() {
     elements.contactEmailLink
   ].forEach(element => {
     if (!element || !element.isContentEditable) return;
-    preventNewline(element);
     element.addEventListener('blur', () => {
       const text = stripHtml(element.innerHTML).trim();
       element.textContent = text;

--- a/details.html
+++ b/details.html
@@ -199,7 +199,7 @@
             </div>
             <div class="location-card">
               <h4>Dojazd i otoczenie</h4>
-              <p id="locationAccess"></p>
+              <div id="locationAccess" class="location-text"></div>
             </div>
           </div>
         </div>

--- a/edit.html
+++ b/edit.html
@@ -239,6 +239,8 @@
                   <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
                   <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
                   <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="insertHtml" aria-label="Wstaw kod HTML"><i class="fas fa-code"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
                   <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
                 </div>
                 <div id="locationAccess" class="location-text rich-text-area" contenteditable="true">Pole do wypełnienia</div>
@@ -278,6 +280,8 @@
               <div class="rich-text-divider" aria-hidden="true"></div>
               <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
               <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="insertHtml" aria-label="Wstaw kod HTML"><i class="fas fa-code"></i></button>
               <div class="rich-text-divider" aria-hidden="true"></div>
               <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
             </div>
@@ -355,6 +359,8 @@
               <div class="rich-text-divider" aria-hidden="true"></div>
               <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
               <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="insertHtml" aria-label="Wstaw kod HTML"><i class="fas fa-code"></i></button>
               <div class="rich-text-divider" aria-hidden="true"></div>
               <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
             </div>

--- a/edit.html
+++ b/edit.html
@@ -218,7 +218,31 @@
             </div>
             <div class="location-card">
               <h4>Dojazd i otoczenie</h4>
-              <p id="locationAccess" contenteditable="true">Pole do wypełnienia</p>
+              <div class="rich-text-editor" data-editor-target="locationAccess">
+                <div class="rich-text-toolbar" role="toolbar" aria-label="Narzędzia formatowania">
+                  <button type="button" class="rich-text-btn" data-action="bold" aria-label="Pogrubienie"><i class="fas fa-bold"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="italic" aria-label="Kursywa"><i class="fas fa-italic"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="underline" aria-label="Podkreślenie"><i class="fas fa-underline"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <select class="rich-text-select" data-action="fontSize" aria-label="Rozmiar tekstu">
+                    <option value="">Rozmiar</option>
+                    <option value="small">Mały</option>
+                    <option value="normal">Standardowy</option>
+                    <option value="large">Duży</option>
+                  </select>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="left" aria-label="Wyrównaj do lewej"><i class="fas fa-align-left"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="center" aria-label="Wyśrodkuj"><i class="fas fa-align-center"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="right" aria-label="Wyrównaj do prawej"><i class="fas fa-align-right"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="justify" aria-label="Wyjustuj"><i class="fas fa-align-justify"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
+                </div>
+                <div id="locationAccess" class="location-text rich-text-area" contenteditable="true">Pole do wypełnienia</div>
+              </div>
             </div>
           </div>
         </div>
@@ -234,7 +258,31 @@
             <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity" contenteditable="true">Pole do wypełnienia</dd></dl>
             <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen" contenteditable="true">Pole do wypełnienia</dd></dl>
           </div>
-          <div class="plan-notes" id="planNotes" contenteditable="true">Pole do wypełnienia</div>
+          <div class="rich-text-editor" data-editor-target="planNotes">
+            <div class="rich-text-toolbar" role="toolbar" aria-label="Narzędzia formatowania">
+              <button type="button" class="rich-text-btn" data-action="bold" aria-label="Pogrubienie"><i class="fas fa-bold"></i></button>
+              <button type="button" class="rich-text-btn" data-action="italic" aria-label="Kursywa"><i class="fas fa-italic"></i></button>
+              <button type="button" class="rich-text-btn" data-action="underline" aria-label="Podkreślenie"><i class="fas fa-underline"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <select class="rich-text-select" data-action="fontSize" aria-label="Rozmiar tekstu">
+                <option value="">Rozmiar</option>
+                <option value="small">Mały</option>
+                <option value="normal">Standardowy</option>
+                <option value="large">Duży</option>
+              </select>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="left" aria-label="Wyrównaj do lewej"><i class="fas fa-align-left"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="center" aria-label="Wyśrodkuj"><i class="fas fa-align-center"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="right" aria-label="Wyrównaj do prawej"><i class="fas fa-align-right"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="justify" aria-label="Wyjustuj"><i class="fas fa-align-justify"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
+              <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
+            </div>
+            <div class="plan-notes rich-text-area" id="planNotes" contenteditable="true">Pole do wypełnienia</div>
+          </div>
         </aside>
       </section>
 
@@ -287,7 +335,31 @@
           <h2 id="descriptionTitle">Opis szczegółowy</h2>
         </div>
         <div class="description-card">
-          <div id="descriptionText" class="description-text" contenteditable="true">Pole do wypełnienia</div>
+          <div class="rich-text-editor" data-editor-target="descriptionText">
+            <div class="rich-text-toolbar" role="toolbar" aria-label="Narzędzia formatowania">
+              <button type="button" class="rich-text-btn" data-action="bold" aria-label="Pogrubienie"><i class="fas fa-bold"></i></button>
+              <button type="button" class="rich-text-btn" data-action="italic" aria-label="Kursywa"><i class="fas fa-italic"></i></button>
+              <button type="button" class="rich-text-btn" data-action="underline" aria-label="Podkreślenie"><i class="fas fa-underline"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <select class="rich-text-select" data-action="fontSize" aria-label="Rozmiar tekstu">
+                <option value="">Rozmiar</option>
+                <option value="small">Mały</option>
+                <option value="normal">Standardowy</option>
+                <option value="large">Duży</option>
+              </select>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="left" aria-label="Wyrównaj do lewej"><i class="fas fa-align-left"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="center" aria-label="Wyśrodkuj"><i class="fas fa-align-center"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="right" aria-label="Wyrównaj do prawej"><i class="fas fa-align-right"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="justify" aria-label="Wyjustuj"><i class="fas fa-align-justify"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
+              <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
+            </div>
+            <div id="descriptionText" class="description-text rich-text-area" contenteditable="true">Pole do wypełnienia</div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- allow multiline text entry in the editor by preserving whitespace in contenteditable inputs and permitting Enter presses
- keep whitespace in detail view metadata, stats, location and plan sections so multi-line formatting is displayed

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d675e40a78832b960b7836d5ae3275