### PR TITLE
Display tag counts in offers filter chips

### DIFF
--- a/oferty.html
+++ b/oferty.html
@@ -1232,6 +1232,13 @@ window.showConfirmModal = showConfirmModal;
     const countValue = displayCounts?.get(tag);
     const numericCount = Number.isFinite(countValue) ? countValue : (Number(tagMetrics.get(tag)) || 0);
 
+    if (Number.isFinite(numericCount)) {
+      const countSpan = document.createElement('span');
+      countSpan.className = 'tag-chip__count';
+      countSpan.textContent = `(${numericCount})`;
+      chip.appendChild(countSpan);
+    }
+
     const compatibleCount = Number.isFinite(countValue) ? countValue : 0;
     const isCompatible = filterState.selectedTags.size > 0 && !isActive && compatibleCount > 0;
     chip.classList.toggle('is-compatible', isCompatible);


### PR DESCRIPTION
## Summary
- render a dedicated count element for each tag filter chip
- show the number of matching offers in parentheses directly in the chip label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e2fa0e34832b93dba67715ddb1f5