### PR TITLE
Add character counters and validation to edit listing form

### DIFF
--- a/assets/edit.css
+++ b/assets/edit.css
@@ -25,6 +25,11 @@
   background: rgba(30,111,186,.06);
 }
 
+[contenteditable="true"].field-over-limit {
+  outline-color: rgba(220,38,38,.55) !important;
+  background: rgba(220,38,38,.08);
+}
+
 [contenteditable="true"].single-line {
   white-space: nowrap;
 }
@@ -83,6 +88,60 @@
 
 .meta-chip--select select option {
   color: var(--darker);
+}
+
+.char-counter {
+  font-size: .75rem;
+  color: #64748b;
+  line-height: 1.2;
+  margin-top: .35rem;
+}
+
+.char-counter--inline {
+  display: inline-block;
+  margin-left: .45rem;
+  margin-top: 0;
+  font-size: .7rem;
+}
+
+.char-counter--end {
+  text-align: right;
+}
+
+.char-counter--tags {
+  margin-top: 0;
+}
+
+.char-counter.is-over-limit {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.meta-chip .char-counter--inline {
+  color: #94a3b8;
+}
+
+.field-over-limit:not([contenteditable="true"]) {
+  background: rgba(220,38,38,.08);
+  border-radius: 6px;
+}
+
+.plan-info-grid dd {
+  display: flex;
+  flex-direction: column;
+  gap: .3rem;
+}
+
+.plan-info-value {
+  display: block;
+  font-weight: 600;
+  color: var(--darker);
+  white-space: pre-wrap;
+}
+
+.plan-info-grid dd .char-counter {
+  text-align: right;
+  margin-top: 0;
 }
 
 .utilities-grid .utility-card {

--- a/edit.html
+++ b/edit.html
@@ -256,10 +256,30 @@
           </div>
           <div class="plan-badges" id="planBadges"></div>
           <div class="plan-info-grid">
-            <dl><dt>Przeznaczenie</dt><dd id="planDesignation" contenteditable="true">Pole do wypełnienia</dd></dl>
-            <dl><dt>Maks. wysokość</dt><dd id="planHeight" contenteditable="true">Pole do wypełnienia</dd></dl>
-            <dl><dt>Intensywność zabudowy</dt><dd id="planIntensity" contenteditable="true">Pole do wypełnienia</dd></dl>
-            <dl><dt>Pow. biologicznie czynna</dt><dd id="planGreen" contenteditable="true">Pole do wypełnienia</dd></dl>
+            <dl>
+              <dt>Przeznaczenie</dt>
+              <dd>
+                <div id="planDesignation" class="plan-info-value" contenteditable="true">Pole do wypełnienia</div>
+              </dd>
+            </dl>
+            <dl>
+              <dt>Maks. wysokość</dt>
+              <dd>
+                <div id="planHeight" class="plan-info-value" contenteditable="true">Pole do wypełnienia</div>
+              </dd>
+            </dl>
+            <dl>
+              <dt>Intensywność zabudowy</dt>
+              <dd>
+                <div id="planIntensity" class="plan-info-value" contenteditable="true">Pole do wypełnienia</div>
+              </dd>
+            </dl>
+            <dl>
+              <dt>Pow. biologicznie czynna</dt>
+              <dd>
+                <div id="planGreen" class="plan-info-value" contenteditable="true">Pole do wypełnienia</div>
+              </dd>
+            </dl>
           </div>
           <div class="rich-text-editor" data-editor-target="planNotes">
             <div class="rich-text-toolbar" role="toolbar" aria-label="Narzędzia formatowania">
@@ -381,6 +401,7 @@
           </p>
           <div class="tags-list" id="tagsList"></div>
           <p class="tags-empty" id="tagsEmpty" hidden>Brak dodatkowych parametrów.</p>
+          <p class="char-counter char-counter--end char-counter--tags" id="tagCounter" aria-live="polite">0/10</p>
           <div class="tag-form">
             <input type="text" id="tagInput" placeholder="Dodaj własny znacznik, np. #Budowlana">
             <button class="btn btn-primary" type="button" id="addTagBtn"><i class="fas fa-plus"></i> Dodaj</button>


### PR DESCRIPTION
## Summary
- add configurable character counters to key text fields in the edit listing view and highlight limits in the UI
- enforce a 10-tag cap with a live counter and disable adding more when the limit is reached
- block saving when character or tag limits are exceeded and surface toast notifications for violations

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d6d5954144832b9a09cd140b3302f1