### PR TITLE
Allow custom font sizes in rich text editors

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -82,6 +82,10 @@ main.property-wrapper {
   font-size: .85rem;
 }
 
+.meta-chip span {
+  white-space: pre-wrap;
+}
+
 .meta-chip i {
   color: var(--primary);
 }
@@ -148,6 +152,7 @@ main.property-wrapper {
   font-size: 1rem;
   font-weight: 600;
   color: var(--darker);
+  white-space: pre-wrap;
 }
 
 .property-layout {
@@ -406,10 +411,12 @@ body.lightbox-open {
   font-size: 1rem;
 }
 
-.location-card p {
+.location-card p,
+.location-card .location-text {
   margin: 0;
   color: var(--darker);
   font-size: .95rem;
+  white-space: pre-wrap;
   text-align: justify;
 }
 
@@ -467,6 +474,7 @@ body.lightbox-open {
   font-size: .95rem;
   font-weight: 600;
   color: var(--darker);
+  white-space: pre-wrap;
 }
 
 .plan-notes {
@@ -535,6 +543,143 @@ body.lightbox-open {
   color: var(--darker);
   line-height: 1.6;
   text-align: justify;
+}
+
+.plan-notes,
+.description-text,
+.location-text {
+  display: block;
+}
+
+.plan-notes ul,
+.plan-notes ol,
+.description-text ul,
+.description-text ol,
+.location-text ul,
+.location-text ol {
+  padding-left: 1.4rem;
+  margin: .4rem 0;
+}
+
+.plan-notes li,
+.description-text li,
+.location-text li {
+  margin-bottom: .25rem;
+}
+
+.plan-notes a,
+.description-text a,
+.location-text a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.plan-notes pre,
+.description-text pre,
+.location-text pre {
+  margin: .75rem 0;
+  padding: .85rem 1rem;
+  border-radius: 10px;
+  background: #f1f5f9;
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.plan-notes code,
+.description-text code,
+.location-text code {
+  padding: .1rem .35rem;
+  border-radius: 6px;
+  background: rgba(30,111,186,.12);
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9em;
+}
+
+.plan-notes blockquote,
+.description-text blockquote,
+.location-text blockquote {
+  margin: .75rem 0;
+  padding-left: 1rem;
+  border-left: 3px solid rgba(30,111,186,.35);
+  color: #334155;
+  font-style: italic;
+}
+
+.plan-notes h1,
+.plan-notes h2,
+.plan-notes h3,
+.plan-notes h4,
+.plan-notes h5,
+.plan-notes h6,
+.description-text h1,
+.description-text h2,
+.description-text h3,
+.description-text h4,
+.description-text h5,
+.description-text h6,
+.location-text h1,
+.location-text h2,
+.location-text h3,
+.location-text h4,
+.location-text h5,
+.location-text h6 {
+  margin: .85rem 0 .35rem;
+  color: var(--darker);
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+.plan-notes h1,
+.description-text h1,
+.location-text h1 { font-size: 1.4rem; }
+.plan-notes h2,
+.description-text h2,
+.location-text h2 { font-size: 1.3rem; }
+.plan-notes h3,
+.description-text h3,
+.location-text h3 { font-size: 1.18rem; }
+.plan-notes h4,
+.description-text h4,
+.location-text h4 { font-size: 1.08rem; }
+.plan-notes h5,
+.description-text h5,
+.location-text h5 { font-size: 1rem; }
+.plan-notes h6,
+.description-text h6,
+.location-text h6 { font-size: .95rem; }
+
+.rt-align-left {
+  text-align: left;
+}
+
+.rt-align-center {
+  text-align: center;
+}
+
+.rt-align-right {
+  text-align: right;
+}
+
+.rt-align-justify {
+  text-align: justify;
+}
+
+.rt-size-small {
+  font-size: .82rem;
+}
+
+.rt-size-normal {
+  font-size: 1rem;
+}
+
+.rt-size-large {
+  font-size: 1.35rem;
 }
 
 .tags-card {

--- a/assets/details.js
+++ b/assets/details.js
@@ -15,10 +15,12 @@ import {
   showToast,
   textContentOrFallback,
   sanitizeMultilineText,
+  sanitizeRichText,
   ensureArray,
   parseNumberFromText,
   syncMobileMenu,
-  setDoc
+  setDoc,
+  richTextToPlainText
 } from './property-common.js';
 import {
   signInWithEmailAndPassword,
@@ -301,6 +303,17 @@ function setMultilineText(element, value, fallback = '') {
     ? fallback
     : sanitizeMultilineText(value);
   element.textContent = text;
+}
+
+function setRichTextContent(element, value, fallback = '') {
+  if (!element) return;
+  const sanitized = sanitizeRichText(value || '');
+  const plain = richTextToPlainText(sanitized).trim();
+  if (plain) {
+    element.innerHTML = sanitized;
+  } else {
+    element.textContent = fallback;
+  }
 }
 
 function normalizeLayerKey(key) {
@@ -1118,21 +1131,21 @@ function renderOffer(data, plot) {
   setTextContent(elements.plotStatus, pickValue(plot.status, plot.offerStatus, data.status), '');
 
   setMultilineText(elements.locationAddress, pickValue(plot.locationAddress, data.address, plot.address), '');
-  setMultilineText(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access), '');
+  setRichTextContent(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access), '');
 
   renderPlanBadges(pickValue(plot.planBadges, data.planBadges));
   setTextContent(elements.planDesignation, pickValue(plot.planDesignation, plot.planUsage, data.planDesignation), '');
   setTextContent(elements.planHeight, pickValue(plot.planHeight, data.planHeight), '');
   setTextContent(elements.planIntensity, pickValue(plot.planIntensity, data.planIntensity), '');
   setTextContent(elements.planGreen, pickValue(plot.planGreen, data.planGreen), '');
-  setMultilineText(elements.planNotes, pickValue(plot.planNotes, data.planNotes), '');
+  setRichTextContent(elements.planNotes, pickValue(plot.planNotes, data.planNotes), '');
 
   updateMapImages(collectMapImages(plot, data, state.plotIndex, state.offerId));
 
   const utilities = mergeUtilities(data.utilities, plot.utilities);
   renderUtilities(utilities);
 
-  setMultilineText(elements.descriptionText, pickValue(plot.description, data.description), '');
+  setRichTextContent(elements.descriptionText, pickValue(plot.description, data.description), '');
 
   renderTags(pickValue(plot.tags, data.tags));
 

--- a/assets/edit.css
+++ b/assets/edit.css
@@ -13,6 +13,7 @@
   transition: outline-color .15s ease, background-color .15s ease;
   border-radius: 6px;
   cursor: text;
+  white-space: pre-wrap;
 }
 
 [contenteditable="true"]:hover {
@@ -199,6 +200,224 @@
   align-items: center;
   gap: .45rem;
   padding-right: .5rem;
+}
+
+.location-card .location-text {
+  color: var(--darker);
+  font-size: .95rem;
+  line-height: 1.6;
+  white-space: normal;
+}
+
+.rich-text-editor {
+  display: flex;
+  flex-direction: column;
+  gap: .6rem;
+}
+
+.rich-text-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem;
+  align-items: center;
+}
+
+.rich-text-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid rgba(30,111,186,.22);
+  background: #fff;
+  color: var(--darker);
+  cursor: pointer;
+  transition: background-color .15s ease, border-color .15s ease, color .15s ease, box-shadow .15s ease;
+}
+
+.rich-text-btn i {
+  font-size: .8rem;
+}
+
+.rich-text-btn:hover,
+.rich-text-btn:focus-visible {
+  background: #e6f2ff;
+  border-color: rgba(30,111,186,.45);
+  color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(30,111,186,.18);
+}
+
+.rich-text-btn:focus-visible {
+  outline: none;
+}
+
+.rich-text-select,
+.rich-text-input {
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid rgba(30,111,186,.22);
+  padding: 0 .8rem;
+  font-size: .9rem;
+  color: var(--darker);
+  background: #fff;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.rich-text-select {
+  cursor: pointer;
+}
+
+.rich-text-input {
+  width: 120px;
+  cursor: text;
+}
+
+.rich-text-select:focus,
+.rich-text-input:focus {
+  outline: none;
+  border-color: rgba(30,111,186,.45);
+  box-shadow: 0 0 0 2px rgba(30,111,186,.18);
+}
+
+.rich-text-divider {
+  width: 1px;
+  height: 24px;
+  background: rgba(30,111,186,.18);
+}
+
+.rich-text-area[contenteditable="true"] {
+  min-height: 160px;
+  padding: .9rem 1rem;
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid rgba(30,111,186,.18);
+  white-space: normal;
+  line-height: 1.6;
+  font-size: .95rem;
+  color: var(--darker);
+  box-shadow: inset 0 1px 2px rgba(15,23,42,.04);
+}
+
+.location-card .rich-text-area[contenteditable="true"] {
+  min-height: 140px;
+}
+
+.plan-panel .rich-text-area[contenteditable="true"] {
+  min-height: 140px;
+}
+
+.rich-text-area[contenteditable="true"]:focus {
+  background: rgba(30,111,186,.05);
+}
+
+.rt-align-left {
+  text-align: left;
+}
+
+.rt-align-center {
+  text-align: center;
+}
+
+.rt-align-right {
+  text-align: right;
+}
+
+.rt-align-justify {
+  text-align: justify;
+}
+
+.rt-size-small {
+  font-size: .82rem;
+}
+
+.rt-size-normal {
+  font-size: 1rem;
+}
+
+.rt-size-large {
+  font-size: 1.35rem;
+}
+
+.rich-text-area ul,
+.rich-text-area ol {
+  padding-left: 1.4rem;
+  margin: .4rem 0;
+}
+
+.rich-text-area li {
+  margin-bottom: .25rem;
+}
+
+.rich-text-area a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.rich-text-area pre {
+  margin: .75rem 0;
+  padding: .85rem 1rem;
+  border-radius: 10px;
+  background: #f1f5f9;
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.rich-text-area code {
+  padding: .1rem .35rem;
+  border-radius: 6px;
+  background: rgba(30,111,186,.12);
+  font-family: 'Fira Code', 'JetBrains Mono', 'Source Code Pro', monospace;
+  font-size: .9em;
+}
+
+.rich-text-area blockquote {
+  margin: .75rem 0;
+  padding-left: 1rem;
+  border-left: 3px solid rgba(30,111,186,.35);
+  color: #334155;
+  font-style: italic;
+}
+
+.rich-text-area h1,
+.rich-text-area h2,
+.rich-text-area h3,
+.rich-text-area h4,
+.rich-text-area h5,
+.rich-text-area h6 {
+  margin: .85rem 0 .35rem;
+  color: var(--darker);
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+.rich-text-area h1 { font-size: 1.45rem; }
+.rich-text-area h2 { font-size: 1.35rem; }
+.rich-text-area h3 { font-size: 1.2rem; }
+.rich-text-area h4 { font-size: 1.1rem; }
+.rich-text-area h5 { font-size: 1rem; }
+.rich-text-area h6 { font-size: .95rem; }
+
+@media (max-width: 768px) {
+  .rich-text-toolbar {
+    gap: .3rem;
+  }
+
+  .rich-text-btn,
+  .rich-text-select,
+  .rich-text-input {
+    height: 32px;
+  }
+
+  .rich-text-btn {
+    width: 32px;
+  }
 }
 
 .tag-chip .tag-remove {

--- a/assets/edit.js
+++ b/assets/edit.js
@@ -19,11 +19,14 @@ import {
   showToast,
   textContentOrFallback,
   sanitizeMultilineText,
+  sanitizeRichText,
   ensureArray,
   parseNumberFromText,
   cloneDeep,
   stripHtml,
-  syncMobileMenu
+  richTextToPlainText,
+  syncMobileMenu,
+  normalizeRichTextFontSize
 } from './property-common.js';
 import {
   signInWithEmailAndPassword,
@@ -62,6 +65,11 @@ const state = {
 };
 
 const EMPTY_FIELD_PLACEHOLDER = 'Pole do wypełnienia';
+
+const RICH_TEXT_FIELD_IDS = ['locationAccess', 'planNotes', 'descriptionText'];
+const RICH_TEXT_ALIGN_CLASSES = ['rt-align-left', 'rt-align-center', 'rt-align-right', 'rt-align-justify'];
+const RICH_TEXT_SIZE_CLASSES = ['rt-size-small', 'rt-size-normal', 'rt-size-large'];
+const RICH_TEXT_SELECTIONS = new WeakMap();
 
 const elements = {
   loadingState: document.getElementById('loadingState'),
@@ -241,6 +249,135 @@ function normalizeMultilineValue(value) {
   const trimmed = sanitized.trim();
   if (!trimmed) return '';
   return trimmed.toLowerCase() === EMPTY_FIELD_PLACEHOLDER.toLowerCase() ? '' : sanitized;
+}
+
+function applyRichTextPlaceholder(element, value) {
+  if (!element) return;
+  const sanitized = sanitizeRichText(value || '');
+  const plain = richTextToPlainText(sanitized).trim();
+  if (plain) {
+    element.innerHTML = sanitized;
+    normalizeRichTextStructure(element);
+    element.dataset.placeholderActive = 'false';
+  } else {
+    element.textContent = EMPTY_FIELD_PLACEHOLDER;
+    element.dataset.placeholderActive = 'true';
+  }
+}
+
+function clearRichTextPlaceholder(element) {
+  if (!element) return;
+  if (element.dataset.placeholderActive === 'true') {
+    element.innerHTML = '';
+    element.dataset.placeholderActive = 'false';
+  }
+}
+
+function normalizeRichTextStructure(element) {
+  if (!element || element.dataset.placeholderActive === 'true') {
+    return;
+  }
+
+  const nodes = Array.from(element.childNodes);
+  nodes.forEach(node => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      if (!node.textContent.trim()) {
+        node.remove();
+        return;
+      }
+      if (node.parentNode === element) {
+        const block = document.createElement('p');
+        element.insertBefore(block, node);
+        block.appendChild(node);
+      }
+      return;
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      node.remove();
+      return;
+    }
+
+    const tag = node.tagName.toLowerCase();
+    if (tag === 'br') {
+      const wrapper = document.createElement('p');
+      element.insertBefore(wrapper, node);
+      wrapper.appendChild(node);
+      return;
+    }
+
+    if (isRichTextBlock(node)) {
+      return;
+    }
+
+    const wrapper = document.createElement('p');
+    element.insertBefore(wrapper, node);
+    wrapper.appendChild(node);
+  });
+
+  if (!element.childNodes.length) {
+    const block = document.createElement('p');
+    block.appendChild(document.createElement('br'));
+    element.appendChild(block);
+  }
+}
+
+function commitRichTextValue(element, options = {}) {
+  if (!element) return;
+
+  const { restoreRange = null } = options;
+  const rangeToRestore = restoreRange ? restoreRange.cloneRange() : null;
+
+  normalizeRichTextStructure(element);
+  const currentHtml = element.innerHTML || '';
+  const sanitized = sanitizeRichText(currentHtml);
+  const plain = richTextToPlainText(sanitized).trim();
+  if (plain) {
+    if (currentHtml !== sanitized) {
+      element.innerHTML = sanitized;
+    }
+    element.dataset.placeholderActive = 'false';
+  } else {
+    element.textContent = EMPTY_FIELD_PLACEHOLDER;
+    element.dataset.placeholderActive = 'true';
+  }
+
+  if (rangeToRestore) {
+    const schedule = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (cb) => setTimeout(cb, 0);
+    schedule(() => {
+      const ancestor = rangeToRestore.commonAncestorContainer;
+      if (ancestor && element.contains(ancestor)) {
+        restoreSelectionRange(rangeToRestore);
+      } else {
+        selectAllText(element);
+      }
+      rememberRichTextSelection(element);
+    });
+  }
+}
+
+function normalizeRichTextValue(value) {
+  const sanitized = sanitizeRichText(value || '');
+  const plain = richTextToPlainText(sanitized).trim();
+  return plain ? sanitized : '';
+}
+
+function getRichTextContent(element) {
+  if (!element || element.dataset.placeholderActive === 'true') {
+    return '';
+  }
+  normalizeRichTextStructure(element);
+  const sanitized = sanitizeRichText(element.innerHTML || '');
+  const plain = richTextToPlainText(sanitized).trim();
+  if (!plain) {
+    element.textContent = EMPTY_FIELD_PLACEHOLDER;
+    element.dataset.placeholderActive = 'true';
+    return '';
+  }
+  element.innerHTML = sanitized;
+  return sanitized;
 }
 
 function extractPlotNumberSegment(value) {
@@ -750,11 +887,287 @@ function selectAllText(element) {
   selection.addRange(range);
 }
 
-function preventNewline(element) {
-  if (!element?.isContentEditable) return;
-  element.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
+function cloneSelectionRange(root) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  if (!root || !root.contains(range.commonAncestorContainer)) {
+    return null;
+  }
+  return range.cloneRange();
+}
+
+function restoreSelectionRange(range) {
+  if (!range) return;
+  const selection = window.getSelection();
+  if (!selection) return;
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function rememberRichTextSelection(area) {
+  if (!area) return;
+  const range = cloneSelectionRange(area);
+  if (range) {
+    RICH_TEXT_SELECTIONS.set(area, range);
+  }
+}
+
+function getStoredRichTextSelection(area) {
+  const range = area ? RICH_TEXT_SELECTIONS.get(area) : null;
+  return range ? range.cloneRange() : null;
+}
+
+function getRangeHtml(range) {
+  if (!range) return '';
+  const fragment = range.cloneContents();
+  const container = document.createElement('div');
+  container.appendChild(fragment);
+  return container.innerHTML;
+}
+
+function placeCaretAtEnd(element) {
+  if (!element) return;
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function isRichTextBlock(node) {
+  if (!node || node.nodeType !== Node.ELEMENT_NODE) return false;
+  const tag = node.tagName.toLowerCase();
+  return tag === 'p'
+    || tag === 'div'
+    || tag === 'li'
+    || tag === 'blockquote'
+    || tag === 'pre'
+    || tag === 'ul'
+    || tag === 'ol';
+}
+
+function findClosestBlock(node, root) {
+  let current = node;
+  while (current && current !== root) {
+    if (isRichTextBlock(current)) {
+      return current;
+    }
+    current = current.parentNode;
+  }
+  if (root && root.nodeType === Node.ELEMENT_NODE && isRichTextBlock(root)) {
+    return root;
+  }
+  return null;
+}
+
+function getSelectionBlocks(root) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return root ? [root] : [];
+  }
+  const range = selection.getRangeAt(0);
+  if (!root || !root.contains(range.commonAncestorContainer)) {
+    return [];
+  }
+
+  const blocks = new Set();
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      if (!isRichTextBlock(node)) {
+        return NodeFilter.FILTER_SKIP;
+      }
+      return range.intersectsNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+    }
+  });
+
+  while (walker.nextNode()) {
+    blocks.add(walker.currentNode);
+  }
+
+  if (!blocks.size) {
+    const block = findClosestBlock(range.startContainer, root);
+    if (block) {
+      blocks.add(block);
+    }
+  }
+
+  if (!blocks.size && root) {
+    blocks.add(root);
+  }
+
+  return Array.from(blocks);
+}
+
+function applyRichTextAlignment(area, value) {
+  const blocks = getSelectionBlocks(area);
+  const targetClass = value ? `rt-align-${value}` : '';
+  blocks.forEach(block => {
+    RICH_TEXT_ALIGN_CLASSES.forEach(cls => block.classList.remove(cls));
+    if (targetClass) {
+      block.classList.add(targetClass);
+    }
+  });
+}
+
+function pruneEmptyStyleAttribute(element) {
+  if (!element || !element.getAttribute) return;
+  const style = element.getAttribute('style');
+  if (!style) return;
+  if (style.trim() === '') {
+    element.removeAttribute('style');
+  }
+}
+
+function applyRichTextFontSize(area, value) {
+  const blocks = getSelectionBlocks(area);
+  if (typeof value === 'string' && value.trim() === '') {
+    blocks.forEach(block => {
+      RICH_TEXT_SIZE_CLASSES.forEach(cls => block.classList.remove(cls));
+      block.style.removeProperty('font-size');
+      pruneEmptyStyleAttribute(block);
+    });
+    return '';
+  }
+  const normalized = normalizeRichTextFontSize(value);
+  if (!normalized) {
+    return null;
+  }
+  blocks.forEach(block => {
+    RICH_TEXT_SIZE_CLASSES.forEach(cls => block.classList.remove(cls));
+    block.style.fontSize = normalized;
+  });
+  return normalized;
+}
+
+function clearRichTextFormatting(area) {
+  const blocks = getSelectionBlocks(area);
+  blocks.forEach(block => {
+    RICH_TEXT_ALIGN_CLASSES.forEach(cls => block.classList.remove(cls));
+    RICH_TEXT_SIZE_CLASSES.forEach(cls => block.classList.remove(cls));
+    block.style.removeProperty('font-size');
+    pruneEmptyStyleAttribute(block);
+  });
+}
+
+function handleRichTextAction(area, action, value = '') {
+  if (!area) return;
+  clearRichTextPlaceholder(area);
+  let range = cloneSelectionRange(area);
+  if (!range) {
+    range = getStoredRichTextSelection(area);
+  }
+
+  if (action === 'insertHtml') {
+    const defaultValue = range ? sanitizeRichText(getRangeHtml(range)) : '';
+    const html = window.prompt('Wklej kod HTML do wstawienia', defaultValue);
+    area.focus();
+    if (html !== null) {
+      const sanitized = sanitizeRichText(html);
+      if (range) {
+        restoreSelectionRange(range);
+      } else {
+        placeCaretAtEnd(area);
+      }
+      document.execCommand('insertHTML', false, sanitized);
+      const selectionAfterInsert = cloneSelectionRange(area) || range;
+      commitRichTextValue(area, { restoreRange: selectionAfterInsert });
+    } else {
+      if (range) {
+        restoreSelectionRange(range);
+      } else {
+        placeCaretAtEnd(area);
+      }
+      commitRichTextValue(area, { restoreRange: range || null });
+    }
+    return;
+  }
+
+  area.focus();
+  if (range) {
+    restoreSelectionRange(range);
+  } else {
+    placeCaretAtEnd(area);
+  }
+
+  if (action === 'align' || action === 'fontSize' || action === 'clear') {
+    normalizeRichTextStructure(area);
+    const normalizedRange = cloneSelectionRange(area);
+    if (normalizedRange) {
+      range = normalizedRange;
+      restoreSelectionRange(range);
+    }
+  }
+
+  let actionResult = true;
+  if (action === 'bold' || action === 'italic' || action === 'underline') {
+    document.execCommand(action);
+  } else if (action === 'orderedList') {
+    document.execCommand('insertOrderedList');
+  } else if (action === 'unorderedList') {
+    document.execCommand('insertUnorderedList');
+  } else if (action === 'align') {
+    applyRichTextAlignment(area, value || 'left');
+  } else if (action === 'fontSize') {
+    actionResult = applyRichTextFontSize(area, value);
+  } else if (action === 'clear') {
+    document.execCommand('removeFormat');
+    clearRichTextFormatting(area);
+  }
+
+  const selectionAfterAction = cloneSelectionRange(area) || range;
+  commitRichTextValue(area, { restoreRange: selectionAfterAction });
+  return actionResult;
+}
+
+function setupRichTextEditors() {
+  const editors = Array.from(document.querySelectorAll('.rich-text-editor'));
+  editors.forEach(editor => {
+    const targetId = editor.dataset.editorTarget;
+    if (!targetId) return;
+    const area = document.getElementById(targetId);
+    if (!area) return;
+
+    editor.querySelectorAll('.rich-text-btn[data-action]').forEach(button => {
+      const action = button.dataset.action;
+      button.addEventListener('mousedown', event => {
+        event.preventDefault();
+        area.focus();
+        rememberRichTextSelection(area);
+      });
+      button.addEventListener('click', () => {
+        handleRichTextAction(area, action, button.dataset.value || '');
+      });
+    });
+
+    const sizeControl = editor.querySelector('[data-action="fontSize"]');
+    if (sizeControl) {
+      const rememberSelection = () => {
+        rememberRichTextSelection(area);
+      };
+      sizeControl.addEventListener('mousedown', rememberSelection);
+      sizeControl.addEventListener('focus', rememberSelection);
+      const applySize = () => {
+        const result = handleRichTextAction(area, 'fontSize', sizeControl.value);
+        if (result === null) {
+          return;
+        }
+        if (typeof result === 'string') {
+          sizeControl.value = result;
+        }
+      };
+      sizeControl.addEventListener('change', applySize);
+      sizeControl.addEventListener('blur', applySize);
+      sizeControl.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          applySize();
+        }
+      });
     }
   });
 }
@@ -832,7 +1245,6 @@ function attachEditorListeners() {
     elements.contactEmailLink
   ].forEach(element => {
     if (!element || !element.isContentEditable) return;
-    preventNewline(element);
     element.addEventListener('blur', () => {
       const text = stripHtml(element.innerHTML).trim();
       element.textContent = text;
@@ -844,6 +1256,34 @@ function attachEditorListeners() {
       }
     });
   });
+
+  const richTextElements = RICH_TEXT_FIELD_IDS
+    .map(id => elements[id])
+    .filter(element => element && element.isContentEditable);
+
+  richTextElements.forEach(element => {
+    element.addEventListener('focus', () => {
+      clearRichTextPlaceholder(element);
+      normalizeRichTextStructure(element);
+      rememberRichTextSelection(element);
+    });
+    element.addEventListener('blur', () => {
+      commitRichTextValue(element);
+      rememberRichTextSelection(element);
+    });
+    element.addEventListener('input', () => {
+      element.dataset.placeholderActive = 'false';
+      normalizeRichTextStructure(element);
+      rememberRichTextSelection(element);
+    });
+    ['mouseup', 'keyup', 'touchend'].forEach(eventName => {
+      element.addEventListener(eventName, () => {
+        rememberRichTextSelection(element);
+      });
+    });
+  });
+
+  setupRichTextEditors();
 
   elements.plotOwnershipSelect?.addEventListener('change', () => {
     const value = elements.plotOwnershipSelect.value;
@@ -1069,7 +1509,7 @@ function renderEditor(data, plot) {
   }
 
   applyMultilinePlaceholder(elements.locationAddress, pickValue(plot.locationAddress, data.address, plot.address));
-  applyMultilinePlaceholder(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access));
+  applyRichTextPlaceholder(elements.locationAccess, pickValue(plot.locationAccess, plot.access, data.access));
 
   updateMapImages(collectMapImages(plot, data, state.plotIndex, state.offerId));
 
@@ -1079,12 +1519,12 @@ function renderEditor(data, plot) {
   applyPlaceholder(elements.planHeight, pickValue(plot.planHeight, data.planHeight));
   applyPlaceholder(elements.planIntensity, pickValue(plot.planIntensity, data.planIntensity));
   applyPlaceholder(elements.planGreen, pickValue(plot.planGreen, data.planGreen));
-  applyMultilinePlaceholder(elements.planNotes, pickValue(plot.planNotes, data.planNotes));
+  applyRichTextPlaceholder(elements.planNotes, pickValue(plot.planNotes, data.planNotes));
 
   state.utilities = mergeUtilities(data.utilities, plot.utilities);
   renderUtilitiesEdit();
 
-  applyMultilinePlaceholder(elements.descriptionText, pickValue(plot.description, data.description));
+  applyRichTextPlaceholder(elements.descriptionText, pickValue(plot.description, data.description));
 
   const normalizedTags = ensureArray(pickValue(plot.tags, data.tags))
     .map(normalizeTag)
@@ -1809,13 +2249,13 @@ function buildUpdatedPlot() {
   base.landRegister = normalizePlaceholderValue(stripHtml(elements.landRegister.innerHTML));
   base.status = (elements.plotOwnershipSelect?.value || '').trim();
   base.locationAddress = normalizeMultilineValue(elements.locationAddress.textContent || '');
-  base.locationAccess = normalizeMultilineValue(elements.locationAccess.textContent || '');
+  base.locationAccess = normalizeRichTextValue(getRichTextContent(elements.locationAccess));
   base.planDesignation = normalizePlaceholderValue(stripHtml(elements.planDesignation.innerHTML));
   base.planHeight = normalizePlaceholderValue(stripHtml(elements.planHeight.innerHTML));
   base.planIntensity = normalizePlaceholderValue(stripHtml(elements.planIntensity.innerHTML));
   base.planGreen = normalizePlaceholderValue(stripHtml(elements.planGreen.innerHTML));
-  base.planNotes = normalizeMultilineValue(elements.planNotes.textContent || '');
-  base.description = normalizeMultilineValue(elements.descriptionText.textContent || '');
+  base.planNotes = normalizeRichTextValue(getRichTextContent(elements.planNotes));
+  base.description = normalizeRichTextValue(getRichTextContent(elements.descriptionText));
   base.utilities = { ...state.utilities };
   base.tags = [...state.tags];
   base.planBadges = state.planBadges || base.planBadges || [];

--- a/assets/property-common.js
+++ b/assets/property-common.js
@@ -271,6 +271,218 @@ export function sanitizeMultilineText(value) {
   return String(value).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
+const ALLOWED_RICH_TEXT_TAGS = new Set([
+  'a',
+  'b',
+  'blockquote',
+  'code',
+  'div',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'i',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'span',
+  'strong',
+  'u',
+  'ul',
+  'br'
+]);
+
+const ALLOWED_RICH_TEXT_CLASS_PREFIXES = ['rt-align-', 'rt-size-'];
+const RICH_TEXT_FONT_SIZE_UNITS = ['px', 'em', 'rem', '%'];
+
+export function normalizeRichTextFontSize(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+  const compact = trimmed.replace(/\s+/g, '').replace(/,/g, '.');
+  if (!compact) {
+    return null;
+  }
+  const numericOnlyMatch = compact.match(/^\d*(?:\.\d+)?$/);
+  if (numericOnlyMatch) {
+    const numeric = Number.parseFloat(numericOnlyMatch[0]);
+    if (!Number.isFinite(numeric)) {
+      return null;
+    }
+    return `${numeric}px`;
+  }
+  const sizedMatch = compact.match(/^(\d*(?:\.\d+)?)(px|em|rem|%)$/i);
+  if (!sizedMatch) {
+    return null;
+  }
+  const numeric = Number.parseFloat(sizedMatch[1]);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  const unit = sizedMatch[2].toLowerCase();
+  if (!RICH_TEXT_FONT_SIZE_UNITS.includes(unit)) {
+    return null;
+  }
+  return `${numeric}${unit}`;
+}
+
+const ALLOWED_RICH_TEXT_ATTRIBUTES = {
+  a: {
+    href: sanitizeRichTextHref,
+    target: sanitizeRichTextTarget
+  }
+};
+
+function sanitizeRichTextHref(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith('#')) {
+    return trimmed;
+  }
+  if (/^(https?:|mailto:|tel:)/i.test(trimmed)) {
+    return trimmed;
+  }
+  if (/^\//.test(trimmed) || /^\.\.\//.test(trimmed) || /^\.\//.test(trimmed)) {
+    return trimmed;
+  }
+  if (!trimmed.includes(':') && !/^\/\//.test(trimmed) && !/\s/.test(trimmed)) {
+    return trimmed;
+  }
+  return null;
+}
+
+function sanitizeRichTextTarget(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = String(value).trim().toLowerCase();
+  return trimmed === '_blank' ? '_blank' : null;
+}
+
+function sanitizeRichTextElement(root) {
+  const nodes = Array.from(root.childNodes);
+  nodes.forEach((node) => {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      node.remove();
+      return;
+    }
+    if (node.nodeType === Node.TEXT_NODE) {
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      node.remove();
+      return;
+    }
+
+    const tag = node.tagName.toLowerCase();
+    if (!ALLOWED_RICH_TEXT_TAGS.has(tag)) {
+      sanitizeRichTextElement(node);
+      while (node.firstChild) {
+        root.insertBefore(node.firstChild, node);
+      }
+      node.remove();
+      return;
+    }
+
+    Array.from(node.attributes).forEach(attr => {
+      if (attr.name === 'class') {
+        const classes = attr.value
+          .split(/\s+/)
+          .filter(Boolean)
+          .filter(cls => ALLOWED_RICH_TEXT_CLASS_PREFIXES.some(prefix => cls.startsWith(prefix)));
+        if (classes.length > 0) {
+          node.setAttribute('class', Array.from(new Set(classes)).join(' '));
+        } else {
+          node.removeAttribute('class');
+        }
+        return;
+      }
+
+      if (attr.name === 'style') {
+        const sanitizedStyle = attr.value
+          .split(';')
+          .map(part => part.trim())
+          .filter(Boolean)
+          .map(part => {
+            const [property, ...valueParts] = part.split(':');
+            if (!property || valueParts.length === 0) {
+              return null;
+            }
+            const name = property.trim().toLowerCase();
+            const value = valueParts.join(':').trim();
+            if (name !== 'font-size') {
+              return null;
+            }
+            const normalized = normalizeRichTextFontSize(value);
+            return normalized ? `font-size: ${normalized}` : null;
+          })
+          .filter(Boolean);
+        if (sanitizedStyle.length > 0) {
+          node.setAttribute('style', Array.from(new Set(sanitizedStyle)).join('; '));
+        } else {
+          node.removeAttribute('style');
+        }
+        return;
+      }
+
+      const allowedForTag = ALLOWED_RICH_TEXT_ATTRIBUTES[tag];
+      if (allowedForTag && Object.prototype.hasOwnProperty.call(allowedForTag, attr.name)) {
+        const sanitizer = allowedForTag[attr.name];
+        const sanitizedValue = sanitizer(attr.value);
+        if (sanitizedValue) {
+          node.setAttribute(attr.name, sanitizedValue);
+        } else {
+          node.removeAttribute(attr.name);
+        }
+        return;
+      }
+
+      node.removeAttribute(attr.name);
+    });
+
+    if (tag === 'a') {
+      if (!node.hasAttribute('href')) {
+        sanitizeRichTextElement(node);
+        while (node.firstChild) {
+          root.insertBefore(node.firstChild, node);
+        }
+        node.remove();
+        return;
+      }
+      if (node.getAttribute('target') === '_blank') {
+        node.setAttribute('rel', 'noopener noreferrer');
+      } else {
+        node.removeAttribute('rel');
+      }
+    }
+
+    sanitizeRichTextElement(node);
+  });
+}
+
+export function sanitizeRichText(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const container = document.createElement('div');
+  container.innerHTML = String(value);
+  sanitizeRichTextElement(container);
+  return container.innerHTML;
+}
+
 export function cloneDeep(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -288,6 +500,13 @@ export function stripHtml(value) {
   const tmp = document.createElement("div");
   tmp.innerHTML = value;
   return tmp.textContent || tmp.innerText || "";
+}
+
+export function richTextToPlainText(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return stripHtml(sanitizeRichText(value));
 }
 
 export function syncMobileMenu() {

--- a/details.html
+++ b/details.html
@@ -199,7 +199,7 @@
             </div>
             <div class="location-card">
               <h4>Dojazd i otoczenie</h4>
-              <p id="locationAccess"></p>
+              <div id="locationAccess" class="location-text"></div>
             </div>
           </div>
         </div>

--- a/edit.html
+++ b/edit.html
@@ -218,7 +218,28 @@
             </div>
             <div class="location-card">
               <h4>Dojazd i otoczenie</h4>
-              <p id="locationAccess" contenteditable="true">Pole do wypełnienia</p>
+              <div class="rich-text-editor" data-editor-target="locationAccess">
+                <div class="rich-text-toolbar" role="toolbar" aria-label="Narzędzia formatowania">
+                  <button type="button" class="rich-text-btn" data-action="bold" aria-label="Pogrubienie"><i class="fas fa-bold"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="italic" aria-label="Kursywa"><i class="fas fa-italic"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="underline" aria-label="Podkreślenie"><i class="fas fa-underline"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <input type="text" class="rich-text-input" data-action="fontSize" aria-label="Rozmiar tekstu" placeholder="Rozmiar (np. 16px)" list="fontSizeOptions" />
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="left" aria-label="Wyrównaj do lewej"><i class="fas fa-align-left"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="center" aria-label="Wyśrodkuj"><i class="fas fa-align-center"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="right" aria-label="Wyrównaj do prawej"><i class="fas fa-align-right"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="align" data-value="justify" aria-label="Wyjustuj"><i class="fas fa-align-justify"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
+                  <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="insertHtml" aria-label="Wstaw kod HTML"><i class="fas fa-code"></i></button>
+                  <div class="rich-text-divider" aria-hidden="true"></div>
+                  <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
+                </div>
+                <div id="locationAccess" class="location-text rich-text-area" contenteditable="true">Pole do wypełnienia</div>
+              </div>
             </div>
           </div>
         </div>
@@ -234,7 +255,28 @@
             <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity" contenteditable="true">Pole do wypełnienia</dd></dl>
             <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen" contenteditable="true">Pole do wypełnienia</dd></dl>
           </div>
-          <div class="plan-notes" id="planNotes" contenteditable="true">Pole do wypełnienia</div>
+          <div class="rich-text-editor" data-editor-target="planNotes">
+            <div class="rich-text-toolbar" role="toolbar" aria-label="Narzędzia formatowania">
+              <button type="button" class="rich-text-btn" data-action="bold" aria-label="Pogrubienie"><i class="fas fa-bold"></i></button>
+              <button type="button" class="rich-text-btn" data-action="italic" aria-label="Kursywa"><i class="fas fa-italic"></i></button>
+              <button type="button" class="rich-text-btn" data-action="underline" aria-label="Podkreślenie"><i class="fas fa-underline"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <input type="text" class="rich-text-input" data-action="fontSize" aria-label="Rozmiar tekstu" placeholder="Rozmiar (np. 16px)" list="fontSizeOptions" />
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="left" aria-label="Wyrównaj do lewej"><i class="fas fa-align-left"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="center" aria-label="Wyśrodkuj"><i class="fas fa-align-center"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="right" aria-label="Wyrównaj do prawej"><i class="fas fa-align-right"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="justify" aria-label="Wyjustuj"><i class="fas fa-align-justify"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
+              <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="insertHtml" aria-label="Wstaw kod HTML"><i class="fas fa-code"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
+            </div>
+            <div class="plan-notes rich-text-area" id="planNotes" contenteditable="true">Pole do wypełnienia</div>
+          </div>
         </aside>
       </section>
 
@@ -287,7 +329,28 @@
           <h2 id="descriptionTitle">Opis szczegółowy</h2>
         </div>
         <div class="description-card">
-          <div id="descriptionText" class="description-text" contenteditable="true">Pole do wypełnienia</div>
+          <div class="rich-text-editor" data-editor-target="descriptionText">
+            <div class="rich-text-toolbar" role="toolbar" aria-label="Narzędzia formatowania">
+              <button type="button" class="rich-text-btn" data-action="bold" aria-label="Pogrubienie"><i class="fas fa-bold"></i></button>
+              <button type="button" class="rich-text-btn" data-action="italic" aria-label="Kursywa"><i class="fas fa-italic"></i></button>
+              <button type="button" class="rich-text-btn" data-action="underline" aria-label="Podkreślenie"><i class="fas fa-underline"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <input type="text" class="rich-text-input" data-action="fontSize" aria-label="Rozmiar tekstu" placeholder="Rozmiar (np. 16px)" list="fontSizeOptions" />
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="left" aria-label="Wyrównaj do lewej"><i class="fas fa-align-left"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="center" aria-label="Wyśrodkuj"><i class="fas fa-align-center"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="right" aria-label="Wyrównaj do prawej"><i class="fas fa-align-right"></i></button>
+              <button type="button" class="rich-text-btn" data-action="align" data-value="justify" aria-label="Wyjustuj"><i class="fas fa-align-justify"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="unorderedList" aria-label="Lista wypunktowana"><i class="fas fa-list-ul"></i></button>
+              <button type="button" class="rich-text-btn" data-action="orderedList" aria-label="Lista numerowana"><i class="fas fa-list-ol"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="insertHtml" aria-label="Wstaw kod HTML"><i class="fas fa-code"></i></button>
+              <div class="rich-text-divider" aria-hidden="true"></div>
+              <button type="button" class="rich-text-btn" data-action="clear" aria-label="Wyczyść formatowanie"><i class="fas fa-eraser"></i></button>
+            </div>
+            <div id="descriptionText" class="description-text rich-text-area" contenteditable="true">Pole do wypełnienia</div>
+          </div>
         </div>
       </section>
 
@@ -466,6 +529,16 @@
       </div>
     </div>
   </footer>
+
+  <datalist id="fontSizeOptions">
+    <option value="12px"></option>
+    <option value="14px"></option>
+    <option value="16px"></option>
+    <option value="18px"></option>
+    <option value="20px"></option>
+    <option value="24px"></option>
+    <option value="32px"></option>
+  </datalist>
 
   <script type="module" src="assets/edit.js"></script>
   <div class="cookie-banner" data-cookie-banner role="dialog" aria-modal="false" aria-live="polite" tabindex="-1">


### PR DESCRIPTION
## Summary
- replace the preset font size dropdowns with a free-form input and persist the current selection while applying the value
- sanitize and store inline font-size declarations so custom sizes survive saves and render in both edit and details views
- tweak toolbar styling to accommodate the new control and add common size suggestions via a datalist

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d675e40a78832b960b7836d5ae3275