### PR TITLE
Stabilize Voronoi fallback visuals at close zoom levels

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -25,104 +25,115 @@
   align-items:flex-end;
 }
 
-#map-controls .voronoi-panel {
+
+.sidebar-stack {
   display:flex;
   flex-direction:column;
-  gap:10px;
-  min-width:180px;
-  max-width:220px;
+  gap:22px;
+  margin-bottom:24px;
+}
+
+.voronoi-panel {
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+  width:100%;
   background:rgba(15,23,42,0.92);
   border:1px solid rgba(59,130,246,0.42);
   box-shadow:0 12px 28px rgba(2,6,23,0.55);
-  border-radius:14px;
-  padding:12px 14px;
+  border-radius:16px;
+  padding:18px 20px;
   color:#e2e8f0;
   backdrop-filter:blur(10px);
   -webkit-backdrop-filter:blur(10px);
 }
 
-#map-controls .voronoi-panel__header {
+.voronoi-panel__header {
   width:100%;
   display:flex;
   align-items:center;
-  justify-content:flex-end;
+  justify-content:space-between;
 }
 
-#map-controls .voronoi-toggle-control {
+.voronoi-toggle-control {
   display:flex;
   align-items:center;
-  gap:8px;
-  font-size:0.78rem;
+  justify-content:space-between;
+  gap:12px;
+  width:100%;
+  font-size:0.82rem;
   color:#cbd5f5;
 }
 
-#map-controls .voronoi-legend {
+.voronoi-legend {
   width:100%;
   background:rgba(30,64,175,0.35);
   border:1px solid rgba(96,165,250,0.45);
-  border-radius:10px;
-  padding:8px 10px;
+  border-radius:12px;
+  padding:12px 14px;
   display:flex;
   flex-direction:column;
-  gap:6px;
-  font-size:0.72rem;
+  gap:8px;
+  font-size:0.78rem;
   color:#dbeafe;
 }
 
-#map-controls .voronoi-legend__item {
+.voronoi-legend__item {
   display:flex;
   align-items:center;
-  gap:6px;
+  gap:8px;
   white-space:nowrap;
 }
 
-#map-controls .voronoi-legend__swatch {
-  width:14px;
-  height:14px;
+.voronoi-legend__swatch {
+  width:16px;
+  height:16px;
   border-radius:4px;
   border:1px solid rgba(148,163,184,0.6);
   box-shadow:0 1px 3px rgba(2,6,23,0.4);
 }
 
-#map-controls .voronoi-legend__swatch--selected {
+.voronoi-legend__swatch--selected {
   background:rgba(34,197,94,0.7);
   border-color:#22c55e;
 }
 
-#map-controls .voronoi-legend__swatch--source {
+.voronoi-legend__swatch--source {
   background:rgba(59,130,246,0.65);
   border-color:#2563eb;
 }
 
-#map-controls .voronoi-legend__label {
-  font-weight:500;
+.voronoi-legend__label {
+  font-weight:600;
   color:#e2e8f0;
 }
 
-#map-controls .voronoi-toggle-control input[type="checkbox"] {
-  width:16px;
-  height:16px;
+.voronoi-toggle-control input[type="checkbox"] {
+  width:18px;
+  height:18px;
   accent-color:#60a5fa;
   cursor:pointer;
+  flex-shrink:0;
 }
 
-#map-controls .voronoi-toggle-control label {
+.voronoi-toggle-control label {
   cursor:pointer;
   font-weight:600;
   color:#e0e7ff;
-  text-align:right;
+  text-align:left;
+  line-height:1.4;
 }
 
-#map-controls .voronoi-inspector {
+.voronoi-inspector {
   width:100%;
   color:#f8fafc;
   display:flex;
   flex-direction:column;
-  gap:6px;
-  font-size:0.74rem;
+  gap:10px;
+  font-size:0.82rem;
 }
 
-#map-controls .voronoi-inspector[hidden] {
+.voronoi-inspector[hidden] {
   display:none !important;
 }
 
@@ -194,15 +205,16 @@
   border:1px solid var(--filters-border);
   box-shadow:var(--filters-shadow);
   padding:20px 22px;
-  margin-bottom:22px;
+  margin:0;
   display:flex;
   flex-direction:column;
   gap:1.15rem;
-  position:sticky;
-  top:24px;
-  z-index:5;
   backdrop-filter:blur(14px);
   -webkit-backdrop-filter:blur(14px);
+}
+
+.sidebar-stack .filters-panel {
+  margin-bottom:0;
 }
 
 @media (min-width:993px){
@@ -212,9 +224,10 @@
     overflow-y:visible;
   }
 
-  .filters-panel {
+  .sidebar-stack {
     position:sticky;
     top:24px;
+    z-index:5;
   }
 }
 
@@ -230,26 +243,24 @@
 }
 
 @media (max-width:768px){
-  #map-controls {
-    left:auto;
-    right:12px;
-    transform:none;
-    align-items:flex-end;
+  .sidebar-stack {
+    position:static;
+    top:auto;
+    z-index:auto;
+    gap:18px;
+    margin-bottom:18px;
   }
 
-  #map-controls .voronoi-panel {
-    min-width:unset;
-    width:min(88vw,260px);
-    padding:12px 14px;
-    gap:8px;
+  .voronoi-panel {
+    padding:16px 18px;
+    gap:10px;
   }
 
-  #map-controls .voronoi-inspector {
+  .voronoi-inspector {
     font-size:0.78rem;
     max-height:45vh;
     overflow-y:auto;
     gap:8px;
-    padding:10px 12px;
   }
 
   .voronoi-inspector__list {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -49,8 +49,10 @@
 .voronoi-panel__header {
   width:100%;
   display:flex;
-  align-items:center;
+  align-items:flex-start;
   justify-content:space-between;
+  flex-wrap:wrap;
+  gap:12px;
 }
 
 .voronoi-panel__title {
@@ -59,17 +61,42 @@
   font-weight:700;
   letter-spacing:0.01em;
   color:#1f2937;
+  flex:1 1 auto;
 }
 
 .voronoi-toggle {
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  gap:8px;
+  padding:12px 16px;
+  border-radius:16px;
+  background:linear-gradient(140deg, rgba(255,255,255,0.96), rgba(241,248,255,0.96));
+  border:1px solid rgba(148,163,184,0.28);
+  box-shadow:0 16px 32px rgba(15,23,42,0.08);
+  min-width:220px;
+  max-width:100%;
+  margin-left:auto;
+}
+
+.voronoi-toggle__label {
+  font-size:0.72rem;
+  font-weight:700;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:#1d4ed8;
+}
+
+.voronoi-toggle__controls {
   position:relative;
   display:inline-flex;
   align-items:center;
-  padding:3px;
+  padding:4px;
   border-radius:999px;
   background:linear-gradient(135deg, rgba(191,219,254,0.55), rgba(148,197,255,0.75));
   border:1px solid rgba(96,165,250,0.6);
   gap:4px;
+  width:100%;
 }
 
 .voronoi-toggle__input {
@@ -84,11 +111,11 @@
   z-index:1;
   border:0;
   border-radius:999px;
-  padding:6px 14px;
-  font-size:0.78rem;
+  padding:7px 16px;
+  font-size:0.82rem;
   font-weight:600;
   color:#1d4ed8;
-  background:transparent;
+  background:rgba(255,255,255,0.35);
   cursor:pointer;
   transition:color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -96,7 +123,14 @@
 .voronoi-toggle__option--active {
   color:#0b1c4a;
   background:#e0f2ff;
-  box-shadow:0 6px 16px rgba(30,64,175,0.18);
+  box-shadow:0 8px 18px rgba(30,64,175,0.18);
+}
+
+@media (max-width: 640px) {
+  .voronoi-toggle {
+    width:100%;
+    margin-left:0;
+  }
 }
 
 .voronoi-toggle__option:focus-visible {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -583,24 +583,26 @@
 /* zmniejszenie marginesów w oknie informacji na mapie */
 .gm-style-iw-c { padding:8px !important; }
 
+
 .voronoi-label {
   background:rgba(15,23,42,0.88);
   border:1px solid rgba(148,163,184,0.35);
-  border-radius:999px;
-  padding:6px 14px;
+  border-radius:14px;
+  padding:8px 14px;
   font-size:0.82rem;
-  line-height:1.2;
+  line-height:1.25;
   color:#ffffff;
   box-shadow:0 18px 34px rgba(15,23,42,0.25);
   min-width:auto;
-  text-align:center;
+  text-align:left;
   font-weight:600;
-  white-space:nowrap;
+  white-space:normal;
   pointer-events:none;
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  gap:0.5rem;
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  justify-content:flex-start;
+  gap:4px;
   transition:transform 120ms ease, box-shadow 160ms ease;
 }
 
@@ -609,6 +611,7 @@
   flex-direction:column;
   align-items:flex-start;
   gap:2px;
+  width:100%;
 }
 
 .voronoi-label__value {
@@ -636,6 +639,7 @@
   font-weight:600;
   letter-spacing:0.08em;
   text-transform:uppercase;
+  align-self:flex-start;
 }
 
 .voronoi-label[data-fallback="true"] {
@@ -645,9 +649,9 @@
 }
 
 .voronoi-label[data-density="compact"] {
-  padding:4px 10px;
+  padding:6px 10px;
   font-size:0.74rem;
-  gap:0.35rem;
+  gap:3px;
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__price {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -587,7 +587,7 @@
   background:rgba(15,23,42,0.88);
   border:1px solid rgba(148,163,184,0.35);
   border-radius:999px;
-  padding:4px 12px;
+  padding:6px 14px;
   font-size:0.82rem;
   line-height:1.2;
   color:#ffffff;
@@ -600,13 +600,63 @@
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:0.35rem;
+  gap:0.5rem;
+  transition:transform 120ms ease, box-shadow 160ms ease;
+}
+
+.voronoi-label__stack {
+  display:flex;
+  flex-direction:column;
+  align-items:flex-start;
+  gap:2px;
 }
 
 .voronoi-label__value {
   color:inherit;
   font-weight:600;
   letter-spacing:0.01em;
+}
+
+.voronoi-label__price {
+  font-size:0.7rem;
+  font-weight:500;
+  opacity:0.85;
+  letter-spacing:0.015em;
+}
+
+.voronoi-label__badge {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:2px 8px;
+  border-radius:999px;
+  background:rgba(248,250,252,0.16);
+  color:#f8fafc;
+  font-size:0.62rem;
+  font-weight:600;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+}
+
+.voronoi-label[data-fallback="true"] {
+  background:rgba(220,38,38,0.88);
+  border-color:rgba(248,113,113,0.5);
+  box-shadow:0 18px 36px rgba(220,38,38,0.3);
+}
+
+.voronoi-label[data-density="compact"] {
+  padding:4px 10px;
+  font-size:0.74rem;
+  gap:0.35rem;
+}
+
+.voronoi-label[data-density="compact"] .voronoi-label__price {
+  font-size:0.64rem;
+}
+
+.voronoi-label[data-density="compact"] .voronoi-label__badge {
+  padding:1px 6px;
+  font-size:0.56rem;
 }
 
 @media (max-width:768px){

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -40,6 +40,51 @@
   -webkit-backdrop-filter:blur(12px);
 }
 
+#map-controls .voronoi-legend {
+  background:rgba(255,255,255,0.92);
+  border:1px solid rgba(148,163,184,0.35);
+  box-shadow:0 14px 28px rgba(15,23,42,0.22);
+  border-radius:10px;
+  padding:12px 14px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  font-size:0.78rem;
+  color:#1f2937;
+  backdrop-filter:blur(12px);
+  -webkit-backdrop-filter:blur(12px);
+}
+
+#map-controls .voronoi-legend__item {
+  display:flex;
+  align-items:center;
+  gap:8px;
+  white-space:nowrap;
+}
+
+#map-controls .voronoi-legend__swatch {
+  width:16px;
+  height:16px;
+  border-radius:4px;
+  border:1px solid rgba(15,23,42,0.25);
+  box-shadow:0 2px 4px rgba(15,23,42,0.18);
+}
+
+#map-controls .voronoi-legend__swatch--selected {
+  background:#DCFCE7;
+  border-color:#15803D;
+}
+
+#map-controls .voronoi-legend__swatch--source {
+  background:#DBEAFE;
+  border-color:#1D4ED8;
+}
+
+#map-controls .voronoi-legend__label {
+  font-weight:600;
+  color:#1f2937;
+}
+
 #map-controls .voronoi-toggle-control input[type="checkbox"] {
   width:18px;
   height:18px;

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -49,7 +49,7 @@
 .voronoi-panel__header {
   width:100%;
   display:flex;
-  align-items:flex-start;
+  align-items:center;
   justify-content:space-between;
   flex-wrap:wrap;
   gap:12px;
@@ -66,15 +66,14 @@
 
 .voronoi-toggle {
   display:flex;
-  flex-direction:column;
-  align-items:flex-start;
+  align-items:center;
   gap:8px;
-  padding:12px 16px;
-  border-radius:16px;
-  background:linear-gradient(140deg, rgba(255,255,255,0.96), rgba(241,248,255,0.96));
-  border:1px solid rgba(148,163,184,0.28);
-  box-shadow:0 16px 32px rgba(15,23,42,0.08);
-  min-width:220px;
+  padding:0;
+  border-radius:999px;
+  background:transparent;
+  border:0;
+  box-shadow:none;
+  min-width:auto;
   max-width:100%;
   margin-left:auto;
 }
@@ -83,12 +82,12 @@
   position:relative;
   display:inline-flex;
   align-items:center;
-  padding:4px;
+  padding:2px;
   border-radius:999px;
-  background:linear-gradient(135deg, rgba(191,219,254,0.55), rgba(148,197,255,0.75));
-  border:1px solid rgba(96,165,250,0.6);
-  gap:4px;
-  width:100%;
+  background:linear-gradient(135deg, rgba(191,219,254,0.45), rgba(96,165,250,0.6));
+  border:1px solid rgba(59,130,246,0.45);
+  gap:2px;
+  width:auto;
 }
 
 .voronoi-toggle__input {
@@ -103,8 +102,8 @@
   z-index:1;
   border:0;
   border-radius:999px;
-  padding:7px 16px;
-  font-size:0.82rem;
+  padding:6px 12px;
+  font-size:0.78rem;
   font-weight:600;
   color:#1d4ed8;
   background:rgba(255,255,255,0.35);
@@ -115,12 +114,13 @@
 .voronoi-toggle__option--active {
   color:#0b1c4a;
   background:#e0f2ff;
-  box-shadow:0 8px 18px rgba(30,64,175,0.18);
+  box-shadow:0 6px 14px rgba(30,64,175,0.18);
 }
 
 @media (max-width: 640px) {
   .voronoi-toggle {
     width:100%;
+    justify-content:flex-end;
     margin-left:0;
   }
 }

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -79,14 +79,6 @@
   margin-left:auto;
 }
 
-.voronoi-toggle__label {
-  font-size:0.72rem;
-  font-weight:700;
-  letter-spacing:0.08em;
-  text-transform:uppercase;
-  color:#1d4ed8;
-}
-
 .voronoi-toggle__controls {
   position:relative;
   display:inline-flex;

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -79,6 +79,47 @@
   color:#f8fafc;
 }
 
+.voronoi-inspector__summary {
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+
+.voronoi-inspector__summary[hidden] {
+  display:none !important;
+}
+
+.voronoi-inspector__summary-pill {
+  background:linear-gradient(135deg,rgba(15,23,42,0.9),rgba(30,41,59,0.92));
+  border:1px solid rgba(148,163,184,0.4);
+  border-radius:999px;
+  padding:12px 16px;
+  box-shadow:0 14px 32px rgba(2,6,23,0.45);
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.voronoi-inspector__summary-row {
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:12px;
+}
+
+.voronoi-inspector__summary-label {
+  font-size:0.72rem;
+  letter-spacing:0.02em;
+  text-transform:uppercase;
+  color:rgba(226,232,240,0.82);
+}
+
+.voronoi-inspector__summary-value {
+  font-weight:600;
+  color:#f8fafc;
+  font-variant-numeric:tabular-nums;
+}
+
 .voronoi-inspector__empty {
   margin:0;
   color:rgba(226,232,240,0.85);

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -155,6 +155,80 @@
   font-size:0.82rem;
 }
 
+.voronoi-inspector__summary {
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  background:linear-gradient(135deg,#0b1f3a,#12284f);
+  color:#f8fafc;
+  padding:12px 14px;
+  border-radius:14px;
+  box-shadow:0 6px 14px rgba(15,23,42,0.18);
+}
+
+.voronoi-inspector__summary[hidden] {
+  display:none !important;
+}
+
+.voronoi-inspector__summary-header {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+}
+
+.voronoi-inspector__summary-title {
+  font-size:0.78rem;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:0.05em;
+  color:rgba(248,250,252,0.78);
+}
+
+.voronoi-inspector__summary-badge {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:2px 8px;
+  border-radius:999px;
+  background:rgba(248,250,252,0.2);
+  color:#f8fafc;
+  font-size:0.68rem;
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+}
+
+.voronoi-inspector__summary-badge[hidden] {
+  display:none !important;
+}
+
+.voronoi-inspector__summary-grid {
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.voronoi-inspector__summary-item {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+
+.voronoi-inspector__summary-label {
+  font-size:0.75rem;
+  font-weight:500;
+  color:rgba(226,232,240,0.82);
+}
+
+.voronoi-inspector__summary-value {
+  font-size:0.9rem;
+  font-weight:700;
+  font-variant-numeric:tabular-nums;
+  color:#ffffff;
+}
+
 .voronoi-inspector[hidden] {
   display:none !important;
 }

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -38,14 +38,12 @@
   flex-direction:column;
   gap:14px;
   width:100%;
-  background:rgba(15,23,42,0.92);
-  border:1px solid rgba(59,130,246,0.42);
-  box-shadow:0 12px 28px rgba(2,6,23,0.55);
+  background:#fff;
+  border:1px solid rgba(148,163,184,0.25);
+  box-shadow:0 18px 40px rgba(15,23,42,0.08);
   border-radius:16px;
   padding:18px 20px;
-  color:#e2e8f0;
-  backdrop-filter:blur(10px);
-  -webkit-backdrop-filter:blur(10px);
+  color:#1f2937;
 }
 
 .voronoi-panel__header {
@@ -62,7 +60,7 @@
   gap:12px;
   width:100%;
   font-size:0.82rem;
-  color:#cbd5f5;
+  color:#1f2937;
 }
 
 .voronoi-legend {
@@ -119,14 +117,14 @@
 .voronoi-toggle-control label {
   cursor:pointer;
   font-weight:600;
-  color:#e0e7ff;
+  color:#0f172a;
   text-align:left;
   line-height:1.4;
 }
 
 .voronoi-inspector {
   width:100%;
-  color:#f8fafc;
+  color:#1f2937;
   display:flex;
   flex-direction:column;
   gap:10px;
@@ -139,7 +137,7 @@
 
 .voronoi-inspector__empty {
   margin:0;
-  color:rgba(226,232,240,0.8);
+  color:#64748b;
   line-height:1.4;
 }
 
@@ -161,7 +159,7 @@
 
 .voronoi-inspector__tag {
   font-weight:600;
-  color:#e2e8f0;
+  color:#0f172a;
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -169,7 +167,7 @@
 
 .voronoi-inspector__percentage {
   font-weight:600;
-  color:#bae6fd;
+  color:#1d4ed8;
   font-variant-numeric:tabular-nums;
 }
 

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -52,6 +52,94 @@
   font-weight:600;
 }
 
+#map-controls .voronoi-inspector {
+  min-width:240px;
+  max-width:320px;
+  background:rgba(15,23,42,0.82);
+  color:#e2e8f0;
+  border-radius:12px;
+  border:1px solid rgba(148,163,184,0.35);
+  box-shadow:0 20px 45px rgba(15,23,42,0.28);
+  padding:14px 16px;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  font-size:0.84rem;
+  backdrop-filter:blur(16px);
+  -webkit-backdrop-filter:blur(16px);
+}
+
+#map-controls .voronoi-inspector[hidden] {
+  display:none !important;
+}
+
+.voronoi-inspector__title {
+  font-weight:600;
+  font-size:0.9rem;
+  color:#f8fafc;
+}
+
+.voronoi-inspector__empty {
+  margin:0;
+  color:rgba(226,232,240,0.85);
+  line-height:1.4;
+}
+
+.voronoi-inspector__list {
+  margin:0;
+  padding:0;
+  list-style:none;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.voronoi-inspector__item {
+  background:rgba(15,23,42,0.45);
+  border:1px solid rgba(148,163,184,0.35);
+  border-radius:10px;
+  padding:8px 10px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.voronoi-inspector__item-header {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+}
+
+.voronoi-inspector__tag {
+  font-weight:600;
+  color:#f1f5f9;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.voronoi-inspector__value {
+  font-variant-numeric:tabular-nums;
+  color:rgba(226,232,240,0.85);
+  font-size:0.78rem;
+}
+
+.voronoi-inspector__meter {
+  position:relative;
+  height:4px;
+  border-radius:999px;
+  background:rgba(148,163,184,0.35);
+  overflow:hidden;
+}
+
+.voronoi-inspector__meter-fill {
+  display:block;
+  height:100%;
+  background:linear-gradient(90deg,#f97316,#facc15);
+  border-radius:inherit;
+}
+
 #map {
   width:100%;
   height:100%;

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -61,62 +61,52 @@
   color:#1f2937;
 }
 
-.voronoi-switch {
+.voronoi-toggle {
   position:relative;
   display:inline-flex;
   align-items:center;
-  cursor:pointer;
+  padding:3px;
+  border-radius:999px;
+  background:linear-gradient(135deg, rgba(191,219,254,0.55), rgba(148,197,255,0.75));
+  border:1px solid rgba(96,165,250,0.6);
+  gap:4px;
 }
 
-.voronoi-switch__input {
+.voronoi-toggle__input {
   position:absolute;
+  inset:0;
   opacity:0;
-  width:1px;
-  height:1px;
-  margin:0;
+  pointer-events:none;
 }
 
-.voronoi-switch__track {
+.voronoi-toggle__option {
   position:relative;
-  width:48px;
-  height:26px;
+  z-index:1;
+  border:0;
   border-radius:999px;
-  border:1px solid rgba(148,163,184,0.65);
-  background:linear-gradient(135deg, #e2e8f0, #cbd5f5);
-  display:inline-flex;
-  align-items:center;
-  padding:0 4px;
-  transition:background-color 0.24s ease, border-color 0.24s ease;
+  padding:6px 14px;
+  font-size:0.78rem;
+  font-weight:600;
+  color:#1d4ed8;
+  background:transparent;
+  cursor:pointer;
+  transition:color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.voronoi-switch__thumb {
-  width:18px;
-  height:18px;
-  border-radius:999px;
-  background:#fff;
-  box-shadow:0 2px 4px rgba(15,23,42,0.18);
-  transform:translateX(0);
-  transition:transform 0.24s ease;
+.voronoi-toggle__option--active {
+  color:#0b1c4a;
+  background:#e0f2ff;
+  box-shadow:0 6px 16px rgba(30,64,175,0.18);
 }
 
-.voronoi-switch__input:checked + .voronoi-switch__track {
-  background:linear-gradient(135deg, #60a5fa, #2563eb);
-  border-color:#2563eb;
-}
-
-.voronoi-switch__input:checked + .voronoi-switch__track .voronoi-switch__thumb {
-  transform:translateX(20px);
-  box-shadow:0 2px 4px rgba(2,6,23,0.3);
-}
-
-.voronoi-switch__input:focus-visible + .voronoi-switch__track {
-  outline:3px solid rgba(59,130,246,0.45);
+.voronoi-toggle__option:focus-visible {
+  outline:3px solid rgba(59,130,246,0.55);
   outline-offset:2px;
 }
 
 .voronoi-legend {
   width:100%;
-  background:#f8fafc;
+  background:transparent;
   border:1px solid rgba(148,163,184,0.35);
   border-radius:12px;
   padding:12px 14px;
@@ -147,8 +137,8 @@
 }
 
 .voronoi-legend__swatch--source {
-  background:rgba(96,165,250,0.65);
-  border-color:#3b82f6;
+  background:rgba(147,197,253,0.7);
+  border-color:#60a5fa;
 }
 
 .voronoi-legend__label {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -53,27 +53,78 @@
   justify-content:space-between;
 }
 
-.voronoi-toggle-control {
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:12px;
-  width:100%;
-  font-size:0.82rem;
+.voronoi-panel__title {
+  margin:0;
+  font-size:1rem;
+  font-weight:700;
+  letter-spacing:0.01em;
   color:#1f2937;
+}
+
+.voronoi-switch {
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  cursor:pointer;
+}
+
+.voronoi-switch__input {
+  position:absolute;
+  opacity:0;
+  width:1px;
+  height:1px;
+  margin:0;
+}
+
+.voronoi-switch__track {
+  position:relative;
+  width:48px;
+  height:26px;
+  border-radius:999px;
+  border:1px solid rgba(148,163,184,0.65);
+  background:linear-gradient(135deg, #e2e8f0, #cbd5f5);
+  display:inline-flex;
+  align-items:center;
+  padding:0 4px;
+  transition:background-color 0.24s ease, border-color 0.24s ease;
+}
+
+.voronoi-switch__thumb {
+  width:18px;
+  height:18px;
+  border-radius:999px;
+  background:#fff;
+  box-shadow:0 2px 4px rgba(15,23,42,0.18);
+  transform:translateX(0);
+  transition:transform 0.24s ease;
+}
+
+.voronoi-switch__input:checked + .voronoi-switch__track {
+  background:linear-gradient(135deg, #60a5fa, #2563eb);
+  border-color:#2563eb;
+}
+
+.voronoi-switch__input:checked + .voronoi-switch__track .voronoi-switch__thumb {
+  transform:translateX(20px);
+  box-shadow:0 2px 4px rgba(2,6,23,0.3);
+}
+
+.voronoi-switch__input:focus-visible + .voronoi-switch__track {
+  outline:3px solid rgba(59,130,246,0.45);
+  outline-offset:2px;
 }
 
 .voronoi-legend {
   width:100%;
-  background:rgba(30,64,175,0.35);
-  border:1px solid rgba(96,165,250,0.45);
+  background:#f8fafc;
+  border:1px solid rgba(148,163,184,0.35);
   border-radius:12px;
   padding:12px 14px;
   display:flex;
   flex-direction:column;
   gap:8px;
   font-size:0.78rem;
-  color:#dbeafe;
+  color:#1f2937;
 }
 
 .voronoi-legend__item {
@@ -87,8 +138,7 @@
   width:16px;
   height:16px;
   border-radius:4px;
-  border:1px solid rgba(148,163,184,0.6);
-  box-shadow:0 1px 3px rgba(2,6,23,0.4);
+  border:1px solid rgba(148,163,184,0.45);
 }
 
 .voronoi-legend__swatch--selected {
@@ -97,29 +147,13 @@
 }
 
 .voronoi-legend__swatch--source {
-  background:rgba(59,130,246,0.65);
-  border-color:#2563eb;
+  background:rgba(96,165,250,0.65);
+  border-color:#3b82f6;
 }
 
 .voronoi-legend__label {
   font-weight:600;
-  color:#e2e8f0;
-}
-
-.voronoi-toggle-control input[type="checkbox"] {
-  width:18px;
-  height:18px;
-  accent-color:#60a5fa;
-  cursor:pointer;
-  flex-shrink:0;
-}
-
-.voronoi-toggle-control label {
-  cursor:pointer;
-  font-weight:600;
-  color:#0f172a;
-  text-align:left;
-  line-height:1.4;
+  color:#1f2937;
 }
 
 .voronoi-inspector {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -20,39 +20,53 @@
   left:16px;
   display:flex;
   flex-direction:column;
-  gap:8px;
+  gap:12px;
   z-index:5;
   align-items:flex-start;
 }
 
-#map-controls .voronoi-toggle-control {
-  background:rgba(255,255,255,0.9);
-  border:1px solid rgba(148,163,184,0.35);
-  box-shadow:0 12px 24px rgba(15,23,42,0.18);
-  border-radius:10px;
-  padding:10px 14px;
+#map-controls .voronoi-panel {
   display:flex;
-  align-items:center;
-  gap:10px;
-  font-size:0.85rem;
-  color:#1f2937;
+  flex-direction:column;
+  gap:12px;
+  min-width:240px;
+  max-width:320px;
+  background:rgba(248,250,252,0.94);
+  border:1px solid rgba(59,130,246,0.24);
+  box-shadow:0 18px 40px rgba(15,23,42,0.16);
+  border-radius:18px;
+  padding:16px 18px;
+  color:#0f172a;
   backdrop-filter:blur(12px);
   -webkit-backdrop-filter:blur(12px);
 }
 
+#map-controls .voronoi-panel__header {
+  width:100%;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+}
+
+#map-controls .voronoi-toggle-control {
+  display:flex;
+  align-items:center;
+  gap:10px;
+  font-size:0.85rem;
+  color:#0f172a;
+}
+
 #map-controls .voronoi-legend {
-  background:rgba(255,255,255,0.92);
-  border:1px solid rgba(148,163,184,0.35);
-  box-shadow:0 14px 28px rgba(15,23,42,0.22);
-  border-radius:10px;
+  width:100%;
+  background:rgba(37,99,235,0.08);
+  border:1px solid rgba(59,130,246,0.18);
+  border-radius:14px;
   padding:12px 14px;
   display:flex;
   flex-direction:column;
   gap:8px;
   font-size:0.78rem;
-  color:#1f2937;
-  backdrop-filter:blur(12px);
-  -webkit-backdrop-filter:blur(12px);
+  color:#0f172a;
 }
 
 #map-controls .voronoi-legend__item {
@@ -82,36 +96,35 @@
 
 #map-controls .voronoi-legend__label {
   font-weight:600;
-  color:#1f2937;
+  color:#0f172a;
 }
 
 #map-controls .voronoi-toggle-control input[type="checkbox"] {
   width:18px;
   height:18px;
-  accent-color:#4a5568;
+  accent-color:#2563eb;
   cursor:pointer;
 }
 
 #map-controls .voronoi-toggle-control label {
   cursor:pointer;
   font-weight:600;
+  color:#0f172a;
+  flex:1;
 }
 
 #map-controls .voronoi-inspector {
-  min-width:240px;
-  max-width:320px;
-  background:rgba(15,23,42,0.82);
-  color:#e2e8f0;
-  border-radius:12px;
-  border:1px solid rgba(148,163,184,0.35);
-  box-shadow:0 20px 45px rgba(15,23,42,0.28);
+  width:100%;
+  background:rgba(255,255,255,0.92);
+  color:#0f172a;
+  border-radius:14px;
+  border:1px solid rgba(59,130,246,0.24);
+  box-shadow:0 16px 36px rgba(15,23,42,0.18);
   padding:14px 16px;
   display:flex;
   flex-direction:column;
-  gap:10px;
+  gap:12px;
   font-size:0.84rem;
-  backdrop-filter:blur(16px);
-  -webkit-backdrop-filter:blur(16px);
 }
 
 #map-controls .voronoi-inspector[hidden] {
@@ -119,9 +132,9 @@
 }
 
 .voronoi-inspector__title {
-  font-weight:600;
+  font-weight:700;
   font-size:0.9rem;
-  color:#f8fafc;
+  color:#0f172a;
 }
 
 .voronoi-inspector__summary {
@@ -135,11 +148,11 @@
 }
 
 .voronoi-inspector__summary-pill {
-  background:linear-gradient(135deg,rgba(15,23,42,0.9),rgba(30,41,59,0.92));
-  border:1px solid rgba(148,163,184,0.4);
-  border-radius:999px;
-  padding:12px 16px;
-  box-shadow:0 14px 32px rgba(2,6,23,0.45);
+  background:linear-gradient(135deg,rgba(59,130,246,0.12),rgba(59,130,246,0.22));
+  border:1px solid rgba(37,99,235,0.24);
+  border-radius:16px;
+  padding:12px 14px;
+  box-shadow:0 10px 22px rgba(37,99,235,0.18);
   display:flex;
   flex-direction:column;
   gap:8px;
@@ -156,18 +169,18 @@
   font-size:0.72rem;
   letter-spacing:0.02em;
   text-transform:uppercase;
-  color:rgba(226,232,240,0.82);
+  color:#1d4ed8;
 }
 
 .voronoi-inspector__summary-value {
-  font-weight:600;
-  color:#f8fafc;
+  font-weight:700;
+  color:#0f172a;
   font-variant-numeric:tabular-nums;
 }
 
 .voronoi-inspector__empty {
   margin:0;
-  color:rgba(226,232,240,0.85);
+  color:rgba(15,23,42,0.7);
   line-height:1.4;
 }
 
@@ -177,14 +190,14 @@
   list-style:none;
   display:flex;
   flex-direction:column;
-  gap:8px;
+  gap:10px;
 }
 
 .voronoi-inspector__item {
-  background:rgba(15,23,42,0.45);
-  border:1px solid rgba(148,163,184,0.35);
-  border-radius:10px;
-  padding:8px 10px;
+  background:rgba(37,99,235,0.08);
+  border:1px solid rgba(59,130,246,0.2);
+  border-radius:12px;
+  padding:10px 12px;
   display:flex;
   flex-direction:column;
   gap:6px;
@@ -199,7 +212,7 @@
 
 .voronoi-inspector__tag {
   font-weight:600;
-  color:#f1f5f9;
+  color:#0f172a;
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
@@ -207,7 +220,7 @@
 
 .voronoi-inspector__value {
   font-variant-numeric:tabular-nums;
-  color:rgba(226,232,240,0.85);
+  color:#1d4ed8;
   font-size:0.78rem;
 }
 
@@ -215,14 +228,14 @@
   position:relative;
   height:4px;
   border-radius:999px;
-  background:rgba(148,163,184,0.35);
+  background:rgba(191,219,254,0.6);
   overflow:hidden;
 }
 
 .voronoi-inspector__meter-fill {
   display:block;
   height:100%;
-  background:linear-gradient(90deg,#f97316,#facc15);
+  background:linear-gradient(90deg,#38bdf8,#2563eb);
   border-radius:inherit;
 }
 
@@ -290,6 +303,45 @@
   .content-container {
     height:auto;
     overflow-y:visible;
+  }
+}
+
+@media (max-width:768px){
+  #map-controls {
+    left:50%;
+    right:auto;
+    transform:translateX(-50%);
+    align-items:center;
+  }
+
+  #map-controls .voronoi-panel {
+    min-width:unset;
+    width:min(90vw,300px);
+    padding:12px 14px;
+    gap:10px;
+  }
+
+  #map-controls .voronoi-inspector {
+    font-size:0.8rem;
+    max-height:50vh;
+    overflow-y:auto;
+    gap:10px;
+    padding:12px;
+  }
+
+  .voronoi-inspector__summary-pill {
+    flex-direction:row;
+    justify-content:space-between;
+    flex-wrap:wrap;
+    row-gap:6px;
+  }
+
+  .voronoi-inspector__summary-row {
+    width:100%;
+  }
+
+  .voronoi-inspector__list {
+    gap:8px;
   }
 }
 

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -17,170 +17,118 @@
 #map-controls {
   position:absolute;
   bottom:16px;
-  left:16px;
+  right:16px;
   display:flex;
   flex-direction:column;
-  gap:12px;
+  gap:10px;
   z-index:5;
-  align-items:flex-start;
+  align-items:flex-end;
 }
 
 #map-controls .voronoi-panel {
   display:flex;
   flex-direction:column;
-  gap:12px;
-  min-width:240px;
-  max-width:320px;
-  background:rgba(248,250,252,0.94);
-  border:1px solid rgba(59,130,246,0.24);
-  box-shadow:0 18px 40px rgba(15,23,42,0.16);
-  border-radius:18px;
-  padding:16px 18px;
-  color:#0f172a;
-  backdrop-filter:blur(12px);
-  -webkit-backdrop-filter:blur(12px);
+  gap:10px;
+  min-width:180px;
+  max-width:220px;
+  background:rgba(15,23,42,0.92);
+  border:1px solid rgba(59,130,246,0.42);
+  box-shadow:0 12px 28px rgba(2,6,23,0.55);
+  border-radius:14px;
+  padding:12px 14px;
+  color:#e2e8f0;
+  backdrop-filter:blur(10px);
+  -webkit-backdrop-filter:blur(10px);
 }
 
 #map-controls .voronoi-panel__header {
   width:100%;
   display:flex;
   align-items:center;
-  justify-content:space-between;
+  justify-content:flex-end;
 }
 
 #map-controls .voronoi-toggle-control {
   display:flex;
   align-items:center;
-  gap:10px;
-  font-size:0.85rem;
-  color:#0f172a;
+  gap:8px;
+  font-size:0.78rem;
+  color:#cbd5f5;
 }
 
 #map-controls .voronoi-legend {
   width:100%;
-  background:rgba(37,99,235,0.08);
-  border:1px solid rgba(59,130,246,0.18);
-  border-radius:14px;
-  padding:12px 14px;
+  background:rgba(30,64,175,0.35);
+  border:1px solid rgba(96,165,250,0.45);
+  border-radius:10px;
+  padding:8px 10px;
   display:flex;
   flex-direction:column;
-  gap:8px;
-  font-size:0.78rem;
-  color:#0f172a;
+  gap:6px;
+  font-size:0.72rem;
+  color:#dbeafe;
 }
 
 #map-controls .voronoi-legend__item {
   display:flex;
   align-items:center;
-  gap:8px;
+  gap:6px;
   white-space:nowrap;
 }
 
 #map-controls .voronoi-legend__swatch {
-  width:16px;
-  height:16px;
+  width:14px;
+  height:14px;
   border-radius:4px;
-  border:1px solid rgba(15,23,42,0.25);
-  box-shadow:0 2px 4px rgba(15,23,42,0.18);
+  border:1px solid rgba(148,163,184,0.6);
+  box-shadow:0 1px 3px rgba(2,6,23,0.4);
 }
 
 #map-controls .voronoi-legend__swatch--selected {
-  background:#DCFCE7;
-  border-color:#15803D;
+  background:rgba(34,197,94,0.7);
+  border-color:#22c55e;
 }
 
 #map-controls .voronoi-legend__swatch--source {
-  background:#DBEAFE;
-  border-color:#1D4ED8;
+  background:rgba(59,130,246,0.65);
+  border-color:#2563eb;
 }
 
 #map-controls .voronoi-legend__label {
-  font-weight:600;
-  color:#0f172a;
+  font-weight:500;
+  color:#e2e8f0;
 }
 
 #map-controls .voronoi-toggle-control input[type="checkbox"] {
-  width:18px;
-  height:18px;
-  accent-color:#2563eb;
+  width:16px;
+  height:16px;
+  accent-color:#60a5fa;
   cursor:pointer;
 }
 
 #map-controls .voronoi-toggle-control label {
   cursor:pointer;
   font-weight:600;
-  color:#0f172a;
-  flex:1;
+  color:#e0e7ff;
+  text-align:right;
 }
 
 #map-controls .voronoi-inspector {
   width:100%;
-  background:rgba(255,255,255,0.92);
-  color:#0f172a;
-  border-radius:14px;
-  border:1px solid rgba(59,130,246,0.24);
-  box-shadow:0 16px 36px rgba(15,23,42,0.18);
-  padding:14px 16px;
+  color:#f8fafc;
   display:flex;
   flex-direction:column;
-  gap:12px;
-  font-size:0.84rem;
+  gap:6px;
+  font-size:0.74rem;
 }
 
 #map-controls .voronoi-inspector[hidden] {
   display:none !important;
 }
 
-.voronoi-inspector__title {
-  font-weight:700;
-  font-size:0.9rem;
-  color:#0f172a;
-}
-
-.voronoi-inspector__summary {
-  display:flex;
-  flex-direction:column;
-  gap:10px;
-}
-
-.voronoi-inspector__summary[hidden] {
-  display:none !important;
-}
-
-.voronoi-inspector__summary-pill {
-  background:linear-gradient(135deg,rgba(59,130,246,0.12),rgba(59,130,246,0.22));
-  border:1px solid rgba(37,99,235,0.24);
-  border-radius:16px;
-  padding:12px 14px;
-  box-shadow:0 10px 22px rgba(37,99,235,0.18);
-  display:flex;
-  flex-direction:column;
-  gap:8px;
-}
-
-.voronoi-inspector__summary-row {
-  display:flex;
-  align-items:flex-start;
-  justify-content:space-between;
-  gap:12px;
-}
-
-.voronoi-inspector__summary-label {
-  font-size:0.72rem;
-  letter-spacing:0.02em;
-  text-transform:uppercase;
-  color:#1d4ed8;
-}
-
-.voronoi-inspector__summary-value {
-  font-weight:700;
-  color:#0f172a;
-  font-variant-numeric:tabular-nums;
-}
-
 .voronoi-inspector__empty {
   margin:0;
-  color:rgba(15,23,42,0.7);
+  color:rgba(226,232,240,0.8);
   line-height:1.4;
 }
 
@@ -190,20 +138,10 @@
   list-style:none;
   display:flex;
   flex-direction:column;
-  gap:10px;
+  gap:4px;
 }
 
 .voronoi-inspector__item {
-  background:rgba(37,99,235,0.08);
-  border:1px solid rgba(59,130,246,0.2);
-  border-radius:12px;
-  padding:10px 12px;
-  display:flex;
-  flex-direction:column;
-  gap:6px;
-}
-
-.voronoi-inspector__item-header {
   display:flex;
   align-items:center;
   justify-content:space-between;
@@ -212,31 +150,16 @@
 
 .voronoi-inspector__tag {
   font-weight:600;
-  color:#0f172a;
+  color:#e2e8f0;
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
 }
 
-.voronoi-inspector__value {
+.voronoi-inspector__percentage {
+  font-weight:600;
+  color:#bae6fd;
   font-variant-numeric:tabular-nums;
-  color:#1d4ed8;
-  font-size:0.78rem;
-}
-
-.voronoi-inspector__meter {
-  position:relative;
-  height:4px;
-  border-radius:999px;
-  background:rgba(191,219,254,0.6);
-  overflow:hidden;
-}
-
-.voronoi-inspector__meter-fill {
-  display:block;
-  height:100%;
-  background:linear-gradient(90deg,#38bdf8,#2563eb);
-  border-radius:inherit;
 }
 
 #map {
@@ -308,36 +231,25 @@
 
 @media (max-width:768px){
   #map-controls {
-    left:50%;
-    right:auto;
-    transform:translateX(-50%);
-    align-items:center;
+    left:auto;
+    right:12px;
+    transform:none;
+    align-items:flex-end;
   }
 
   #map-controls .voronoi-panel {
     min-width:unset;
-    width:min(90vw,300px);
+    width:min(88vw,260px);
     padding:12px 14px;
-    gap:10px;
+    gap:8px;
   }
 
   #map-controls .voronoi-inspector {
-    font-size:0.8rem;
-    max-height:50vh;
+    font-size:0.78rem;
+    max-height:45vh;
     overflow-y:auto;
-    gap:10px;
-    padding:12px;
-  }
-
-  .voronoi-inspector__summary-pill {
-    flex-direction:row;
-    justify-content:space-between;
-    flex-wrap:wrap;
-    row-gap:6px;
-  }
-
-  .voronoi-inspector__summary-row {
-    width:100%;
+    gap:8px;
+    padding:10px 12px;
   }
 
   .voronoi-inspector__list {

--- a/oferty.html
+++ b/oferty.html
@@ -2571,7 +2571,10 @@ window.showConfirmModal = showConfirmModal;
   }
 
   function clearVoronoiLayer(options = {}) {
-    const { resetHighlight = true } = options || {};
+    const {
+      resetHighlight = true,
+      preserveResolvedData = false
+    } = options || {};
     clearVoronoiHighlights({ resetSelection: resetHighlight });
 
     voronoiLayerState.polygons.forEach(poly => {
@@ -2599,10 +2602,12 @@ window.showConfirmModal = showConfirmModal;
     voronoiLayerState.labels = [];
     voronoiLayerState.labelLayout.boxes = [];
     voronoiLayerState.labelLayout.projectionPending = false;
-    voronoiLayerState.connectorIndexMap = new Map();
-    voronoiLayerState.resolvedValues = [];
-    voronoiLayerState.datasetSnapshot = [];
-    voronoiLayerState.cells = [];
+    if (!preserveResolvedData) {
+      voronoiLayerState.connectorIndexMap = new Map();
+      voronoiLayerState.resolvedValues = [];
+      voronoiLayerState.datasetSnapshot = [];
+      voronoiLayerState.cells = [];
+    }
   }
 
   function getVoronoiSourceOffers() {
@@ -2634,8 +2639,7 @@ window.showConfirmModal = showConfirmModal;
     }
 
     if (shouldHideVoronoiLayer()) {
-      clearVoronoiLayer();
-      voronoiLayerState.cachedDataset = null;
+      clearVoronoiLayer({ resetHighlight: false, preserveResolvedData: true });
       return;
     }
 

--- a/oferty.html
+++ b/oferty.html
@@ -242,20 +242,20 @@ window.showConfirmModal = showConfirmModal;
                 <button
                   type="button"
                   class="voronoi-toggle__option"
-                  data-voronoi-toggle="off"
-                  aria-pressed="false"
-                  aria-label="Wyłącz warstwę"
-                >
-                  Wył.
-                </button>
-                <button
-                  type="button"
-                  class="voronoi-toggle__option"
                   data-voronoi-toggle="on"
                   aria-pressed="false"
                   aria-label="Włącz warstwę"
                 >
                   Wł.
+                </button>
+                <button
+                  type="button"
+                  class="voronoi-toggle__option"
+                  data-voronoi-toggle="off"
+                  aria-pressed="false"
+                  aria-label="Wyłącz warstwę"
+                >
+                  Wył.
                 </button>
               </div>
             </div>

--- a/oferty.html
+++ b/oferty.html
@@ -1463,9 +1463,57 @@ window.showConfirmModal = showConfirmModal;
   }
 
   function computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset) {
+    const baseEntry = baseValues[index] || {};
+    const directNeighbors = (adjacencyList[index] || []).filter(i => Number.isInteger(i));
+    const directPriced = directNeighbors
+      .map(neighborIndex => ({ index: neighborIndex, value: baseValues[neighborIndex] }))
+      .filter(entry => entry.value?.hasPrice && entry.value.price > 0);
+
+    if (directPriced.length) {
+      const ppm2Values = directPriced
+        .map(entry => Number(entry.value.pricePerSqm))
+        .filter(value => Number.isFinite(value) && value > 0);
+      const priceValues = directPriced
+        .map(entry => Number(entry.value.price))
+        .filter(value => Number.isFinite(value) && value > 0);
+
+      const averagePpm2 = ppm2Values.length
+        ? ppm2Values.reduce((sum, value) => sum + value, 0) / ppm2Values.length
+        : 0;
+      const averagePrice = priceValues.length
+        ? priceValues.reduce((sum, value) => sum + value, 0) / priceValues.length
+        : 0;
+
+      const area = Number(baseEntry.area);
+      const resolvedPricePerSqm = averagePpm2 > 0
+        ? averagePpm2
+        : (averagePrice > 0 && area > 0)
+          ? averagePrice / area
+          : 0;
+      const resolvedPrice = area > 0 && resolvedPricePerSqm > 0
+        ? resolvedPricePerSqm * area
+        : averagePrice;
+
+      if (resolvedPrice > 0) {
+        const seen = new Set();
+        const paths = [];
+        directPriced.forEach(entry => {
+          if (!seen.has(entry.index)) {
+            seen.add(entry.index);
+            paths.push([index, entry.index]);
+          }
+        });
+        return {
+          price: resolvedPrice,
+          pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
+          paths
+        };
+      }
+    }
+
     const visited = new Set([index]);
     const parents = new Map();
-    let frontier = (adjacencyList[index] || []).filter(i => Number.isInteger(i));
+    let frontier = directNeighbors.slice();
 
     frontier.forEach(neighborIndex => {
       if (Number.isInteger(neighborIndex)) {
@@ -1537,7 +1585,7 @@ window.showConfirmModal = showConfirmModal;
             return {
               price: chosenValue.price,
               pricePerSqm: chosenValue.pricePerSqm,
-              path: Array.isArray(chosenPath) ? chosenPath : null
+              paths: Array.isArray(chosenPath) ? [chosenPath] : []
             };
           }
         }
@@ -1569,14 +1617,18 @@ window.showConfirmModal = showConfirmModal;
         };
       }
 
+      const sourcePaths = Array.isArray(fallback.paths)
+        ? fallback.paths.filter(path => Array.isArray(path) && path.length >= 2).map(path => path.slice())
+        : (Array.isArray(fallback.path) && fallback.path.length >= 2)
+          ? [fallback.path.slice()]
+          : [];
+
       return {
         ...entry,
         price: fallback.price,
         pricePerSqm: fallback.pricePerSqm,
         hasPrice: true,
-        fallbackSources: Array.isArray(fallback.path) && fallback.path.length >= 2
-          ? [fallback.path.slice()]
-          : []
+        fallbackSources: sourcePaths
       };
     });
   }

--- a/oferty.html
+++ b/oferty.html
@@ -1595,12 +1595,24 @@ window.showConfirmModal = showConfirmModal;
       return null;
     }
 
-    const resolvedPricePerSqm = metrics.pricePerSqm > 0 ? metrics.pricePerSqm : 0;
+    const sourceArea = Number(baseValues[bestSource.sourceIndex]?.area);
+    const fallbackArea = Number.isFinite(baseArea) && baseArea > 0
+      ? baseArea
+      : (Number.isFinite(sourceArea) && sourceArea > 0 ? sourceArea : 0);
+
+    let resolvedPricePerSqm = metrics.pricePerSqm > 0 ? metrics.pricePerSqm : 0;
+    if (!(resolvedPricePerSqm > 0) && metrics.price > 0 && fallbackArea > 0) {
+      resolvedPricePerSqm = metrics.price / fallbackArea;
+    }
+
     let resolvedPrice = 0;
     if (resolvedPricePerSqm > 0 && Number.isFinite(baseArea) && baseArea > 0) {
       resolvedPrice = resolvedPricePerSqm * baseArea;
-    } else {
-      resolvedPrice = metrics.price > 0 ? metrics.price : 0;
+    } else if (metrics.price > 0) {
+      resolvedPrice = metrics.price;
+      if (!(resolvedPricePerSqm > 0) && fallbackArea > 0) {
+        resolvedPricePerSqm = metrics.price / fallbackArea;
+      }
     }
 
     if (!(resolvedPrice > 0) && !(resolvedPricePerSqm > 0)) {
@@ -2208,19 +2220,29 @@ window.showConfirmModal = showConfirmModal;
     cells.forEach((cell, index) => {
       if (!cell) return;
       let stats = aggregateVoronoiValues(resolvedValues, index);
-      if ((!stats || stats.pricePerSqm <= 0) && resolvedValues[index] && Number.isFinite(resolvedValues[index].pricePerSqm) && resolvedValues[index].pricePerSqm > 0) {
+      const resolvedEntry = resolvedValues[index];
+      const resolvedPricePerSqm = Number(resolvedEntry?.pricePerSqm);
+      const resolvedPriceValue = Number(resolvedEntry?.price);
+      const hasFallbackSources = Array.isArray(resolvedEntry?.fallbackSources) && resolvedEntry.fallbackSources.length > 0;
+
+      if (
+        (!stats || stats.pricePerSqm <= 0 || stats.price <= 0)
+        && resolvedEntry
+        && ((Number.isFinite(resolvedPricePerSqm) && resolvedPricePerSqm > 0) || (Number.isFinite(resolvedPriceValue) && resolvedPriceValue > 0))
+      ) {
         stats = {
-          price: resolvedValues[index].price,
-          pricePerSqm: resolvedValues[index].pricePerSqm
+          price: Number.isFinite(resolvedPriceValue) && resolvedPriceValue > 0 ? resolvedPriceValue : 0,
+          pricePerSqm: Number.isFinite(resolvedPricePerSqm) && resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0
         };
       }
+
       if (!stats) {
         stats = { price: 0, pricePerSqm: 0 };
       }
-      const fallbackSources = Array.isArray(resolvedValues[index]?.fallbackSources)
-        ? resolvedValues[index].fallbackSources
+      const fallbackSources = Array.isArray(resolvedEntry?.fallbackSources)
+        ? resolvedEntry.fallbackSources
         : [];
-      const isFallback = fallbackSources.length > 0;
+      const isFallback = hasFallbackSources;
       const content = buildVoronoiLabelContent(stats, { fallback: isFallback });
 
       const polygon = new google.maps.Polygon({

--- a/oferty.html
+++ b/oferty.html
@@ -227,6 +227,16 @@ window.showConfirmModal = showConfirmModal;
           <input type="checkbox" id="toggleVoronoiLayer" />
           <label for="toggleVoronoiLayer">Wycena nieruchomości (beta)</label>
         </div>
+        <div class="voronoi-legend" aria-live="polite">
+          <div class="voronoi-legend__item">
+            <span class="voronoi-legend__swatch voronoi-legend__swatch--selected" aria-hidden="true"></span>
+            <span class="voronoi-legend__label">Wybrana działka</span>
+          </div>
+          <div class="voronoi-legend__item">
+            <span class="voronoi-legend__swatch voronoi-legend__swatch--source" aria-hidden="true"></span>
+            <span class="voronoi-legend__label">Źródło wyceny</span>
+          </div>
+        </div>
         <div
           class="voronoi-inspector"
           id="voronoiInspector"

--- a/oferty.html
+++ b/oferty.html
@@ -470,8 +470,8 @@ window.showConfirmModal = showConfirmModal;
   };
 
   const VORONOI_LABEL_SIZE = {
-    width: 132,
-    height: 34
+    width: 150,
+    height: 42
   };
 
   const VORONOI_FREEZE_ZOOM_LEVEL = 16;
@@ -542,6 +542,28 @@ window.showConfirmModal = showConfirmModal;
       }
     }
     return true;
+  }
+
+  function determineVoronoiLabelDensity(count) {
+    if (!Number.isFinite(count) || count <= 0) {
+      return 'default';
+    }
+    const zoom = getMapZoomLevel();
+    if (!Number.isFinite(zoom)) {
+      return 'default';
+    }
+
+    if (count >= 220 && zoom <= 16) {
+      return 'compact';
+    }
+    if (count >= 160 && zoom <= 15) {
+      return 'compact';
+    }
+    if (count >= 110 && zoom <= 14) {
+      return 'compact';
+    }
+
+    return 'default';
   }
 
   const MAP_STATE_STORAGE_KEY = 'grunteo::offers::mapState';
@@ -1464,50 +1486,47 @@ window.showConfirmModal = showConfirmModal;
 
   function computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset) {
     const baseEntry = baseValues[index] || {};
+    const basePosition = dataset[index]?.position || null;
     const directNeighbors = (adjacencyList[index] || []).filter(i => Number.isInteger(i));
     const directPriced = directNeighbors
       .map(neighborIndex => ({ index: neighborIndex, value: baseValues[neighborIndex] }))
       .filter(entry => entry.value?.hasPrice && entry.value.price > 0);
 
     if (directPriced.length) {
-      const ppm2Values = directPriced
-        .map(entry => Number(entry.value.pricePerSqm))
-        .filter(value => Number.isFinite(value) && value > 0);
-      const priceValues = directPriced
-        .map(entry => Number(entry.value.price))
-        .filter(value => Number.isFinite(value) && value > 0);
+      let chosenEntry = null;
+      let bestDistance = Infinity;
 
-      const averagePpm2 = ppm2Values.length
-        ? ppm2Values.reduce((sum, value) => sum + value, 0) / ppm2Values.length
-        : 0;
-      const averagePrice = priceValues.length
-        ? priceValues.reduce((sum, value) => sum + value, 0) / priceValues.length
-        : 0;
+      directPriced.forEach(entry => {
+        const neighborPosition = dataset[entry.index]?.position || null;
+        const distance = computeDistanceBetweenPoints(basePosition, neighborPosition);
+        const normalizedDistance = Number.isFinite(distance) ? distance : 0;
+        if (normalizedDistance < bestDistance) {
+          bestDistance = normalizedDistance;
+          chosenEntry = entry;
+        }
+      });
 
-      const area = Number(baseEntry.area);
-      const resolvedPricePerSqm = averagePpm2 > 0
-        ? averagePpm2
-        : (averagePrice > 0 && area > 0)
-          ? averagePrice / area
-          : 0;
-      const resolvedPrice = area > 0 && resolvedPricePerSqm > 0
-        ? resolvedPricePerSqm * area
-        : averagePrice;
+      if (chosenEntry) {
+        const neighborValue = chosenEntry.value;
+        const area = Number(baseEntry.area);
+        const neighborPricePerSqm = Number(neighborValue.pricePerSqm);
+        const neighborPrice = Number(neighborValue.price);
+        const resolvedPricePerSqm = neighborPricePerSqm > 0
+          ? neighborPricePerSqm
+          : (neighborPrice > 0 && area > 0)
+            ? neighborPrice / area
+            : 0;
+        const resolvedPrice = area > 0 && resolvedPricePerSqm > 0
+          ? resolvedPricePerSqm * area
+          : neighborPrice;
 
-      if (resolvedPrice > 0) {
-        const seen = new Set();
-        const paths = [];
-        directPriced.forEach(entry => {
-          if (!seen.has(entry.index)) {
-            seen.add(entry.index);
-            paths.push([index, entry.index]);
-          }
-        });
-        return {
-          price: resolvedPrice,
-          pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-          paths
-        };
+        if (resolvedPrice > 0) {
+          return {
+            price: resolvedPrice,
+            pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
+            paths: [[index, chosenEntry.index]]
+          };
+        }
       }
     }
 
@@ -1572,8 +1591,9 @@ window.showConfirmModal = showConfirmModal;
           }
           const normalizedPath = path.reverse();
           const distance = computePathDistance(normalizedPath, dataset);
-          if (distance < chosenDistance) {
-            chosenDistance = distance;
+          const normalizedDistance = Number.isFinite(distance) ? distance : Number.MAX_VALUE;
+          if (normalizedDistance < chosenDistance) {
+            chosenDistance = normalizedDistance;
             chosenIndex = targetIndex;
             chosenPath = normalizedPath;
           }
@@ -1582,11 +1602,25 @@ window.showConfirmModal = showConfirmModal;
         if (chosenIndex !== null) {
           const chosenValue = baseValues[chosenIndex];
           if (chosenValue?.hasPrice && chosenValue.price > 0) {
-            return {
-              price: chosenValue.price,
-              pricePerSqm: chosenValue.pricePerSqm,
-              paths: Array.isArray(chosenPath) ? [chosenPath] : []
-            };
+            const area = Number(baseEntry.area);
+            const neighborPricePerSqm = Number(chosenValue.pricePerSqm);
+            const neighborPrice = Number(chosenValue.price);
+            const resolvedPricePerSqm = neighborPricePerSqm > 0
+              ? neighborPricePerSqm
+              : (neighborPrice > 0 && area > 0)
+                ? neighborPrice / area
+                : 0;
+            const resolvedPrice = area > 0 && resolvedPricePerSqm > 0
+              ? resolvedPricePerSqm * area
+              : neighborPrice;
+
+            if (resolvedPrice > 0) {
+              return {
+                price: resolvedPrice,
+                pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
+                paths: Array.isArray(chosenPath) ? [chosenPath] : []
+              };
+            }
           }
         }
 
@@ -1784,11 +1818,35 @@ window.showConfirmModal = showConfirmModal;
     return rounded.toLocaleString('pl-PL');
   }
 
-  function buildVoronoiLabelContent(stats) {
+  function buildVoronoiLabelContent(stats, options = {}) {
+    const isFallback = options.fallback === true;
     const ppm2 = `${formatPriceValue(stats.pricePerSqm)} zł/m²`;
+    const priceValue = Number.isFinite(stats.price) && stats.price > 0
+      ? `${formatPriceValue(stats.price)} zł`
+      : null;
+
+    const parts = [];
+    if (isFallback) {
+      parts.push('<span class="voronoi-label__badge" aria-hidden="true">szac.</span>');
+    }
+    const stackParts = [`<span class="voronoi-label__value">${ppm2}</span>`];
+    if (priceValue) {
+      stackParts.push(`<span class="voronoi-label__price">${priceValue}</span>`);
+    }
+    parts.push(`<span class="voronoi-label__stack">${stackParts.join('')}</span>`);
+
+    const plainParts = [ppm2];
+    if (priceValue) {
+      plainParts.push(priceValue);
+    }
+    if (isFallback) {
+      plainParts.push('szac.');
+    }
+
     return {
-      html: `<span class="voronoi-label__value">${ppm2}</span>`,
-      plain: ppm2
+      html: parts.join(''),
+      plain: plainParts.join(' · '),
+      fallback: isFallback
     };
   }
 
@@ -1926,13 +1984,21 @@ window.showConfirmModal = showConfirmModal;
     return first || fallback || null;
   }
 
-  function createVoronoiLabelNode(htmlContent, fallbackText, position) {
+  function createVoronoiLabelNode(htmlContent, fallbackText, position, options = {}) {
     if (!position) return null;
+    const isFallback = options.fallback === true;
+    const density = typeof options.density === 'string' ? options.density : 'default';
     try {
       if (google?.maps?.marker?.AdvancedMarkerElement) {
         const wrapper = document.createElement('div');
         wrapper.className = 'voronoi-label';
         wrapper.innerHTML = htmlContent;
+        if (isFallback) {
+          wrapper.dataset.fallback = 'true';
+        }
+        if (density && density !== 'default') {
+          wrapper.dataset.density = density;
+        }
         return new google.maps.marker.AdvancedMarkerElement({
           position,
           map: voronoiLayerState.enabled ? map : null,
@@ -2147,6 +2213,7 @@ window.showConfirmModal = showConfirmModal;
     resetVoronoiLabelLayout();
 
     const shouldRenderLabels = shouldRenderVoronoiLabelsForDatasetSize(dataset.length);
+    const labelDensity = determineVoronoiLabelDensity(dataset.length);
     const cells = dataset.map(({ position }, index) => {
       if (!voronoi) return null;
       const polygonCoords = voronoi.cellPolygon(index);
@@ -2168,7 +2235,11 @@ window.showConfirmModal = showConfirmModal;
       if (!stats) {
         stats = { price: 0, pricePerSqm: 0 };
       }
-      const content = buildVoronoiLabelContent(stats);
+      const fallbackSources = Array.isArray(resolvedValues[index]?.fallbackSources)
+        ? resolvedValues[index].fallbackSources
+        : [];
+      const isFallback = fallbackSources.length > 0;
+      const content = buildVoronoiLabelContent(stats, { fallback: isFallback });
 
       const polygon = new google.maps.Polygon({
         paths: cell.path,
@@ -2185,15 +2256,15 @@ window.showConfirmModal = showConfirmModal;
 
       if (shouldRenderLabels) {
         const labelPosition = findNonOverlappingLabelPosition(cell.centroid || cell.position);
-        const label = createVoronoiLabelNode(content.html, content.plain, labelPosition);
+        const label = createVoronoiLabelNode(content.html, content.plain, labelPosition, {
+          fallback: isFallback,
+          density: labelDensity
+        });
         if (label) {
           voronoiLayerState.labels.push(label);
         }
       }
 
-      const fallbackSources = Array.isArray(resolvedValues[index]?.fallbackSources)
-        ? resolvedValues[index].fallbackSources
-        : [];
       fallbackSources.forEach(pathIndices => {
         const connectorPath = Array.isArray(pathIndices)
           ? pathIndices

--- a/oferty.html
+++ b/oferty.html
@@ -234,6 +234,23 @@ window.showConfirmModal = showConfirmModal;
           hidden
         >
           <div class="voronoi-inspector__title">Tagi i wagi</div>
+          <div
+            class="voronoi-inspector__summary"
+            id="voronoiInspectorSummary"
+            aria-hidden="true"
+            hidden
+          >
+            <div class="voronoi-inspector__summary-pill">
+              <div class="voronoi-inspector__summary-row">
+                <span class="voronoi-inspector__summary-label">Śr. cena za m²</span>
+                <span class="voronoi-inspector__summary-value" id="voronoiInspectorPricePerSqm">—</span>
+              </div>
+              <div class="voronoi-inspector__summary-row">
+                <span class="voronoi-inspector__summary-label">Szacunkowa wartość działki</span>
+                <span class="voronoi-inspector__summary-value" id="voronoiInspectorEstimatedValue">—</span>
+              </div>
+            </div>
+          </div>
           <p
             class="voronoi-inspector__empty"
             id="voronoiInspectorEmpty"
@@ -575,10 +592,85 @@ window.showConfirmModal = showConfirmModal;
     const container = document.getElementById('voronoiInspector');
     const list = document.getElementById('voronoiInspectorList');
     const emptyState = document.getElementById('voronoiInspectorEmpty');
+    const summary = document.getElementById('voronoiInspectorSummary');
+    const average = document.getElementById('voronoiInspectorPricePerSqm');
+    const estimated = document.getElementById('voronoiInspectorEstimatedValue');
     if (!container || !list || !emptyState) {
       return null;
     }
-    return { container, list, emptyState };
+    return { container, list, emptyState, summary, average, estimated };
+  }
+
+  function extractPlotAreaFromOffer(offer) {
+    if (!offer || typeof offer !== 'object') {
+      return 0;
+    }
+    const plot = offer.plot || {};
+    const candidates = [
+      plot.pow_dzialki_m2_uldk,
+      plot.powierzchnia,
+      plot.powierzchnia_m2,
+      plot.area,
+      plot.areaM2,
+      plot.powierzchniaDzialki,
+      offer.area,
+      offer.areaM2
+    ];
+    for (const candidate of candidates) {
+      const value = Number(candidate);
+      if (Number.isFinite(value) && value > 0) {
+        return value;
+      }
+    }
+    return 0;
+  }
+
+  function updateVoronoiInspectorSummary(elements, datasetEntry, resolvedEntry) {
+    if (!elements) return;
+    const { summary, average, estimated } = elements;
+    if (!summary || !average || !estimated) {
+      return;
+    }
+
+    const offer = datasetEntry?.offer || null;
+    const baseStats = offer ? computeOfferValueWithTags(offer) : null;
+
+    let area = Number(baseStats?.area);
+    if (!(Number.isFinite(area) && area > 0)) {
+      const extractedArea = extractPlotAreaFromOffer(offer);
+      area = Number.isFinite(extractedArea) && extractedArea > 0 ? extractedArea : 0;
+    }
+
+    let pricePerSqm = Number(resolvedEntry?.pricePerSqm);
+    let price = Number(resolvedEntry?.price);
+
+    if (!(pricePerSqm > 0) && Number.isFinite(baseStats?.pricePerSqm) && baseStats.pricePerSqm > 0) {
+      pricePerSqm = baseStats.pricePerSqm;
+    }
+    if (!(price > 0) && Number.isFinite(baseStats?.price) && baseStats.price > 0) {
+      price = baseStats.price;
+    }
+
+    if (!(price > 0) && pricePerSqm > 0 && area > 0) {
+      price = pricePerSqm * area;
+    }
+    if (!(pricePerSqm > 0) && price > 0 && area > 0) {
+      pricePerSqm = price / area;
+    }
+
+    const hasSummary = (pricePerSqm > 0) || (price > 0);
+
+    if (hasSummary) {
+      summary.hidden = false;
+      summary.setAttribute('aria-hidden', 'false');
+      average.textContent = pricePerSqm > 0 ? `${formatPriceValue(pricePerSqm)} zł/m²` : '—';
+      estimated.textContent = price > 0 ? `${formatPriceValue(price)} zł` : '—';
+    } else {
+      summary.hidden = true;
+      summary.setAttribute('aria-hidden', 'true');
+      average.textContent = '—';
+      estimated.textContent = '—';
+    }
   }
 
   function hideVoronoiTagInspector() {
@@ -591,6 +683,7 @@ window.showConfirmModal = showConfirmModal;
     emptyState.hidden = false;
     container.setAttribute('hidden', 'true');
     container.setAttribute('aria-hidden', 'true');
+    updateVoronoiInspectorSummary(elements, null, null);
   }
 
   function updateVoronoiTagInspector(index) {
@@ -606,6 +699,10 @@ window.showConfirmModal = showConfirmModal;
     const datasetEntry = Array.isArray(voronoiLayerState.datasetSnapshot)
       ? voronoiLayerState.datasetSnapshot[index]
       : null;
+    const resolvedEntry = Array.isArray(voronoiLayerState.resolvedValues)
+      ? voronoiLayerState.resolvedValues[index]
+      : null;
+    updateVoronoiInspectorSummary(elements, datasetEntry, resolvedEntry);
     const offerTags = Array.isArray(datasetEntry?.offer?.tags)
       ? datasetEntry.offer.tags.filter(tag => typeof tag === 'string' && tag.trim().length)
       : [];

--- a/oferty.html
+++ b/oferty.html
@@ -222,7 +222,12 @@ window.showConfirmModal = showConfirmModal;
     <!-- Lewa strona - statyczna mapa -->
     <div class="map-container">
       <div id="map"></div>
-      <div id="map-controls">
+      <div id="map-controls"></div>
+    </div>
+
+    <!-- Prawa strona - przewijana zawartość -->
+    <div class="content-container">
+      <div class="sidebar-stack">
         <div class="voronoi-panel" id="voronoiPanel">
           <div class="voronoi-panel__header">
             <div class="voronoi-toggle-control">
@@ -256,34 +261,31 @@ window.showConfirmModal = showConfirmModal;
             <ul class="voronoi-inspector__list" id="voronoiInspectorList"></ul>
           </div>
         </div>
-      </div>
-    </div>
-    
-    <!-- Prawa strona - przewijana zawartość -->
-    <div class="content-container">
-      <!-- Panel filtrów ofert -->
-      <div class="filters-panel" id="filtersPanel">
-        <h3 class="filters-title">Filtruj działki</h3>
-        <div class="filters-row sort-row">
-          <span class="filters-label">Sortuj:</span>
-          <div class="sort-buttons">
-            <button type="button" class="sort-chip" data-sort-key="price" aria-pressed="false">
-              Cena
-            </button>
-            <button type="button" class="sort-chip" data-sort-key="area" aria-pressed="false">
-              Powierzchnia
-            </button>
-          </div>
-        </div>
-        <div class="filters-row tags-row">
-          <span class="filters-label">Tagi:</span>
-          <div class="tags-area">
-            <div class="tags-wrapper" id="tagFiltersList" data-expanded="false">
-              <span class="tag-placeholder">Ładuję tagi…</span>
+
+        <!-- Panel filtrów ofert -->
+        <div class="filters-panel" id="filtersPanel">
+          <h3 class="filters-title">Filtruj działki</h3>
+          <div class="filters-row sort-row">
+            <span class="filters-label">Sortuj:</span>
+            <div class="sort-buttons">
+              <button type="button" class="sort-chip" data-sort-key="price" aria-pressed="false">
+                Cena
+              </button>
+              <button type="button" class="sort-chip" data-sort-key="area" aria-pressed="false">
+                Powierzchnia
+              </button>
             </div>
-            <button type="button" class="toggle-tags-btn" id="toggleTagsBtn" aria-expanded="false" aria-controls="tagFiltersList" hidden>
-              Pokaż wszystkie tagi
-            </button>
+          </div>
+          <div class="filters-row tags-row">
+            <span class="filters-label">Tagi:</span>
+            <div class="tags-area">
+              <div class="tags-wrapper" id="tagFiltersList" data-expanded="false">
+                <span class="tag-placeholder">Ładuję tagi…</span>
+              </div>
+              <button type="button" class="toggle-tags-btn" id="toggleTagsBtn" aria-expanded="false" aria-controls="tagFiltersList" hidden>
+                Pokaż wszystkie tagi
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/oferty.html
+++ b/oferty.html
@@ -466,13 +466,147 @@ window.showConfirmModal = showConfirmModal;
       projectionPending: false
     },
     cachedDataset: null,
-    cacheSignature: null
+    cacheSignature: null,
+    connectorIndexMap: new Map(),
+    resolvedValues: [],
+    datasetSnapshot: [],
+    cells: [],
+    highlight: {
+      baseIndex: null,
+      polygons: new Set(),
+      connectors: new Set()
+    }
   };
 
   const VORONOI_LABEL_SIZE = {
     width: 150,
     height: 42
   };
+
+  function getVoronoiPolygonStyle(mode = 'default') {
+    if (mode === 'baseHighlight') {
+      return {
+        strokeColor: '#DC2626',
+        strokeOpacity: 0.95,
+        strokeWeight: 2.4,
+        fillColor: '#FEE2E2',
+        fillOpacity: 0.55
+      };
+    }
+    if (mode === 'sourceHighlight') {
+      return {
+        strokeColor: '#F87171',
+        strokeOpacity: 0.9,
+        strokeWeight: 2,
+        fillColor: '#FFE4E6',
+        fillOpacity: 0.45
+      };
+    }
+    return {
+      strokeColor: '#D1D5DB',
+      strokeOpacity: 0.8,
+      strokeWeight: 1.2,
+      fillColor: '#FFFFFF',
+      fillOpacity: 0.28
+    };
+  }
+
+  function applyVoronoiPolygonStyle(polygon, mode = 'default') {
+    if (!polygon || typeof polygon.setOptions !== 'function') {
+      return;
+    }
+    polygon.setOptions(getVoronoiPolygonStyle(mode));
+  }
+
+  function buildVoronoiConnectorStyle(mode = 'default') {
+    const presets = mode === 'highlight'
+      ? { strokeOpacity: 0.95, strokeWeight: 2, scale: 3, repeat: '10px', zIndex: 41 }
+      : { strokeOpacity: 0.65, strokeWeight: 1.1, scale: 2, repeat: '12px', zIndex: 38 };
+
+    return {
+      strokeColor: '#DC2626',
+      strokeOpacity: presets.strokeOpacity,
+      strokeWeight: presets.strokeWeight,
+      geodesic: true,
+      icons: [{
+        icon: { path: 'M 0,-1 0,1', strokeOpacity: 1, scale: presets.scale },
+        offset: '0',
+        repeat: presets.repeat
+      }],
+      zIndex: presets.zIndex
+    };
+  }
+
+  function applyVoronoiConnectorStyle(connector, mode = 'default') {
+    if (!connector || typeof connector.setOptions !== 'function') {
+      return;
+    }
+    connector.setOptions(buildVoronoiConnectorStyle(mode));
+  }
+
+  function clearVoronoiHighlights() {
+    const highlight = voronoiLayerState.highlight;
+    if (highlight.polygons.size) {
+      highlight.polygons.forEach(polygon => applyVoronoiPolygonStyle(polygon, 'default'));
+    }
+    if (highlight.connectors.size) {
+      highlight.connectors.forEach(connector => applyVoronoiConnectorStyle(connector, 'default'));
+    }
+    highlight.polygons.clear();
+    highlight.connectors.clear();
+    highlight.baseIndex = null;
+  }
+
+  function highlightVoronoiPolygon(index) {
+    if (!Number.isInteger(index) || index < 0) {
+      return;
+    }
+    const polygon = voronoiLayerState.polygons[index];
+    if (!polygon) {
+      return;
+    }
+
+    clearVoronoiHighlights();
+
+    const highlight = voronoiLayerState.highlight;
+    applyVoronoiPolygonStyle(polygon, 'baseHighlight');
+    highlight.polygons.add(polygon);
+    highlight.baseIndex = index;
+
+    const resolvedEntry = Array.isArray(voronoiLayerState.resolvedValues)
+      ? voronoiLayerState.resolvedValues[index]
+      : null;
+    const fallbackSources = Array.isArray(resolvedEntry?.fallbackSources)
+      ? resolvedEntry.fallbackSources
+      : [];
+    const uniqueSources = new Set();
+
+    fallbackSources.forEach(path => {
+      if (!Array.isArray(path) || path.length < 2) return;
+      const sourceIndex = path[path.length - 1];
+      if (Number.isInteger(sourceIndex)) {
+        uniqueSources.add(sourceIndex);
+      }
+    });
+
+    uniqueSources.forEach(sourceIndex => {
+      if (sourceIndex === index) return;
+      const sourcePolygon = voronoiLayerState.polygons[sourceIndex];
+      if (!sourcePolygon) return;
+      applyVoronoiPolygonStyle(sourcePolygon, 'sourceHighlight');
+      highlight.polygons.add(sourcePolygon);
+    });
+
+    const connectorList = voronoiLayerState.connectorIndexMap instanceof Map
+      ? voronoiLayerState.connectorIndexMap.get(index)
+      : null;
+    if (Array.isArray(connectorList)) {
+      connectorList.forEach(connector => {
+        applyVoronoiConnectorStyle(connector, 'highlight');
+        highlight.connectors.add(connector);
+      });
+    }
+  }
 
   const VORONOI_FREEZE_ZOOM_LEVEL = 15;
   const VORONOI_LABEL_BASE_MIN_ZOOM = 13;
@@ -1511,6 +1645,49 @@ window.showConfirmModal = showConfirmModal;
       };
     };
 
+    const pricedNeighbors = directNeighbors
+      .map(neighbor => ({ index: neighbor, metrics: buildPriceMetrics(baseValues[neighbor]) }))
+      .filter(entry => !!entry.metrics);
+
+    if (pricedNeighbors.length) {
+      const validPerSqm = pricedNeighbors
+        .map(entry => entry.metrics.pricePerSqm)
+        .filter(value => Number.isFinite(value) && value > 0);
+      const avgPerSqm = validPerSqm.length
+        ? validPerSqm.reduce((sum, value) => sum + value, 0) / validPerSqm.length
+        : 0;
+
+      const validPrices = pricedNeighbors
+        .map(entry => entry.metrics.price)
+        .filter(value => Number.isFinite(value) && value > 0);
+      let resolvedPrice = 0;
+      let resolvedPricePerSqm = avgPerSqm > 0 ? avgPerSqm : 0;
+
+      if (resolvedPricePerSqm > 0 && Number.isFinite(baseArea) && baseArea > 0) {
+        resolvedPrice = resolvedPricePerSqm * baseArea;
+      } else if (validPrices.length) {
+        resolvedPrice = validPrices.reduce((sum, value) => sum + value, 0) / validPrices.length;
+        if (!(resolvedPricePerSqm > 0) && Number.isFinite(baseArea) && baseArea > 0) {
+          resolvedPricePerSqm = resolvedPrice / baseArea;
+        }
+      }
+
+      if (!(resolvedPrice > 0) && !(resolvedPricePerSqm > 0)) {
+        return null;
+      }
+
+      const sources = pricedNeighbors.map(entry => ({
+        sourceIndex: entry.index,
+        directPath: [index, entry.index]
+      }));
+
+      return {
+        price: resolvedPrice > 0 ? resolvedPrice : 0,
+        pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
+        sources
+      };
+    }
+
     const reconstructPath = (targetIndex, parentsMap) => {
       const path = [targetIndex];
       let current = targetIndex;
@@ -1586,13 +1763,23 @@ window.showConfirmModal = showConfirmModal;
     };
 
     const bestSource = findNearestPricedPolygon();
-    if (!bestSource || !Array.isArray(bestSource.path) || bestSource.path.length < 2) {
+    if (!bestSource) {
       return null;
     }
 
     const metrics = buildPriceMetrics(baseValues[bestSource.sourceIndex]);
     if (!metrics) {
       return null;
+    }
+
+    const path = Array.isArray(bestSource.path) && bestSource.path.length
+      ? bestSource.path.slice()
+      : [index, bestSource.sourceIndex];
+    if (path[0] !== index) {
+      path.unshift(index);
+    }
+    if (path[path.length - 1] !== bestSource.sourceIndex) {
+      path.push(bestSource.sourceIndex);
     }
 
     const sourceArea = Number(baseValues[bestSource.sourceIndex]?.area);
@@ -1622,8 +1809,11 @@ window.showConfirmModal = showConfirmModal;
     return {
       price: resolvedPrice > 0 ? resolvedPrice : 0,
       pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-      path: bestSource.path.slice(),
-      paths: [bestSource.path.slice()]
+      sources: [{
+        sourceIndex: bestSource.sourceIndex,
+        directPath: [index, bestSource.sourceIndex],
+        fullPath: path
+      }]
     };
   }
 
@@ -1645,11 +1835,27 @@ window.showConfirmModal = showConfirmModal;
         };
       }
 
-      const sourcePaths = Array.isArray(fallback.paths)
-        ? fallback.paths.filter(path => Array.isArray(path) && path.length >= 2).map(path => path.slice())
-        : (Array.isArray(fallback.path) && fallback.path.length >= 2)
-          ? [fallback.path.slice()]
-          : [];
+      const sourcePaths = Array.isArray(fallback.sources)
+        ? fallback.sources
+            .map(source => {
+              if (Array.isArray(source?.directPath) && source.directPath.length >= 2) {
+                return source.directPath.slice();
+              }
+              if (Array.isArray(source?.fullPath) && source.fullPath.length >= 2) {
+                const path = source.fullPath.slice();
+                if (path[0] !== index) {
+                  path.unshift(index);
+                }
+                return path;
+              }
+              const sourceIndex = Number.isInteger(source?.sourceIndex) ? source.sourceIndex : null;
+              if (!Number.isInteger(sourceIndex)) {
+                return null;
+              }
+              return [index, sourceIndex];
+            })
+            .filter(path => Array.isArray(path) && path.length >= 2)
+        : [];
 
       return {
         ...entry,
@@ -2019,6 +2225,8 @@ window.showConfirmModal = showConfirmModal;
   }
 
   function clearVoronoiLayer() {
+    clearVoronoiHighlights();
+
     voronoiLayerState.polygons.forEach(poly => {
       if (poly && typeof poly.setMap === 'function') {
         poly.setMap(null);
@@ -2044,6 +2252,10 @@ window.showConfirmModal = showConfirmModal;
     voronoiLayerState.labels = [];
     voronoiLayerState.labelLayout.boxes = [];
     voronoiLayerState.labelLayout.projectionPending = false;
+    voronoiLayerState.connectorIndexMap = new Map();
+    voronoiLayerState.resolvedValues = [];
+    voronoiLayerState.datasetSnapshot = [];
+    voronoiLayerState.cells = [];
   }
 
   function getVoronoiSourceOffers() {
@@ -2217,6 +2429,11 @@ window.showConfirmModal = showConfirmModal;
       return { path, centroid, position };
     });
 
+    voronoiLayerState.resolvedValues = resolvedValues;
+    voronoiLayerState.datasetSnapshot = dataset;
+    voronoiLayerState.cells = cells;
+    voronoiLayerState.connectorIndexMap = new Map();
+
     cells.forEach((cell, index) => {
       if (!cell) return;
       let stats = aggregateVoronoiValues(resolvedValues, index);
@@ -2248,15 +2465,20 @@ window.showConfirmModal = showConfirmModal;
       const polygon = new google.maps.Polygon({
         paths: cell.path,
         map: voronoiLayerState.enabled ? map : null,
-        strokeColor: '#D1D5DB',
-        strokeOpacity: 0.8,
-        strokeWeight: 1.2,
-        fillColor: '#FFFFFF',
-        fillOpacity: 0.28,
-        clickable: false,
+        ...getVoronoiPolygonStyle('default'),
+        clickable: true,
         zIndex: 40
       });
+      polygon.__voronoiIndex = index;
+      polygon.addListener('click', () => {
+        if (!voronoiLayerState.enabled) return;
+        highlightVoronoiPolygon(index);
+      });
       voronoiLayerState.polygons.push(polygon);
+
+      if (!voronoiLayerState.connectorIndexMap.has(index)) {
+        voronoiLayerState.connectorIndexMap.set(index, []);
+      }
 
       if (shouldRenderLabels) {
         const labelPosition = findNonOverlappingLabelPosition(cell.centroid || cell.position);
@@ -2285,19 +2507,15 @@ window.showConfirmModal = showConfirmModal;
         const connector = new google.maps.Polyline({
           path: connectorPath,
           map: voronoiLayerState.enabled ? map : null,
-          strokeColor: '#DC2626',
-          strokeOpacity: 0.65,
-          strokeWeight: 1.1,
-          geodesic: true,
           clickable: false,
-          icons: [{
-            icon: { path: 'M 0,-1 0,1', strokeOpacity: 1, scale: 2 },
-            offset: '0',
-            repeat: '12px'
-          }],
-          zIndex: 38
+          ...buildVoronoiConnectorStyle('default')
         });
+        connector.__voronoiBaseIndex = index;
+        connector.__voronoiSourceIndex = pathIndices[pathIndices.length - 1];
         voronoiLayerState.connectors.push(connector);
+        const connectorsForBase = voronoiLayerState.connectorIndexMap.get(index) || [];
+        connectorsForBase.push(connector);
+        voronoiLayerState.connectorIndexMap.set(index, connectorsForBase);
       });
     });
   }
@@ -2751,6 +2969,9 @@ window.showConfirmModal = showConfirmModal;
     google.maps.event.addListener(map, "zoom_changed", () => {
       keepMapFlat();
       updatePolygonVisibility();
+    });
+    google.maps.event.addListener(map, "click", () => {
+      clearVoronoiHighlights();
     });
     await loadOffers();
     focusOfferFromMapState();

--- a/oferty.html
+++ b/oferty.html
@@ -231,19 +231,22 @@ window.showConfirmModal = showConfirmModal;
         <div class="voronoi-panel" id="voronoiPanel">
           <div class="voronoi-panel__header">
             <h3 class="filters-title voronoi-panel__title">Wycena nieruchomości (beta)</h3>
-            <div class="voronoi-toggle" role="group" aria-label="Wycena nieruchomości">
-              <input
-                type="checkbox"
-                id="toggleVoronoiLayer"
-                class="voronoi-toggle__input"
-                aria-label="Przełącz warstwę wyceny nieruchomości"
-              />
-              <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="off" aria-pressed="false">
-                Wyłączone
-              </button>
-              <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="on" aria-pressed="false">
-                Włączone
-              </button>
+            <div class="voronoi-toggle" role="group" aria-labelledby="voronoiToggleLabel">
+              <span class="voronoi-toggle__label" id="voronoiToggleLabel">Feature toggle / feature flag</span>
+              <div class="voronoi-toggle__controls">
+                <input
+                  type="checkbox"
+                  id="toggleVoronoiLayer"
+                  class="voronoi-toggle__input"
+                  aria-label="Przełącz warstwę wyceny nieruchomości"
+                />
+                <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="off" aria-pressed="false">
+                  Wyłączone
+                </button>
+                <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="on" aria-pressed="false">
+                  Włączone
+                </button>
+              </div>
             </div>
           </div>
           <div class="voronoi-legend" aria-live="polite">

--- a/oferty.html
+++ b/oferty.html
@@ -2066,7 +2066,16 @@ window.showConfirmModal = showConfirmModal;
     cells.forEach((cell, index) => {
       if (!cell) return;
       const neighborIndices = adjacencyList[index] || [];
-      const stats = aggregateVoronoiValues(resolvedValues, index, neighborIndices);
+      let stats = aggregateVoronoiValues(resolvedValues, index, neighborIndices);
+      if ((!stats || stats.pricePerSqm <= 0) && resolvedValues[index] && Number.isFinite(resolvedValues[index].pricePerSqm) && resolvedValues[index].pricePerSqm > 0) {
+        stats = {
+          price: resolvedValues[index].price,
+          pricePerSqm: resolvedValues[index].pricePerSqm
+        };
+      }
+      if (!stats) {
+        stats = { price: 0, pricePerSqm: 0 };
+      }
       const content = buildVoronoiLabelContent(stats);
 
       const polygon = new google.maps.Polygon({
@@ -2628,9 +2637,17 @@ window.showConfirmModal = showConfirmModal;
     if (!sortedOffers.length) {
       listContainer.innerHTML = '<p class="no-offers">Brak ofert w widocznym obszarze</p>';
       if (voronoiLayerState.enabled) {
-        clearVoronoiLayer();
-        voronoiLayerState.cachedDataset = null;
-        voronoiLayerState.cacheSignature = null;
+        const freezeActive = shouldFreezeVoronoiLayout();
+        const hasFrozenCache = freezeActive && Array.isArray(voronoiLayerState.cachedDataset?.dataset)
+          && voronoiLayerState.cachedDataset.dataset.length;
+
+        if (hasFrozenCache) {
+          updateVoronoiLayer(true);
+        } else {
+          clearVoronoiLayer();
+          voronoiLayerState.cachedDataset = null;
+          voronoiLayerState.cacheSignature = null;
+        }
       }
       return;
     }

--- a/oferty.html
+++ b/oferty.html
@@ -230,9 +230,8 @@ window.showConfirmModal = showConfirmModal;
       <div class="sidebar-stack">
         <div class="voronoi-panel" id="voronoiPanel">
           <div class="voronoi-panel__header">
-            <h3 class="filters-title voronoi-panel__title">Wycena nieruchomości (beta)</h3>
-            <div class="voronoi-toggle" role="group" aria-labelledby="voronoiToggleLabel">
-              <span class="voronoi-toggle__label" id="voronoiToggleLabel">Wł. / Wył.</span>
+            <h3 class="filters-title voronoi-panel__title" id="voronoiPanelTitle">Wycena nieruchomości (beta)</h3>
+            <div class="voronoi-toggle" role="group" aria-labelledby="voronoiPanelTitle">
               <div class="voronoi-toggle__controls">
                 <input
                   type="checkbox"

--- a/oferty.html
+++ b/oferty.html
@@ -233,11 +233,11 @@ window.showConfirmModal = showConfirmModal;
           <div class="voronoi-legend" aria-live="polite">
             <div class="voronoi-legend__item">
               <span class="voronoi-legend__swatch voronoi-legend__swatch--selected" aria-hidden="true"></span>
-              <span class="voronoi-legend__label">Wybrana działka</span>
+              <span class="voronoi-legend__label">Zaznaczona wycena – zielony</span>
             </div>
             <div class="voronoi-legend__item">
               <span class="voronoi-legend__swatch voronoi-legend__swatch--source" aria-hidden="true"></span>
-              <span class="voronoi-legend__label">Źródło wyceny</span>
+              <span class="voronoi-legend__label">Źródło wyceny – niebieski</span>
             </div>
           </div>
           <div
@@ -246,30 +246,12 @@ window.showConfirmModal = showConfirmModal;
             aria-hidden="true"
             hidden
           >
-            <div class="voronoi-inspector__title">Tagi i wagi</div>
-            <div
-              class="voronoi-inspector__summary"
-              id="voronoiInspectorSummary"
-              aria-hidden="true"
-              hidden
-            >
-              <div class="voronoi-inspector__summary-pill">
-                <div class="voronoi-inspector__summary-row">
-                  <span class="voronoi-inspector__summary-label">Śr. cena za m²</span>
-                  <span class="voronoi-inspector__summary-value" id="voronoiInspectorPricePerSqm">—</span>
-                </div>
-                <div class="voronoi-inspector__summary-row">
-                  <span class="voronoi-inspector__summary-label">Szacunkowa wartość działki</span>
-                  <span class="voronoi-inspector__summary-value" id="voronoiInspectorEstimatedValue">—</span>
-                </div>
-              </div>
-            </div>
             <p
               class="voronoi-inspector__empty"
               id="voronoiInspectorEmpty"
-              data-default-message="Kliknij poligon, aby zobaczyć tagi i ich wagi."
+              data-default-message="Kliknij poligon, aby zobaczyć procenty tagów."
             >
-              Kliknij poligon, aby zobaczyć tagi i ich wagi.
+              Kliknij poligon, aby zobaczyć procenty tagów.
             </p>
             <ul class="voronoi-inspector__list" id="voronoiInspectorList"></ul>
           </div>
@@ -548,16 +530,16 @@ window.showConfirmModal = showConfirmModal;
         strokeColor: '#1D4ED8',
         strokeOpacity: 0.9,
         strokeWeight: 2,
-        fillColor: '#DBEAFE',
-        fillOpacity: 0.45
+        fillColor: '#1E3A8A',
+        fillOpacity: 0.5
       };
     }
     return {
-      strokeColor: '#D1D5DB',
-      strokeOpacity: 0.8,
+      strokeColor: '#1e3a8a',
+      strokeOpacity: 0.75,
       strokeWeight: 1.2,
-      fillColor: '#FFFFFF',
-      fillOpacity: 0.28
+      fillColor: '#1B2A5B',
+      fillOpacity: 0.22
     };
   }
 
@@ -606,13 +588,10 @@ window.showConfirmModal = showConfirmModal;
     const container = document.getElementById('voronoiInspector');
     const list = document.getElementById('voronoiInspectorList');
     const emptyState = document.getElementById('voronoiInspectorEmpty');
-    const summary = document.getElementById('voronoiInspectorSummary');
-    const average = document.getElementById('voronoiInspectorPricePerSqm');
-    const estimated = document.getElementById('voronoiInspectorEstimatedValue');
     if (!container || !list || !emptyState) {
       return null;
     }
-    return { container, list, emptyState, summary, average, estimated };
+    return { container, list, emptyState };
   }
 
   function extractPlotAreaFromOffer(offer) {
@@ -639,54 +618,6 @@ window.showConfirmModal = showConfirmModal;
     return 0;
   }
 
-  function updateVoronoiInspectorSummary(elements, datasetEntry, resolvedEntry) {
-    if (!elements) return;
-    const { summary, average, estimated } = elements;
-    if (!summary || !average || !estimated) {
-      return;
-    }
-
-    const offer = datasetEntry?.offer || null;
-    const baseStats = offer ? computeOfferValueWithTags(offer) : null;
-
-    let area = Number(baseStats?.area);
-    if (!(Number.isFinite(area) && area > 0)) {
-      const extractedArea = extractPlotAreaFromOffer(offer);
-      area = Number.isFinite(extractedArea) && extractedArea > 0 ? extractedArea : 0;
-    }
-
-    let pricePerSqm = Number(resolvedEntry?.pricePerSqm);
-    let price = Number(resolvedEntry?.price);
-
-    if (!(pricePerSqm > 0) && Number.isFinite(baseStats?.pricePerSqm) && baseStats.pricePerSqm > 0) {
-      pricePerSqm = baseStats.pricePerSqm;
-    }
-    if (!(price > 0) && Number.isFinite(baseStats?.price) && baseStats.price > 0) {
-      price = baseStats.price;
-    }
-
-    if (!(price > 0) && pricePerSqm > 0 && area > 0) {
-      price = pricePerSqm * area;
-    }
-    if (!(pricePerSqm > 0) && price > 0 && area > 0) {
-      pricePerSqm = price / area;
-    }
-
-    const hasSummary = (pricePerSqm > 0) || (price > 0);
-
-    if (hasSummary) {
-      summary.hidden = false;
-      summary.setAttribute('aria-hidden', 'false');
-      average.textContent = pricePerSqm > 0 ? `${formatPriceValue(pricePerSqm)} zł/m²` : '—';
-      estimated.textContent = price > 0 ? `${formatPriceValue(price)} zł` : '—';
-    } else {
-      summary.hidden = true;
-      summary.setAttribute('aria-hidden', 'true');
-      average.textContent = '—';
-      estimated.textContent = '—';
-    }
-  }
-
   function hideVoronoiTagInspector() {
     const elements = getVoronoiInspectorElements();
     if (!elements) return;
@@ -697,7 +628,6 @@ window.showConfirmModal = showConfirmModal;
     emptyState.hidden = false;
     container.setAttribute('hidden', 'true');
     container.setAttribute('aria-hidden', 'true');
-    updateVoronoiInspectorSummary(elements, null, null);
   }
 
   function updateVoronoiTagInspector(index) {
@@ -713,10 +643,6 @@ window.showConfirmModal = showConfirmModal;
     const datasetEntry = Array.isArray(voronoiLayerState.datasetSnapshot)
       ? voronoiLayerState.datasetSnapshot[index]
       : null;
-    const resolvedEntry = Array.isArray(voronoiLayerState.resolvedValues)
-      ? voronoiLayerState.resolvedValues[index]
-      : null;
-    updateVoronoiInspectorSummary(elements, datasetEntry, resolvedEntry);
     const offerTags = Array.isArray(datasetEntry?.offer?.tags)
       ? datasetEntry.offer.tags.filter(tag => typeof tag === 'string' && tag.trim().length)
       : [];
@@ -740,38 +666,30 @@ window.showConfirmModal = showConfirmModal;
       ? voronoiLayerState.tagWeights
       : new Map();
     const maxValue = Math.max(Number(voronoiLayerState.maxTagValue) || 1, 1);
+    const totalWeight = uniqueTags.reduce((sum, tag) => {
+      const weight = Number(weightMap.get(tag));
+      return sum + (Number.isFinite(weight) && weight > 0 ? weight : 0);
+    }, 0);
 
     uniqueTags.forEach(tag => {
-      const weight = Number(weightMap.get(tag)) || 1;
-      const rawPercent = Math.round((weight / maxValue) * 100);
-      const normalized = Math.max(6, Math.min(100, rawPercent));
+      const weight = Number(weightMap.get(tag)) || 0;
+      const percentBase = totalWeight > 0 ? totalWeight : maxValue;
+      const rawPercent = percentBase > 0 ? Math.round((weight / percentBase) * 100) : 0;
+      const displayPercent = percentBase > 0 && weight > 0 ? Math.max(1, rawPercent) : 0;
 
       const item = document.createElement('li');
       item.className = 'voronoi-inspector__item';
-
-      const header = document.createElement('div');
-      header.className = 'voronoi-inspector__item-header';
 
       const tagLabel = document.createElement('span');
       tagLabel.className = 'voronoi-inspector__tag';
       tagLabel.textContent = formatTagLabel(tag);
 
       const value = document.createElement('span');
-      value.className = 'voronoi-inspector__value';
-      value.textContent = `${weight}/${maxValue} (${rawPercent}%)`;
+      value.className = 'voronoi-inspector__percentage';
+      value.textContent = `${displayPercent}%`;
 
-      const meter = document.createElement('div');
-      meter.className = 'voronoi-inspector__meter';
-
-      const meterFill = document.createElement('span');
-      meterFill.className = 'voronoi-inspector__meter-fill';
-      meterFill.style.width = `${normalized}%`;
-
-      header.appendChild(tagLabel);
-      header.appendChild(value);
-      meter.appendChild(meterFill);
-      item.appendChild(header);
-      item.appendChild(meter);
+      item.appendChild(tagLabel);
+      item.appendChild(value);
       list.appendChild(item);
     });
   }

--- a/oferty.html
+++ b/oferty.html
@@ -486,19 +486,19 @@ window.showConfirmModal = showConfirmModal;
   function getVoronoiPolygonStyle(mode = 'default') {
     if (mode === 'baseHighlight') {
       return {
-        strokeColor: '#DC2626',
+        strokeColor: '#15803D',
         strokeOpacity: 0.95,
         strokeWeight: 2.4,
-        fillColor: '#FEE2E2',
+        fillColor: '#DCFCE7',
         fillOpacity: 0.55
       };
     }
     if (mode === 'sourceHighlight') {
       return {
-        strokeColor: '#F87171',
+        strokeColor: '#1D4ED8',
         strokeOpacity: 0.9,
         strokeWeight: 2,
-        fillColor: '#FFE4E6',
+        fillColor: '#DBEAFE',
         fillOpacity: 0.45
       };
     }
@@ -609,12 +609,14 @@ window.showConfirmModal = showConfirmModal;
   }
 
   const VORONOI_FREEZE_ZOOM_LEVEL = 15;
-  const VORONOI_LABEL_BASE_MIN_ZOOM = 13;
+  const VORONOI_HIDE_ZOOM_LEVEL = 19;
+  const VORONOI_LABEL_BASE_MIN_ZOOM = 14;
   const VORONOI_LABEL_VISIBILITY_RULES = [
-    { minCount: 220, minZoom: 16 },
-    { minCount: 160, minZoom: 15 },
-    { minCount: 110, minZoom: 14 },
-    { minCount: 70, minZoom: 13 }
+    { minCount: 260, minZoom: 18 },
+    { minCount: 200, minZoom: 17 },
+    { minCount: 150, minZoom: 16 },
+    { minCount: 100, minZoom: 15 },
+    { minCount: 60, minZoom: 14 }
   ];
 
   function getMapZoomLevel() {
@@ -626,6 +628,11 @@ window.showConfirmModal = showConfirmModal;
   function shouldFreezeVoronoiLayout() {
     const zoom = getMapZoomLevel();
     return Number.isFinite(zoom) && zoom >= VORONOI_FREEZE_ZOOM_LEVEL;
+  }
+
+  function shouldHideVoronoiLayer() {
+    const zoom = getMapZoomLevel();
+    return Number.isFinite(zoom) && zoom >= VORONOI_HIDE_ZOOM_LEVEL;
   }
 
   function cloneVoronoiCache(dataset, adjacencyList, resolvedValues, extent) {
@@ -687,13 +694,13 @@ window.showConfirmModal = showConfirmModal;
       return 'default';
     }
 
-    if (count >= 220 && zoom <= 16) {
+    if (count >= 150 && zoom <= 16) {
       return 'compact';
     }
-    if (count >= 160 && zoom <= 15) {
+    if (count >= 110 && zoom <= 15) {
       return 'compact';
     }
-    if (count >= 110 && zoom <= 14) {
+    if (count >= 80 && zoom <= 14) {
       return 'compact';
     }
 
@@ -2283,6 +2290,12 @@ window.showConfirmModal = showConfirmModal;
     if (!voronoiLayerState.enabled || !map) return;
     if (!window.d3 || !window.d3.Delaunay) {
       console.warn('Biblioteka d3-delaunay jest niedostępna. Warstwa Voronoi zostanie pominięta.');
+      return;
+    }
+
+    if (shouldHideVoronoiLayer()) {
+      clearVoronoiLayer();
+      voronoiLayerState.cachedDataset = null;
       return;
     }
 

--- a/oferty.html
+++ b/oferty.html
@@ -223,52 +223,56 @@ window.showConfirmModal = showConfirmModal;
     <div class="map-container">
       <div id="map"></div>
       <div id="map-controls">
-        <div class="voronoi-toggle-control">
-          <input type="checkbox" id="toggleVoronoiLayer" />
-          <label for="toggleVoronoiLayer">Wycena nieruchomości (beta)</label>
-        </div>
-        <div class="voronoi-legend" aria-live="polite">
-          <div class="voronoi-legend__item">
-            <span class="voronoi-legend__swatch voronoi-legend__swatch--selected" aria-hidden="true"></span>
-            <span class="voronoi-legend__label">Wybrana działka</span>
+        <div class="voronoi-panel" id="voronoiPanel">
+          <div class="voronoi-panel__header">
+            <div class="voronoi-toggle-control">
+              <input type="checkbox" id="toggleVoronoiLayer" />
+              <label for="toggleVoronoiLayer">Wycena nieruchomości (beta)</label>
+            </div>
           </div>
-          <div class="voronoi-legend__item">
-            <span class="voronoi-legend__swatch voronoi-legend__swatch--source" aria-hidden="true"></span>
-            <span class="voronoi-legend__label">Źródło wyceny</span>
+          <div class="voronoi-legend" aria-live="polite">
+            <div class="voronoi-legend__item">
+              <span class="voronoi-legend__swatch voronoi-legend__swatch--selected" aria-hidden="true"></span>
+              <span class="voronoi-legend__label">Wybrana działka</span>
+            </div>
+            <div class="voronoi-legend__item">
+              <span class="voronoi-legend__swatch voronoi-legend__swatch--source" aria-hidden="true"></span>
+              <span class="voronoi-legend__label">Źródło wyceny</span>
+            </div>
           </div>
-        </div>
-        <div
-          class="voronoi-inspector"
-          id="voronoiInspector"
-          aria-hidden="true"
-          hidden
-        >
-          <div class="voronoi-inspector__title">Tagi i wagi</div>
           <div
-            class="voronoi-inspector__summary"
-            id="voronoiInspectorSummary"
+            class="voronoi-inspector"
+            id="voronoiInspector"
             aria-hidden="true"
             hidden
           >
-            <div class="voronoi-inspector__summary-pill">
-              <div class="voronoi-inspector__summary-row">
-                <span class="voronoi-inspector__summary-label">Śr. cena za m²</span>
-                <span class="voronoi-inspector__summary-value" id="voronoiInspectorPricePerSqm">—</span>
-              </div>
-              <div class="voronoi-inspector__summary-row">
-                <span class="voronoi-inspector__summary-label">Szacunkowa wartość działki</span>
-                <span class="voronoi-inspector__summary-value" id="voronoiInspectorEstimatedValue">—</span>
+            <div class="voronoi-inspector__title">Tagi i wagi</div>
+            <div
+              class="voronoi-inspector__summary"
+              id="voronoiInspectorSummary"
+              aria-hidden="true"
+              hidden
+            >
+              <div class="voronoi-inspector__summary-pill">
+                <div class="voronoi-inspector__summary-row">
+                  <span class="voronoi-inspector__summary-label">Śr. cena za m²</span>
+                  <span class="voronoi-inspector__summary-value" id="voronoiInspectorPricePerSqm">—</span>
+                </div>
+                <div class="voronoi-inspector__summary-row">
+                  <span class="voronoi-inspector__summary-label">Szacunkowa wartość działki</span>
+                  <span class="voronoi-inspector__summary-value" id="voronoiInspectorEstimatedValue">—</span>
+                </div>
               </div>
             </div>
+            <p
+              class="voronoi-inspector__empty"
+              id="voronoiInspectorEmpty"
+              data-default-message="Kliknij poligon, aby zobaczyć tagi i ich wagi."
+            >
+              Kliknij poligon, aby zobaczyć tagi i ich wagi.
+            </p>
+            <ul class="voronoi-inspector__list" id="voronoiInspectorList"></ul>
           </div>
-          <p
-            class="voronoi-inspector__empty"
-            id="voronoiInspectorEmpty"
-            data-default-message="Kliknij poligon, aby zobaczyć tagi i ich wagi."
-          >
-            Kliknij poligon, aby zobaczyć tagi i ich wagi.
-          </p>
-          <ul class="voronoi-inspector__list" id="voronoiInspectorList"></ul>
         </div>
       </div>
     </div>
@@ -1891,7 +1895,8 @@ window.showConfirmModal = showConfirmModal;
           : 0;
       return {
         price: sourcePrice > 0 ? sourcePrice : 0,
-        pricePerSqm: normalizedPerSqm > 0 ? normalizedPerSqm : 0
+        pricePerSqm: normalizedPerSqm > 0 ? normalizedPerSqm : 0,
+        area: Number.isFinite(sourceArea) && sourceArea > 0 ? sourceArea : 0
       };
     };
 
@@ -1950,26 +1955,69 @@ window.showConfirmModal = showConfirmModal;
     };
 
     if (pricedNeighbors.length) {
-      let bestDirect = null;
+      const fallbackSources = [];
+      const seenNeighborSources = new Set();
+      let weightedPerSqmSum = 0;
+      let weightSum = 0;
+      let totalPrice = 0;
+      let totalArea = 0;
+
       pricedNeighbors.forEach(entry => {
-        const path = [index, entry.index];
-        const distance = computePathDistance(path, dataset);
-        const normalizedDistance = Number.isFinite(distance) ? distance : Infinity;
-        if (!bestDirect || normalizedDistance < bestDirect.distance) {
-          bestDirect = {
-            sourceIndex: entry.index,
-            metrics: entry.metrics,
-            path,
-            distance: normalizedDistance
-          };
+        const neighborIndex = entry.index;
+        if (seenNeighborSources.has(neighborIndex)) {
+          return;
+        }
+        seenNeighborSources.add(neighborIndex);
+        const { price, pricePerSqm, area } = entry.metrics;
+        fallbackSources.push({
+          sourceIndex: neighborIndex,
+          directPath: [index, neighborIndex],
+          fullPath: [index, neighborIndex]
+        });
+
+        if (pricePerSqm > 0) {
+          const weight = area > 0 ? area : 1;
+          weightedPerSqmSum += pricePerSqm * weight;
+          weightSum += weight;
+        }
+
+        if (price > 0) {
+          totalPrice += price;
+        }
+
+        if (area > 0) {
+          totalArea += area;
         }
       });
 
-      if (bestDirect) {
-        const fallback = buildFallbackFromSource(bestDirect.sourceIndex, bestDirect.path, bestDirect.metrics);
-        if (fallback) {
-          return fallback;
+      const fallbackArea = Number.isFinite(baseArea) && baseArea > 0
+        ? baseArea
+        : (totalArea > 0 ? totalArea / pricedNeighbors.length : 0);
+
+      let resolvedPricePerSqm = weightSum > 0 ? weightedPerSqmSum / weightSum : 0;
+      if (!(resolvedPricePerSqm > 0) && totalArea > 0 && totalPrice > 0) {
+        resolvedPricePerSqm = totalPrice / totalArea;
+      }
+      if (!(resolvedPricePerSqm > 0) && fallbackArea > 0 && totalPrice > 0 && pricedNeighbors.length) {
+        resolvedPricePerSqm = (totalPrice / pricedNeighbors.length) / fallbackArea;
+      }
+
+      let resolvedPrice = 0;
+      if (resolvedPricePerSqm > 0 && fallbackArea > 0) {
+        resolvedPrice = resolvedPricePerSqm * fallbackArea;
+      } else if (totalPrice > 0 && pricedNeighbors.length) {
+        resolvedPrice = totalPrice / pricedNeighbors.length;
+        if (!(resolvedPricePerSqm > 0) && fallbackArea > 0) {
+          resolvedPricePerSqm = resolvedPrice / fallbackArea;
         }
+      }
+
+      if (resolvedPrice > 0 || resolvedPricePerSqm > 0) {
+        return {
+          price: resolvedPrice > 0 ? resolvedPrice : 0,
+          pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
+          sources: fallbackSources
+        };
       }
     }
 

--- a/oferty.html
+++ b/oferty.html
@@ -475,12 +475,12 @@ window.showConfirmModal = showConfirmModal;
   };
 
   const VORONOI_FREEZE_ZOOM_LEVEL = 16;
-  const VORONOI_LABEL_BASE_MIN_ZOOM = 10;
+  const VORONOI_LABEL_BASE_MIN_ZOOM = 13;
   const VORONOI_LABEL_VISIBILITY_RULES = [
-    { minCount: 220, minZoom: 14 },
-    { minCount: 160, minZoom: 13 },
-    { minCount: 110, minZoom: 12 },
-    { minCount: 70, minZoom: 11 }
+    { minCount: 220, minZoom: 16 },
+    { minCount: 160, minZoom: 15 },
+    { minCount: 110, minZoom: 14 },
+    { minCount: 70, minZoom: 13 }
   ];
 
   function getMapZoomLevel() {
@@ -1422,7 +1422,47 @@ window.showConfirmModal = showConfirmModal;
     return { price: 0, pricePerSqm: 0, area: sanitizedArea, hasPrice: false };
   }
 
-  function computeFallbackFromNeighbors(index, baseValues, adjacencyList) {
+  function toRadians(degrees) {
+    return (degrees * Math.PI) / 180;
+  }
+
+  function computeDistanceBetweenPoints(a, b) {
+    if (!a || !b) return Infinity;
+    const lat1 = Number(a.lat);
+    const lng1 = Number(a.lng);
+    const lat2 = Number(b.lat);
+    const lng2 = Number(b.lng);
+    if (!Number.isFinite(lat1) || !Number.isFinite(lng1) || !Number.isFinite(lat2) || !Number.isFinite(lng2)) {
+      return Infinity;
+    }
+    const earthRadius = 6371000; // metry
+    const dLat = toRadians(lat2 - lat1);
+    const dLng = toRadians(lng2 - lng1);
+    const rLat1 = toRadians(lat1);
+    const rLat2 = toRadians(lat2);
+    const aVal = Math.sin(dLat / 2) ** 2 + Math.cos(rLat1) * Math.cos(rLat2) * Math.sin(dLng / 2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(aVal), Math.sqrt(1 - aVal));
+    return earthRadius * c;
+  }
+
+  function computePathDistance(path, dataset) {
+    if (!Array.isArray(path) || path.length < 2 || !Array.isArray(dataset)) {
+      return Infinity;
+    }
+    let total = 0;
+    for (let i = 1; i < path.length; i++) {
+      const prev = dataset[path[i - 1]]?.position || null;
+      const next = dataset[path[i]]?.position || null;
+      const segment = computeDistanceBetweenPoints(prev, next);
+      if (!Number.isFinite(segment)) {
+        return Infinity;
+      }
+      total += segment;
+    }
+    return total;
+  }
+
+  function computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset) {
     const visited = new Set([index]);
     const parents = new Map();
     let frontier = (adjacencyList[index] || []).filter(i => Number.isInteger(i));
@@ -1459,9 +1499,11 @@ window.showConfirmModal = showConfirmModal;
       });
 
       if (pricedValues.length) {
-        const priceSum = pricedValues.reduce((sum, value) => sum + value.price, 0);
-        const ppm2Sum = pricedValues.reduce((sum, value) => sum + value.pricePerSqm, 0);
-        const paths = pricedIndices.map(targetIndex => {
+        let chosenIndex = null;
+        let chosenPath = null;
+        let chosenDistance = Infinity;
+
+        pricedIndices.forEach(targetIndex => {
           const path = [];
           let current = targetIndex;
           let guard = 0;
@@ -1480,14 +1522,27 @@ window.showConfirmModal = showConfirmModal;
           if (path[path.length - 1] !== index) {
             path.push(index);
           }
-          return path.reverse();
+          const normalizedPath = path.reverse();
+          const distance = computePathDistance(normalizedPath, dataset);
+          if (distance < chosenDistance) {
+            chosenDistance = distance;
+            chosenIndex = targetIndex;
+            chosenPath = normalizedPath;
+          }
         });
 
-        return {
-          price: priceSum / pricedValues.length,
-          pricePerSqm: ppm2Sum / pricedValues.length,
-          paths
-        };
+        if (chosenIndex !== null) {
+          const chosenValue = baseValues[chosenIndex];
+          if (chosenValue?.hasPrice && chosenValue.price > 0) {
+            return {
+              price: chosenValue.price,
+              pricePerSqm: chosenValue.pricePerSqm,
+              path: Array.isArray(chosenPath) ? chosenPath : null
+            };
+          }
+        }
+
+        return null;
       }
 
       frontier = Array.from(nextSet);
@@ -1496,7 +1551,7 @@ window.showConfirmModal = showConfirmModal;
     return null;
   }
 
-  function resolveVoronoiValues(baseValues, adjacencyList) {
+  function resolveVoronoiValues(baseValues, adjacencyList, dataset) {
     return baseValues.map((entry, index) => {
       if (!entry) return entry;
       if (entry.hasPrice && entry.price > 0) {
@@ -1506,7 +1561,7 @@ window.showConfirmModal = showConfirmModal;
         };
       }
 
-      const fallback = computeFallbackFromNeighbors(index, baseValues, adjacencyList);
+      const fallback = computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset);
       if (!fallback) {
         return {
           ...entry,
@@ -1519,36 +1574,22 @@ window.showConfirmModal = showConfirmModal;
         price: fallback.price,
         pricePerSqm: fallback.pricePerSqm,
         hasPrice: true,
-        fallbackSources: Array.isArray(fallback.paths)
-          ? fallback.paths.filter(path => Array.isArray(path) && path.length >= 2)
+        fallbackSources: Array.isArray(fallback.path) && fallback.path.length >= 2
+          ? [fallback.path.slice()]
           : []
       };
     });
   }
 
-  function aggregateVoronoiValues(values, index, neighborIndices) {
-    const aggregated = { price: 0, pricePerSqm: 0, count: 0 };
-    const uniqueIndices = new Set([index]);
-    (neighborIndices || []).forEach(i => {
-      if (Number.isInteger(i)) uniqueIndices.add(i);
-    });
-
-    uniqueIndices.forEach(i => {
-      const entry = values[i];
-      if (!entry) return;
-      aggregated.price += entry.price;
-      aggregated.pricePerSqm += entry.pricePerSqm;
-      aggregated.count += 1;
-    });
-
-    if (!aggregated.count) {
-      return { price: 0, pricePerSqm: 0 };
+  function aggregateVoronoiValues(values, index) {
+    const entry = values[index];
+    if (entry?.hasPrice && entry.price > 0) {
+      return {
+        price: entry.price,
+        pricePerSqm: entry.pricePerSqm
+      };
     }
-
-    return {
-      price: aggregated.price / aggregated.count,
-      pricePerSqm: aggregated.pricePerSqm / aggregated.count
-    };
+    return { price: 0, pricePerSqm: 0 };
   }
 
   function ensureVoronoiLabelOverlay() {
@@ -2040,7 +2081,7 @@ window.showConfirmModal = showConfirmModal;
         return neighbors;
       });
       const baseValues = dataset.map(({ offer }) => computeOfferValueWithTags(offer));
-      resolvedValues = resolveVoronoiValues(baseValues, adjacencyList);
+      resolvedValues = resolveVoronoiValues(baseValues, adjacencyList, dataset);
       shouldUpdateCache = true;
     }
 
@@ -2065,8 +2106,7 @@ window.showConfirmModal = showConfirmModal;
 
     cells.forEach((cell, index) => {
       if (!cell) return;
-      const neighborIndices = adjacencyList[index] || [];
-      let stats = aggregateVoronoiValues(resolvedValues, index, neighborIndices);
+      let stats = aggregateVoronoiValues(resolvedValues, index);
       if ((!stats || stats.pricePerSqm <= 0) && resolvedValues[index] && Number.isFinite(resolvedValues[index].pricePerSqm) && resolvedValues[index].pricePerSqm > 0) {
         stats = {
           price: resolvedValues[index].price,

--- a/oferty.html
+++ b/oferty.html
@@ -474,7 +474,14 @@ window.showConfirmModal = showConfirmModal;
     height: 34
   };
 
-  const VORONOI_FREEZE_ZOOM_LEVEL = 17;
+  const VORONOI_FREEZE_ZOOM_LEVEL = 16;
+  const VORONOI_LABEL_BASE_MIN_ZOOM = 10;
+  const VORONOI_LABEL_VISIBILITY_RULES = [
+    { minCount: 220, minZoom: 14 },
+    { minCount: 160, minZoom: 13 },
+    { minCount: 110, minZoom: 12 },
+    { minCount: 70, minZoom: 11 }
+  ];
 
   function getMapZoomLevel() {
     if (!map || typeof map.getZoom !== 'function') return null;
@@ -513,6 +520,28 @@ window.showConfirmModal = showConfirmModal;
         : [],
       extent: Array.isArray(extent) ? extent.slice() : null
     };
+  }
+
+  function shouldRenderVoronoiLabelsForDatasetSize(count) {
+    if (!Number.isFinite(count) || count <= 0) {
+      return false;
+    }
+    if (count <= 20) {
+      return true;
+    }
+    const zoom = getMapZoomLevel();
+    if (!Number.isFinite(zoom)) {
+      return false;
+    }
+    if (zoom < VORONOI_LABEL_BASE_MIN_ZOOM) {
+      return false;
+    }
+    for (const rule of VORONOI_LABEL_VISIBILITY_RULES) {
+      if (count >= rule.minCount && zoom < rule.minZoom) {
+        return false;
+      }
+    }
+    return true;
   }
 
   const MAP_STATE_STORAGE_KEY = 'grunteo::offers::mapState';
@@ -1893,16 +1922,32 @@ window.showConfirmModal = showConfirmModal;
     }
 
     const freezeActive = shouldFreezeVoronoiLayout();
-    const canUseFrozenCache = freezeActive
-      && voronoiLayerState.cacheSignature
+    const hasFrozenCache = freezeActive
       && Array.isArray(voronoiLayerState.cachedDataset?.dataset)
       && voronoiLayerState.cachedDataset.dataset.length;
 
-    const offers = (canUseFrozenCache ? getFrozenVoronoiOffers() : getVoronoiSourceOffers());
-    const sourceSignature = canUseFrozenCache && voronoiLayerState.cacheSignature
+    let usingFrozenCache = false;
+    let usedFullFilteredOffers = false;
+
+    let offers;
+    if (hasFrozenCache) {
+      offers = getFrozenVoronoiOffers();
+      usingFrozenCache = true;
+    } else if (freezeActive) {
+      offers = getOffersMatchingFilters();
+      if (offers.length) {
+        usedFullFilteredOffers = true;
+      } else {
+        offers = getVoronoiSourceOffers();
+      }
+    } else {
+      offers = getVoronoiSourceOffers();
+    }
+
+    const sourceSignature = usingFrozenCache && voronoiLayerState.cacheSignature
       ? voronoiLayerState.cacheSignature
       : offers.map(offer => (offer?.key || offer?.id || '')).join('|');
-    const cached = canUseFrozenCache
+    const cached = usingFrozenCache
       ? voronoiLayerState.cachedDataset
       : (freezeActive && voronoiLayerState.cacheSignature === sourceSignature)
         ? voronoiLayerState.cachedDataset
@@ -1999,7 +2044,8 @@ window.showConfirmModal = showConfirmModal;
       shouldUpdateCache = true;
     }
 
-    if (shouldUpdateCache || !freezeActive) {
+    const allowCacheRefresh = !freezeActive || usedFullFilteredOffers || !voronoiLayerState.cachedDataset;
+    if (shouldUpdateCache && allowCacheRefresh) {
       voronoiLayerState.cachedDataset = cloneVoronoiCache(dataset, adjacencyList, resolvedValues, extent);
       voronoiLayerState.cacheSignature = sourceSignature;
     }
@@ -2007,6 +2053,7 @@ window.showConfirmModal = showConfirmModal;
     clearVoronoiLayer();
     resetVoronoiLabelLayout();
 
+    const shouldRenderLabels = shouldRenderVoronoiLabelsForDatasetSize(dataset.length);
     const cells = dataset.map(({ position }, index) => {
       if (!voronoi) return null;
       const polygonCoords = voronoi.cellPolygon(index);
@@ -2035,10 +2082,12 @@ window.showConfirmModal = showConfirmModal;
       });
       voronoiLayerState.polygons.push(polygon);
 
-      const labelPosition = findNonOverlappingLabelPosition(cell.centroid || cell.position);
-      const label = createVoronoiLabelNode(content.html, content.plain, labelPosition);
-      if (label) {
-        voronoiLayerState.labels.push(label);
+      if (shouldRenderLabels) {
+        const labelPosition = findNonOverlappingLabelPosition(cell.centroid || cell.position);
+        const label = createVoronoiLabelNode(content.html, content.plain, labelPosition);
+        if (label) {
+          voronoiLayerState.labels.push(label);
+        }
       }
 
       const fallbackSources = Array.isArray(resolvedValues[index]?.fallbackSources)

--- a/oferty.html
+++ b/oferty.html
@@ -1486,151 +1486,210 @@ window.showConfirmModal = showConfirmModal;
 
   function computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset) {
     const baseEntry = baseValues[index] || {};
-    const basePosition = dataset[index]?.position || null;
+    const baseArea = Number(baseEntry.area);
     const directNeighbors = (adjacencyList[index] || []).filter(i => Number.isInteger(i));
-    const directPriced = directNeighbors
-      .map(neighborIndex => ({ index: neighborIndex, value: baseValues[neighborIndex] }))
-      .filter(entry => entry.value?.hasPrice && entry.value.price > 0);
 
-    if (directPriced.length) {
-      let chosenEntry = null;
-      let bestDistance = Infinity;
-
-      directPriced.forEach(entry => {
-        const neighborPosition = dataset[entry.index]?.position || null;
-        const distance = computeDistanceBetweenPoints(basePosition, neighborPosition);
-        const normalizedDistance = Number.isFinite(distance) ? distance : 0;
-        if (normalizedDistance < bestDistance) {
-          bestDistance = normalizedDistance;
-          chosenEntry = entry;
-        }
-      });
-
-      if (chosenEntry) {
-        const neighborValue = chosenEntry.value;
-        const area = Number(baseEntry.area);
-        const neighborPricePerSqm = Number(neighborValue.pricePerSqm);
-        const neighborPrice = Number(neighborValue.price);
-        const resolvedPricePerSqm = neighborPricePerSqm > 0
-          ? neighborPricePerSqm
-          : (neighborPrice > 0 && area > 0)
-            ? neighborPrice / area
-            : 0;
-        const resolvedPrice = area > 0 && resolvedPricePerSqm > 0
-          ? resolvedPricePerSqm * area
-          : neighborPrice;
-
-        if (resolvedPrice > 0) {
-          return {
-            price: resolvedPrice,
-            pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-            paths: [[index, chosenEntry.index]]
-          };
-        }
-      }
+    if (!directNeighbors.length) {
+      return null;
     }
 
-    const visited = new Set([index]);
-    const parents = new Map();
-    let frontier = directNeighbors.slice();
+    const contributions = [];
+    const usedSources = new Set();
 
-    frontier.forEach(neighborIndex => {
-      if (Number.isInteger(neighborIndex)) {
-        parents.set(neighborIndex, index);
+    const buildPriceMetrics = (value) => {
+      if (!value?.hasPrice || !(value.price > 0)) {
+        return null;
       }
-    });
+      const sourcePrice = Number(value.price);
+      const sourcePricePerSqm = Number(value.pricePerSqm);
+      const sourceArea = Number(value.area);
+      const normalizedPerSqm = sourcePricePerSqm > 0
+        ? sourcePricePerSqm
+        : (sourcePrice > 0 && Number.isFinite(sourceArea) && sourceArea > 0)
+          ? sourcePrice / sourceArea
+          : 0;
+      return {
+        price: sourcePrice > 0 ? sourcePrice : 0,
+        pricePerSqm: normalizedPerSqm > 0 ? normalizedPerSqm : 0
+      };
+    };
 
-    while (frontier.length) {
-      const pricedIndices = [];
-      const pricedValues = [];
-      const nextSet = new Set();
-
-      frontier.forEach(neighborIndex => {
-        if (visited.has(neighborIndex)) return;
-        visited.add(neighborIndex);
-
-        const value = baseValues[neighborIndex];
-        if (value?.hasPrice && value.price > 0) {
-          pricedIndices.push(neighborIndex);
-          pricedValues.push(value);
-        }
-
-        (adjacencyList[neighborIndex] || []).forEach(nextIndex => {
-          if (!visited.has(nextIndex) && Number.isInteger(nextIndex)) {
-            if (!parents.has(nextIndex)) {
-              parents.set(nextIndex, neighborIndex);
-            }
-            nextSet.add(nextIndex);
-          }
-        });
+    const pushContribution = (sourceIndex, pathIndices, value) => {
+      const metrics = buildPriceMetrics(value);
+      if (!metrics || !Array.isArray(pathIndices) || pathIndices.length < 2) {
+        return;
+      }
+      contributions.push({
+        sourceIndex,
+        path: pathIndices.slice(),
+        price: metrics.price,
+        pricePerSqm: metrics.pricePerSqm
       });
+      usedSources.add(sourceIndex);
+    };
 
-      if (pricedValues.length) {
-        let chosenIndex = null;
-        let chosenPath = null;
-        let chosenDistance = Infinity;
-
-        pricedIndices.forEach(targetIndex => {
-          const path = [];
-          let current = targetIndex;
-          let guard = 0;
-          const guardLimit = Math.max(baseValues.length * 4, 16);
-          while (Number.isInteger(current) && guard < guardLimit) {
-            path.push(current);
-            if (current === index) {
-              break;
-            }
-            current = parents.get(current);
-            guard += 1;
-            if (!Number.isInteger(current)) {
-              break;
-            }
-          }
-          if (path[path.length - 1] !== index) {
-            path.push(index);
-          }
-          const normalizedPath = path.reverse();
-          const distance = computePathDistance(normalizedPath, dataset);
-          const normalizedDistance = Number.isFinite(distance) ? distance : Number.MAX_VALUE;
-          if (normalizedDistance < chosenDistance) {
-            chosenDistance = normalizedDistance;
-            chosenIndex = targetIndex;
-            chosenPath = normalizedPath;
-          }
-        });
-
-        if (chosenIndex !== null) {
-          const chosenValue = baseValues[chosenIndex];
-          if (chosenValue?.hasPrice && chosenValue.price > 0) {
-            const area = Number(baseEntry.area);
-            const neighborPricePerSqm = Number(chosenValue.pricePerSqm);
-            const neighborPrice = Number(chosenValue.price);
-            const resolvedPricePerSqm = neighborPricePerSqm > 0
-              ? neighborPricePerSqm
-              : (neighborPrice > 0 && area > 0)
-                ? neighborPrice / area
-                : 0;
-            const resolvedPrice = area > 0 && resolvedPricePerSqm > 0
-              ? resolvedPricePerSqm * area
-              : neighborPrice;
-
-            if (resolvedPrice > 0) {
-              return {
-                price: resolvedPrice,
-                pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-                paths: Array.isArray(chosenPath) ? [chosenPath] : []
-              };
-            }
-          }
+    const reconstructPath = (targetIndex, parentsMap) => {
+      const path = [targetIndex];
+      let current = targetIndex;
+      const guardLimit = Math.max(baseValues.length * 4, 16);
+      let guard = 0;
+      while (current !== index && guard < guardLimit) {
+        current = parentsMap.get(current);
+        if (!Number.isInteger(current)) {
+          break;
         }
+        path.push(current);
+        guard += 1;
+      }
+      if (path[path.length - 1] !== index) {
+        path.push(index);
+      }
+      return path.reverse();
+    };
 
+    const findSourceForNeighbor = (startIndex, disallowUsed = true) => {
+      if (!Number.isInteger(startIndex)) {
         return null;
       }
 
-      frontier = Array.from(nextSet);
+      const visited = new Set([index]);
+      const parents = new Map();
+      const queue = [];
+
+      visited.add(startIndex);
+      parents.set(startIndex, index);
+      queue.push({ node: startIndex, depth: 0 });
+
+      let candidateDepth = null;
+      const candidates = [];
+
+      while (queue.length) {
+        const { node, depth } = queue.shift();
+
+        const value = baseValues[node];
+        const alreadyUsed = usedSources.has(node);
+        const isCandidate = node !== index
+          && value?.hasPrice
+          && value.price > 0
+          && (!disallowUsed || !alreadyUsed);
+
+        if (isCandidate) {
+          if (candidateDepth === null) {
+            candidateDepth = depth;
+          }
+          if (depth === candidateDepth) {
+            candidates.push(node);
+          }
+        }
+
+        if (candidateDepth !== null && depth >= candidateDepth) {
+          continue;
+        }
+
+        (adjacencyList[node] || []).forEach(nextIndex => {
+          if (!Number.isInteger(nextIndex) || visited.has(nextIndex)) {
+            return;
+          }
+          visited.add(nextIndex);
+          parents.set(nextIndex, node);
+          queue.push({ node: nextIndex, depth: depth + 1 });
+        });
+      }
+
+      if (!candidates.length) {
+        return null;
+      }
+
+      let chosenIndex = candidates[0];
+      let chosenPath = reconstructPath(chosenIndex, parents);
+      let chosenDistance = computePathDistance(chosenPath, dataset);
+      if (!Number.isFinite(chosenDistance)) {
+        chosenDistance = Infinity;
+      }
+
+      candidates.slice(1).forEach(candidate => {
+        const path = reconstructPath(candidate, parents);
+        const distance = computePathDistance(path, dataset);
+        const normalizedDistance = Number.isFinite(distance) ? distance : Infinity;
+        if (normalizedDistance < chosenDistance) {
+          chosenDistance = normalizedDistance;
+          chosenIndex = candidate;
+          chosenPath = path;
+        }
+      });
+
+      return {
+        sourceIndex: chosenIndex,
+        path: chosenPath
+      };
+    };
+
+    const neighborsNeedingSources = [];
+
+    directNeighbors.forEach(neighborIndex => {
+      const neighborValue = baseValues[neighborIndex];
+      if (neighborValue?.hasPrice && neighborValue.price > 0) {
+        pushContribution(neighborIndex, [index, neighborIndex], neighborValue);
+      } else {
+        neighborsNeedingSources.push(neighborIndex);
+      }
+    });
+
+    neighborsNeedingSources.forEach(neighborIndex => {
+      let result = findSourceForNeighbor(neighborIndex, true);
+      if (!result) {
+        result = findSourceForNeighbor(neighborIndex, false);
+      }
+      if (!result) {
+        return;
+      }
+      const sourceValue = baseValues[result.sourceIndex];
+      if (!sourceValue?.hasPrice || !(sourceValue.price > 0)) {
+        return;
+      }
+      pushContribution(result.sourceIndex, result.path, sourceValue);
+    });
+
+    if (!contributions.length) {
+      return null;
     }
 
-    return null;
+    const ppmValues = contributions
+      .map(entry => Number(entry.pricePerSqm))
+      .filter(value => Number.isFinite(value) && value > 0);
+    const priceValues = contributions
+      .map(entry => Number(entry.price))
+      .filter(value => Number.isFinite(value) && value > 0);
+
+    const resolvedPricePerSqm = ppmValues.length
+      ? ppmValues.reduce((sum, value) => sum + value, 0) / ppmValues.length
+      : 0;
+
+    let resolvedPrice = 0;
+    if (resolvedPricePerSqm > 0 && Number.isFinite(baseArea) && baseArea > 0) {
+      resolvedPrice = resolvedPricePerSqm * baseArea;
+    } else if (priceValues.length) {
+      resolvedPrice = priceValues.reduce((sum, value) => sum + value, 0) / priceValues.length;
+    }
+
+    if (!(resolvedPrice > 0) && !(resolvedPricePerSqm > 0)) {
+      return null;
+    }
+
+    const connectorPaths = contributions
+      .map(entry => entry.path)
+      .filter(path => Array.isArray(path) && path.length >= 2)
+      .map(path => path.slice());
+
+    if (!connectorPaths.length) {
+      return null;
+    }
+
+    return {
+      price: resolvedPrice > 0 ? resolvedPrice : 0,
+      pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
+      paths: connectorPaths
+    };
   }
 
   function resolveVoronoiValues(baseValues, adjacencyList, dataset) {

--- a/oferty.html
+++ b/oferty.html
@@ -232,7 +232,7 @@ window.showConfirmModal = showConfirmModal;
           <div class="voronoi-panel__header">
             <h3 class="filters-title voronoi-panel__title">Wycena nieruchomości (beta)</h3>
             <div class="voronoi-toggle" role="group" aria-labelledby="voronoiToggleLabel">
-              <span class="voronoi-toggle__label" id="voronoiToggleLabel">Feature toggle / feature flag</span>
+              <span class="voronoi-toggle__label" id="voronoiToggleLabel">Wł. / Wył.</span>
               <div class="voronoi-toggle__controls">
                 <input
                   type="checkbox"
@@ -240,11 +240,23 @@ window.showConfirmModal = showConfirmModal;
                   class="voronoi-toggle__input"
                   aria-label="Przełącz warstwę wyceny nieruchomości"
                 />
-                <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="off" aria-pressed="false">
-                  Wyłączone
+                <button
+                  type="button"
+                  class="voronoi-toggle__option"
+                  data-voronoi-toggle="off"
+                  aria-pressed="false"
+                  aria-label="Wyłącz warstwę"
+                >
+                  Wył.
                 </button>
-                <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="on" aria-pressed="false">
-                  Włączone
+                <button
+                  type="button"
+                  class="voronoi-toggle__option"
+                  data-voronoi-toggle="on"
+                  aria-pressed="false"
+                  aria-label="Włącz warstwę"
+                >
+                  Wł.
                 </button>
               </div>
             </div>

--- a/oferty.html
+++ b/oferty.html
@@ -230,19 +230,27 @@ window.showConfirmModal = showConfirmModal;
       <div class="sidebar-stack">
         <div class="voronoi-panel" id="voronoiPanel">
           <div class="voronoi-panel__header">
-            <div class="voronoi-toggle-control">
-              <input type="checkbox" id="toggleVoronoiLayer" />
-              <label for="toggleVoronoiLayer">Wycena nieruchomości (beta)</label>
-            </div>
+            <h3 class="filters-title voronoi-panel__title">Wycena nieruchomości</h3>
+            <label class="voronoi-switch" for="toggleVoronoiLayer">
+              <input
+                type="checkbox"
+                id="toggleVoronoiLayer"
+                class="voronoi-switch__input"
+                aria-label="Włącz warstwę wyceny nieruchomości"
+              />
+              <span class="voronoi-switch__track" aria-hidden="true">
+                <span class="voronoi-switch__thumb"></span>
+              </span>
+            </label>
           </div>
           <div class="voronoi-legend" aria-live="polite">
             <div class="voronoi-legend__item">
               <span class="voronoi-legend__swatch voronoi-legend__swatch--selected" aria-hidden="true"></span>
-              <span class="voronoi-legend__label">Zaznaczona wycena – zielony</span>
+              <span class="voronoi-legend__label">Zaznaczona wycena</span>
             </div>
             <div class="voronoi-legend__item">
               <span class="voronoi-legend__swatch voronoi-legend__swatch--source" aria-hidden="true"></span>
-              <span class="voronoi-legend__label">Źródło wyceny – niebieski</span>
+              <span class="voronoi-legend__label">Źródło wyceny</span>
             </div>
           </div>
           <div
@@ -529,19 +537,19 @@ window.showConfirmModal = showConfirmModal;
     }
     if (mode === 'sourceHighlight') {
       return {
-        strokeColor: '#1D4ED8',
-        strokeOpacity: 0.9,
+        strokeColor: '#2563EB',
+        strokeOpacity: 0.92,
         strokeWeight: 2,
-        fillColor: '#1E3A8A',
-        fillOpacity: 0.5
+        fillColor: '#60A5FA',
+        fillOpacity: 0.45
       };
     }
     return {
-      strokeColor: '#1e3a8a',
-      strokeOpacity: 0.75,
+      strokeColor: '#2563EB',
+      strokeOpacity: 0.72,
       strokeWeight: 1.2,
-      fillColor: '#1B2A5B',
-      fillOpacity: 0.22
+      fillColor: '#3B82F6',
+      fillOpacity: 0.2
     };
   }
 

--- a/oferty.html
+++ b/oferty.html
@@ -230,18 +230,21 @@ window.showConfirmModal = showConfirmModal;
       <div class="sidebar-stack">
         <div class="voronoi-panel" id="voronoiPanel">
           <div class="voronoi-panel__header">
-            <h3 class="filters-title voronoi-panel__title">Wycena nieruchomości</h3>
-            <label class="voronoi-switch" for="toggleVoronoiLayer">
+            <h3 class="filters-title voronoi-panel__title">Wycena nieruchomości (beta)</h3>
+            <div class="voronoi-toggle" role="group" aria-label="Wycena nieruchomości">
               <input
                 type="checkbox"
                 id="toggleVoronoiLayer"
-                class="voronoi-switch__input"
-                aria-label="Włącz warstwę wyceny nieruchomości"
+                class="voronoi-toggle__input"
+                aria-label="Przełącz warstwę wyceny nieruchomości"
               />
-              <span class="voronoi-switch__track" aria-hidden="true">
-                <span class="voronoi-switch__thumb"></span>
-              </span>
-            </label>
+              <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="off" aria-pressed="false">
+                Wyłączone
+              </button>
+              <button type="button" class="voronoi-toggle__option" data-voronoi-toggle="on" aria-pressed="false">
+                Włączone
+              </button>
+            </div>
           </div>
           <div class="voronoi-legend" aria-live="polite">
             <div class="voronoi-legend__item">
@@ -540,16 +543,16 @@ window.showConfirmModal = showConfirmModal;
         strokeColor: '#2563EB',
         strokeOpacity: 0.92,
         strokeWeight: 2,
-        fillColor: '#60A5FA',
-        fillOpacity: 0.45
+        fillColor: '#A5C8FF',
+        fillOpacity: 0.48
       };
     }
     return {
-      strokeColor: '#2563EB',
+      strokeColor: '#1D4ED8',
       strokeOpacity: 0.72,
       strokeWeight: 1.2,
-      fillColor: '#3B82F6',
-      fillOpacity: 0.2
+      fillColor: '#93C5FD',
+      fillOpacity: 0.26
     };
   }
 
@@ -1585,6 +1588,20 @@ window.showConfirmModal = showConfirmModal;
   const toggleTagsBtn = document.getElementById('toggleTagsBtn');
   const sortButtons = document.querySelectorAll('[data-sort-key]');
   const voronoiToggleInput = document.getElementById('toggleVoronoiLayer');
+  const voronoiToggleButtons = document.querySelectorAll('[data-voronoi-toggle]');
+
+  function syncVoronoiToggleUI() {
+    if (!voronoiToggleButtons?.length) {
+      return;
+    }
+    const isEnabled = !!voronoiToggleInput?.checked;
+    voronoiToggleButtons.forEach(button => {
+      const shouldEnable = button.dataset.voronoiToggle === 'on';
+      const isActive = shouldEnable === isEnabled;
+      button.classList.toggle('voronoi-toggle__option--active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
 
   const clusterRenderer = {
     render: ({ count, position }) => {
@@ -1633,7 +1650,27 @@ window.showConfirmModal = showConfirmModal;
     } else {
       clearVoronoiLayer();
     }
+    syncVoronoiToggleUI();
   });
+
+  if (voronoiToggleButtons?.length) {
+    voronoiToggleButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        if (!voronoiToggleInput) {
+          return;
+        }
+        const shouldEnable = button.dataset.voronoiToggle === 'on';
+        if (voronoiToggleInput.checked !== shouldEnable) {
+          voronoiToggleInput.checked = shouldEnable;
+          voronoiToggleInput.dispatchEvent(new Event('change', { bubbles: true }));
+        } else {
+          syncVoronoiToggleUI();
+        }
+      });
+    });
+  }
+
+  syncVoronoiToggleUI();
 
   updateSortButtonsUI();
 

--- a/oferty.html
+++ b/oferty.html
@@ -473,8 +473,11 @@ window.showConfirmModal = showConfirmModal;
     cells: [],
     highlight: {
       baseIndex: null,
+      selectedOfferKey: null,
+      selectedIndexHint: null,
       polygons: new Set(),
-      connectors: new Set()
+      connectors: new Set(),
+      ignoreNextMapClear: false
     }
   };
 
@@ -544,7 +547,16 @@ window.showConfirmModal = showConfirmModal;
     connector.setOptions(buildVoronoiConnectorStyle(mode));
   }
 
-  function clearVoronoiHighlights() {
+  function getVoronoiDatasetOfferKey(entry) {
+    if (!entry || !entry.offer) {
+      return null;
+    }
+    const rawKey = entry.offer.key ?? entry.offer.id ?? entry.offer.plot?.id ?? null;
+    return rawKey != null ? String(rawKey) : null;
+  }
+
+  function clearVoronoiHighlights(options = {}) {
+    const { resetSelection = true } = options || {};
     const highlight = voronoiLayerState.highlight;
     if (highlight.polygons.size) {
       highlight.polygons.forEach(polygon => applyVoronoiPolygonStyle(polygon, 'default'));
@@ -555,6 +567,11 @@ window.showConfirmModal = showConfirmModal;
     highlight.polygons.clear();
     highlight.connectors.clear();
     highlight.baseIndex = null;
+    if (resetSelection) {
+      highlight.selectedOfferKey = null;
+      highlight.selectedIndexHint = null;
+      highlight.ignoreNextMapClear = false;
+    }
   }
 
   function highlightVoronoiPolygon(index) {
@@ -566,12 +583,18 @@ window.showConfirmModal = showConfirmModal;
       return;
     }
 
-    clearVoronoiHighlights();
+    clearVoronoiHighlights({ resetSelection: false });
 
     const highlight = voronoiLayerState.highlight;
     applyVoronoiPolygonStyle(polygon, 'baseHighlight');
     highlight.polygons.add(polygon);
     highlight.baseIndex = index;
+    highlight.selectedIndexHint = index;
+    const datasetEntry = Array.isArray(voronoiLayerState.datasetSnapshot)
+      ? voronoiLayerState.datasetSnapshot[index]
+      : null;
+    const offerKey = getVoronoiDatasetOfferKey(datasetEntry);
+    highlight.selectedOfferKey = offerKey;
 
     const resolvedEntry = Array.isArray(voronoiLayerState.resolvedValues)
       ? voronoiLayerState.resolvedValues[index]
@@ -608,15 +631,15 @@ window.showConfirmModal = showConfirmModal;
     }
   }
 
-  const VORONOI_FREEZE_ZOOM_LEVEL = 15;
+  const VORONOI_FREEZE_ZOOM_LEVEL = 14;
   const VORONOI_HIDE_ZOOM_LEVEL = 19;
-  const VORONOI_LABEL_BASE_MIN_ZOOM = 14;
+  const VORONOI_LABEL_BASE_MIN_ZOOM = 15;
   const VORONOI_LABEL_VISIBILITY_RULES = [
     { minCount: 260, minZoom: 18 },
     { minCount: 200, minZoom: 17 },
     { minCount: 150, minZoom: 16 },
     { minCount: 100, minZoom: 15 },
-    { minCount: 60, minZoom: 14 }
+    { minCount: 60, minZoom: 15 }
   ];
 
   function getMapZoomLevel() {
@@ -2231,8 +2254,9 @@ window.showConfirmModal = showConfirmModal;
     });
   }
 
-  function clearVoronoiLayer() {
-    clearVoronoiHighlights();
+  function clearVoronoiLayer(options = {}) {
+    const { resetHighlight = true } = options || {};
+    clearVoronoiHighlights({ resetSelection: resetHighlight });
 
     voronoiLayerState.polygons.forEach(poly => {
       if (poly && typeof poly.setMap === 'function') {
@@ -2428,7 +2452,9 @@ window.showConfirmModal = showConfirmModal;
       voronoiLayerState.cacheSignature = sourceSignature;
     }
 
-    clearVoronoiLayer();
+    const preservedSelectionKey = voronoiLayerState.highlight.selectedOfferKey;
+    const preservedIndexHint = voronoiLayerState.highlight.selectedIndexHint;
+    clearVoronoiLayer({ resetHighlight: false });
     resetVoronoiLabelLayout();
 
     const shouldRenderLabels = shouldRenderVoronoiLabelsForDatasetSize(dataset.length);
@@ -2485,7 +2511,11 @@ window.showConfirmModal = showConfirmModal;
       polygon.__voronoiIndex = index;
       polygon.addListener('click', () => {
         if (!voronoiLayerState.enabled) return;
+        voronoiLayerState.highlight.ignoreNextMapClear = true;
         highlightVoronoiPolygon(index);
+        window.setTimeout(() => {
+          voronoiLayerState.highlight.ignoreNextMapClear = false;
+        }, 0);
       });
       voronoiLayerState.polygons.push(polygon);
 
@@ -2531,6 +2561,27 @@ window.showConfirmModal = showConfirmModal;
         voronoiLayerState.connectorIndexMap.set(index, connectorsForBase);
       });
     });
+
+    if (preservedSelectionKey || Number.isInteger(preservedIndexHint)) {
+      let rehighlightIndex = -1;
+      if (preservedSelectionKey) {
+        rehighlightIndex = voronoiLayerState.datasetSnapshot.findIndex(entry => {
+          const entryKey = getVoronoiDatasetOfferKey(entry);
+          return entryKey && entryKey === preservedSelectionKey;
+        });
+      }
+      if (rehighlightIndex < 0 && Number.isInteger(preservedIndexHint)) {
+        if (preservedIndexHint >= 0 && preservedIndexHint < voronoiLayerState.datasetSnapshot.length) {
+          rehighlightIndex = preservedIndexHint;
+        }
+      }
+      if (rehighlightIndex >= 0) {
+        highlightVoronoiPolygon(rehighlightIndex);
+      } else {
+        voronoiLayerState.highlight.selectedOfferKey = null;
+        voronoiLayerState.highlight.selectedIndexHint = null;
+      }
+    }
   }
 
   function updateVoronoiLayer(forceRebuild = false) {
@@ -2984,7 +3035,11 @@ window.showConfirmModal = showConfirmModal;
       updatePolygonVisibility();
     });
     google.maps.event.addListener(map, "click", () => {
-      clearVoronoiHighlights();
+      if (voronoiLayerState.highlight.ignoreNextMapClear) {
+        voronoiLayerState.highlight.ignoreNextMapClear = false;
+        return;
+      }
+      clearVoronoiHighlights({ resetSelection: true });
     });
     await loadOffers();
     focusOfferFromMapState();

--- a/oferty.html
+++ b/oferty.html
@@ -456,6 +456,7 @@ window.showConfirmModal = showConfirmModal;
   const voronoiLayerState = {
     enabled: false,
     polygons: [],
+    connectors: [],
     labels: [],
     tagWeights: new Map(),
     maxTagValue: 1,
@@ -463,13 +464,56 @@ window.showConfirmModal = showConfirmModal;
       overlay: null,
       boxes: [],
       projectionPending: false
-    }
+    },
+    cachedDataset: null,
+    cacheSignature: null
   };
 
   const VORONOI_LABEL_SIZE = {
     width: 132,
     height: 34
   };
+
+  const VORONOI_FREEZE_ZOOM_LEVEL = 17;
+
+  function getMapZoomLevel() {
+    if (!map || typeof map.getZoom !== 'function') return null;
+    const zoom = map.getZoom();
+    return typeof zoom === 'number' ? zoom : null;
+  }
+
+  function shouldFreezeVoronoiLayout() {
+    const zoom = getMapZoomLevel();
+    return Number.isFinite(zoom) && zoom >= VORONOI_FREEZE_ZOOM_LEVEL;
+  }
+
+  function cloneVoronoiCache(dataset, adjacencyList, resolvedValues, extent) {
+    return {
+      dataset: Array.isArray(dataset)
+        ? dataset.map(entry => ({
+            offer: entry.offer,
+            position: entry?.position
+              ? { lat: entry.position.lat, lng: entry.position.lng }
+              : null
+          }))
+        : [],
+      adjacencyList: Array.isArray(adjacencyList)
+        ? adjacencyList.map(neighbors => Array.isArray(neighbors) ? neighbors.slice() : [])
+        : [],
+      resolvedValues: Array.isArray(resolvedValues)
+        ? resolvedValues.map(value => {
+            if (!value) return value;
+            return {
+              ...value,
+              fallbackSources: Array.isArray(value.fallbackSources)
+                ? value.fallbackSources.map(path => Array.isArray(path) ? path.slice() : [])
+                : []
+            };
+          })
+        : [],
+      extent: Array.isArray(extent) ? extent.slice() : null
+    };
+  }
 
   const MAP_STATE_STORAGE_KEY = 'grunteo::offers::mapState';
   const MAP_STATE_TTL_MS = 1000 * 60 * 60 * 12; // 12 godzin
@@ -961,6 +1005,8 @@ window.showConfirmModal = showConfirmModal;
     availableTags = [];
     tagMetrics = new Map();
     currentVisibleOffers = [];
+    voronoiLayerState.cachedDataset = null;
+    voronoiLayerState.cacheSignature = null;
 
     if (!Array.isArray(documents)) {
       renderTagFilters();
@@ -1349,9 +1395,17 @@ window.showConfirmModal = showConfirmModal;
 
   function computeFallbackFromNeighbors(index, baseValues, adjacencyList) {
     const visited = new Set([index]);
+    const parents = new Map();
     let frontier = (adjacencyList[index] || []).filter(i => Number.isInteger(i));
 
+    frontier.forEach(neighborIndex => {
+      if (Number.isInteger(neighborIndex)) {
+        parents.set(neighborIndex, index);
+      }
+    });
+
     while (frontier.length) {
+      const pricedIndices = [];
       const pricedValues = [];
       const nextSet = new Set();
 
@@ -1361,11 +1415,15 @@ window.showConfirmModal = showConfirmModal;
 
         const value = baseValues[neighborIndex];
         if (value?.hasPrice && value.price > 0) {
+          pricedIndices.push(neighborIndex);
           pricedValues.push(value);
         }
 
         (adjacencyList[neighborIndex] || []).forEach(nextIndex => {
           if (!visited.has(nextIndex) && Number.isInteger(nextIndex)) {
+            if (!parents.has(nextIndex)) {
+              parents.set(nextIndex, neighborIndex);
+            }
             nextSet.add(nextIndex);
           }
         });
@@ -1374,9 +1432,32 @@ window.showConfirmModal = showConfirmModal;
       if (pricedValues.length) {
         const priceSum = pricedValues.reduce((sum, value) => sum + value.price, 0);
         const ppm2Sum = pricedValues.reduce((sum, value) => sum + value.pricePerSqm, 0);
+        const paths = pricedIndices.map(targetIndex => {
+          const path = [];
+          let current = targetIndex;
+          let guard = 0;
+          const guardLimit = Math.max(baseValues.length * 4, 16);
+          while (Number.isInteger(current) && guard < guardLimit) {
+            path.push(current);
+            if (current === index) {
+              break;
+            }
+            current = parents.get(current);
+            guard += 1;
+            if (!Number.isInteger(current)) {
+              break;
+            }
+          }
+          if (path[path.length - 1] !== index) {
+            path.push(index);
+          }
+          return path.reverse();
+        });
+
         return {
           price: priceSum / pricedValues.length,
-          pricePerSqm: ppm2Sum / pricedValues.length
+          pricePerSqm: ppm2Sum / pricedValues.length,
+          paths
         };
       }
 
@@ -1390,19 +1471,28 @@ window.showConfirmModal = showConfirmModal;
     return baseValues.map((entry, index) => {
       if (!entry) return entry;
       if (entry.hasPrice && entry.price > 0) {
-        return entry;
+        return {
+          ...entry,
+          fallbackSources: Array.isArray(entry.fallbackSources) ? entry.fallbackSources.slice() : []
+        };
       }
 
       const fallback = computeFallbackFromNeighbors(index, baseValues, adjacencyList);
       if (!fallback) {
-        return entry;
+        return {
+          ...entry,
+          fallbackSources: []
+        };
       }
 
       return {
         ...entry,
         price: fallback.price,
         pricePerSqm: fallback.pricePerSqm,
-        hasPrice: true
+        hasPrice: true,
+        fallbackSources: Array.isArray(fallback.paths)
+          ? fallback.paths.filter(path => Array.isArray(path) && path.length >= 2)
+          : []
       };
     });
   }
@@ -1754,6 +1844,13 @@ window.showConfirmModal = showConfirmModal;
     });
     voronoiLayerState.polygons = [];
 
+    voronoiLayerState.connectors.forEach(connector => {
+      if (connector && typeof connector.setMap === 'function') {
+        connector.setMap(null);
+      }
+    });
+    voronoiLayerState.connectors = [];
+
     voronoiLayerState.labels.forEach(label => {
       if (!label) return;
       if (typeof label.setMap === 'function') {
@@ -1785,72 +1882,130 @@ window.showConfirmModal = showConfirmModal;
       return;
     }
 
+    const freezeActive = shouldFreezeVoronoiLayout();
     const offers = getVoronoiSourceOffers();
-    const dataset = offers
-      .map(offer => {
-        const source = offer?.voronoiPoint || null;
-        let lat = Number(source?.lat);
-        let lng = Number(source?.lng);
+    const sourceSignature = offers
+      .map(offer => (offer?.key || offer?.id || '')).join('|');
+    const cached = (freezeActive && voronoiLayerState.cacheSignature === sourceSignature)
+      ? voronoiLayerState.cachedDataset
+      : null;
 
-        if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
-          lat = Number(offer?.plot?.lat);
-          lng = Number(offer?.plot?.lng);
-        }
-
-        if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-
-        return { offer, position: { lat, lng } };
-      })
-      .filter(Boolean);
-
-    clearVoronoiLayer();
-
-    if (!dataset.length) return;
-
-    const bounds = map.getBounds();
-    if (!bounds) return;
-
-    const sw = bounds.getSouthWest();
-    const ne = bounds.getNorthEast();
-    const extent = [sw.lng(), sw.lat(), ne.lng(), ne.lat()];
-
+    let dataset = [];
+    let adjacencyList = [];
+    let resolvedValues = [];
+    let extent = null;
     let delaunay;
-    try {
-      const points = dataset.map(({ position }) => [position.lng, position.lat]);
-      delaunay = window.d3.Delaunay.from(points);
-    } catch (error) {
-      console.warn('Nie udało się zbudować diagramu Voronoi.', error);
-      return;
-    }
+    let voronoi;
+    let shouldUpdateCache = false;
 
-    const voronoi = delaunay.voronoi(extent);
-    const adjacencyList = dataset.map((_, index) => {
-      const iterator = delaunay.neighbors(index);
-      if (!iterator) return [];
-      const neighbors = [];
-      for (const neighbor of iterator) {
-        if (Number.isInteger(neighbor)) {
-          neighbors.push(neighbor);
+    if (cached && Array.isArray(cached.dataset) && cached.dataset.length) {
+      dataset = cached.dataset;
+      adjacencyList = Array.isArray(cached.adjacencyList) ? cached.adjacencyList : [];
+      resolvedValues = Array.isArray(cached.resolvedValues) ? cached.resolvedValues : [];
+      extent = Array.isArray(cached.extent) ? cached.extent.slice() : null;
+      if (!Array.isArray(extent) || extent.length !== 4) {
+        const bounds = map.getBounds();
+        if (bounds) {
+          const sw = bounds.getSouthWest();
+          const ne = bounds.getNorthEast();
+          extent = [sw.lng(), sw.lat(), ne.lng(), ne.lat()];
         }
       }
-      return neighbors;
-    });
-    const baseValues = dataset.map(({ offer }) => computeOfferValueWithTags(offer));
-    const resolvedValues = resolveVoronoiValues(baseValues, adjacencyList);
+      try {
+        const points = dataset.map(({ position }) => [position.lng, position.lat]);
+        delaunay = window.d3.Delaunay.from(points);
+        voronoi = delaunay.voronoi(extent);
+      } catch (error) {
+        console.warn('Nie udało się zbudować zamrożonego diagramu Voronoi.', error);
+        return;
+      }
+    } else {
+      dataset = offers
+        .map(offer => {
+          const source = offer?.voronoiPoint || null;
+          let lat = Number(source?.lat);
+          let lng = Number(source?.lng);
 
+          if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+            lat = Number(offer?.plot?.lat);
+            lng = Number(offer?.plot?.lng);
+          }
+
+          if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+
+          return { offer, position: { lat, lng } };
+        })
+        .filter(Boolean);
+
+      if (!dataset.length) {
+        clearVoronoiLayer();
+        voronoiLayerState.cachedDataset = null;
+        voronoiLayerState.cacheSignature = null;
+        return;
+      }
+
+      const bounds = map.getBounds();
+      if (!bounds) return;
+
+      const sw = bounds.getSouthWest();
+      const ne = bounds.getNorthEast();
+      extent = [sw.lng(), sw.lat(), ne.lng(), ne.lat()];
+
+      try {
+        const points = dataset.map(({ position }) => [position.lng, position.lat]);
+        delaunay = window.d3.Delaunay.from(points);
+      } catch (error) {
+        console.warn('Nie udało się zbudować diagramu Voronoi.', error);
+        return;
+      }
+
+      try {
+        voronoi = delaunay.voronoi(extent);
+      } catch (error) {
+        console.warn('Nie udało się utworzyć diagramu Voronoi dla bieżącego widoku.', error);
+        return;
+      }
+      adjacencyList = dataset.map((_, index) => {
+        const iterator = delaunay.neighbors(index);
+        if (!iterator) return [];
+        const neighbors = [];
+        for (const neighbor of iterator) {
+          if (Number.isInteger(neighbor)) {
+            neighbors.push(neighbor);
+          }
+        }
+        return neighbors;
+      });
+      const baseValues = dataset.map(({ offer }) => computeOfferValueWithTags(offer));
+      resolvedValues = resolveVoronoiValues(baseValues, adjacencyList);
+      shouldUpdateCache = true;
+    }
+
+    if (shouldUpdateCache || !freezeActive) {
+      voronoiLayerState.cachedDataset = cloneVoronoiCache(dataset, adjacencyList, resolvedValues, extent);
+      voronoiLayerState.cacheSignature = sourceSignature;
+    }
+
+    clearVoronoiLayer();
     resetVoronoiLabelLayout();
 
-    dataset.forEach(({ position }, index) => {
+    const cells = dataset.map(({ position }, index) => {
+      if (!voronoi) return null;
       const polygonCoords = voronoi.cellPolygon(index);
-      if (!Array.isArray(polygonCoords) || polygonCoords.length < 3) return;
-
+      if (!Array.isArray(polygonCoords) || polygonCoords.length < 3) return null;
       const path = polygonCoords.map(([lng, lat]) => ({ lat, lng }));
+      const centroid = calculatePolygonCentroid(path) || position;
+      return { path, centroid, position };
+    });
+
+    cells.forEach((cell, index) => {
+      if (!cell) return;
       const neighborIndices = adjacencyList[index] || [];
       const stats = aggregateVoronoiValues(resolvedValues, index, neighborIndices);
       const content = buildVoronoiLabelContent(stats);
 
       const polygon = new google.maps.Polygon({
-        paths: path,
+        paths: cell.path,
         map: voronoiLayerState.enabled ? map : null,
         strokeColor: '#D1D5DB',
         strokeOpacity: 0.8,
@@ -1862,12 +2017,45 @@ window.showConfirmModal = showConfirmModal;
       });
       voronoiLayerState.polygons.push(polygon);
 
-      const centroid = calculatePolygonCentroid(path) || position;
-      const labelPosition = findNonOverlappingLabelPosition(centroid || position);
+      const labelPosition = findNonOverlappingLabelPosition(cell.centroid || cell.position);
       const label = createVoronoiLabelNode(content.html, content.plain, labelPosition);
       if (label) {
         voronoiLayerState.labels.push(label);
       }
+
+      const fallbackSources = Array.isArray(resolvedValues[index]?.fallbackSources)
+        ? resolvedValues[index].fallbackSources
+        : [];
+      fallbackSources.forEach(pathIndices => {
+        const connectorPath = Array.isArray(pathIndices)
+          ? pathIndices
+              .map(i => {
+                const targetCell = cells[i];
+                if (targetCell?.centroid) return targetCell.centroid;
+                const targetDataset = dataset[i];
+                return targetDataset?.position || null;
+              })
+              .filter(Boolean)
+          : [];
+        if (connectorPath.length < 2) return;
+
+        const connector = new google.maps.Polyline({
+          path: connectorPath,
+          map: voronoiLayerState.enabled ? map : null,
+          strokeColor: '#DC2626',
+          strokeOpacity: 0.65,
+          strokeWeight: 1.1,
+          geodesic: true,
+          clickable: false,
+          icons: [{
+            icon: { path: 'M 0,-1 0,1', strokeOpacity: 1, scale: 2 },
+            offset: '0',
+            repeat: '12px'
+          }],
+          zIndex: 38
+        });
+        voronoiLayerState.connectors.push(connector);
+      });
     });
   }
 
@@ -2374,6 +2562,8 @@ window.showConfirmModal = showConfirmModal;
       listContainer.innerHTML = '<p class="no-offers">Brak ofert w widocznym obszarze</p>';
       if (voronoiLayerState.enabled) {
         clearVoronoiLayer();
+        voronoiLayerState.cachedDataset = null;
+        voronoiLayerState.cacheSignature = null;
       }
       return;
     }

--- a/oferty.html
+++ b/oferty.html
@@ -1875,6 +1875,16 @@ window.showConfirmModal = showConfirmModal;
     return allOffers.slice();
   }
 
+  function getFrozenVoronoiOffers() {
+    const cached = voronoiLayerState.cachedDataset;
+    if (!cached || !Array.isArray(cached.dataset)) {
+      return [];
+    }
+    return cached.dataset
+      .map(entry => entry?.offer)
+      .filter(Boolean);
+  }
+
   function rebuildVoronoiLayer() {
     if (!voronoiLayerState.enabled || !map) return;
     if (!window.d3 || !window.d3.Delaunay) {
@@ -1883,12 +1893,20 @@ window.showConfirmModal = showConfirmModal;
     }
 
     const freezeActive = shouldFreezeVoronoiLayout();
-    const offers = getVoronoiSourceOffers();
-    const sourceSignature = offers
-      .map(offer => (offer?.key || offer?.id || '')).join('|');
-    const cached = (freezeActive && voronoiLayerState.cacheSignature === sourceSignature)
+    const canUseFrozenCache = freezeActive
+      && voronoiLayerState.cacheSignature
+      && Array.isArray(voronoiLayerState.cachedDataset?.dataset)
+      && voronoiLayerState.cachedDataset.dataset.length;
+
+    const offers = (canUseFrozenCache ? getFrozenVoronoiOffers() : getVoronoiSourceOffers());
+    const sourceSignature = canUseFrozenCache && voronoiLayerState.cacheSignature
+      ? voronoiLayerState.cacheSignature
+      : offers.map(offer => (offer?.key || offer?.id || '')).join('|');
+    const cached = canUseFrozenCache
       ? voronoiLayerState.cachedDataset
-      : null;
+      : (freezeActive && voronoiLayerState.cacheSignature === sourceSignature)
+        ? voronoiLayerState.cachedDataset
+        : null;
 
     let dataset = [];
     let adjacencyList = [];

--- a/oferty.html
+++ b/oferty.html
@@ -262,6 +262,22 @@ window.showConfirmModal = showConfirmModal;
             aria-hidden="true"
             hidden
           >
+            <div class="voronoi-inspector__summary" id="voronoiInspectorSummary" hidden>
+              <div class="voronoi-inspector__summary-header">
+                <span class="voronoi-inspector__summary-title">Podsumowanie</span>
+                <span class="voronoi-inspector__summary-badge" id="voronoiInspectorSummaryBadge" hidden>szac.</span>
+              </div>
+              <div class="voronoi-inspector__summary-grid">
+                <div class="voronoi-inspector__summary-item">
+                  <span class="voronoi-inspector__summary-label">Średnia cena m²</span>
+                  <span class="voronoi-inspector__summary-value" id="voronoiInspectorAvgValue">—</span>
+                </div>
+                <div class="voronoi-inspector__summary-item">
+                  <span class="voronoi-inspector__summary-label">Szacowana wartość działki</span>
+                  <span class="voronoi-inspector__summary-value" id="voronoiInspectorEstimateValue">—</span>
+                </div>
+              </div>
+            </div>
             <p
               class="voronoi-inspector__empty"
               id="voronoiInspectorEmpty"
@@ -601,10 +617,14 @@ window.showConfirmModal = showConfirmModal;
     const container = document.getElementById('voronoiInspector');
     const list = document.getElementById('voronoiInspectorList');
     const emptyState = document.getElementById('voronoiInspectorEmpty');
+    const summary = document.getElementById('voronoiInspectorSummary');
+    const summaryAvg = document.getElementById('voronoiInspectorAvgValue');
+    const summaryEstimate = document.getElementById('voronoiInspectorEstimateValue');
+    const summaryBadge = document.getElementById('voronoiInspectorSummaryBadge');
     if (!container || !list || !emptyState) {
       return null;
     }
-    return { container, list, emptyState };
+    return { container, list, emptyState, summary, summaryAvg, summaryEstimate, summaryBadge };
   }
 
   function extractPlotAreaFromOffer(offer) {
@@ -634,11 +654,23 @@ window.showConfirmModal = showConfirmModal;
   function hideVoronoiTagInspector() {
     const elements = getVoronoiInspectorElements();
     if (!elements) return;
-    const { container, list, emptyState } = elements;
+    const { container, list, emptyState, summary, summaryAvg, summaryEstimate, summaryBadge } = elements;
     list.innerHTML = '';
     const defaultMessage = emptyState.dataset.defaultMessage || emptyState.textContent || '';
     emptyState.textContent = defaultMessage;
     emptyState.hidden = false;
+    if (summary) {
+      summary.setAttribute('hidden', 'true');
+    }
+    if (summaryAvg) {
+      summaryAvg.textContent = '—';
+    }
+    if (summaryEstimate) {
+      summaryEstimate.textContent = '—';
+    }
+    if (summaryBadge) {
+      summaryBadge.setAttribute('hidden', 'true');
+    }
     container.setAttribute('hidden', 'true');
     container.setAttribute('aria-hidden', 'true');
   }
@@ -646,7 +678,7 @@ window.showConfirmModal = showConfirmModal;
   function updateVoronoiTagInspector(index) {
     const elements = getVoronoiInspectorElements();
     if (!elements) return;
-    const { container, list, emptyState } = elements;
+    const { container, list, emptyState, summary, summaryAvg, summaryEstimate, summaryBadge } = elements;
 
     if (!Number.isInteger(index) || index < 0) {
       hideVoronoiTagInspector();
@@ -656,6 +688,9 @@ window.showConfirmModal = showConfirmModal;
     const datasetEntry = Array.isArray(voronoiLayerState.datasetSnapshot)
       ? voronoiLayerState.datasetSnapshot[index]
       : null;
+    const resolvedEntry = Array.isArray(voronoiLayerState.resolvedValues)
+      ? voronoiLayerState.resolvedValues[index]
+      : null;
     const offerTags = Array.isArray(datasetEntry?.offer?.tags)
       ? datasetEntry.offer.tags.filter(tag => typeof tag === 'string' && tag.trim().length)
       : [];
@@ -663,6 +698,58 @@ window.showConfirmModal = showConfirmModal;
     container.removeAttribute('hidden');
     container.setAttribute('aria-hidden', 'false');
     list.innerHTML = '';
+
+    if (summary) {
+      const summaryData = (() => {
+        if (!resolvedEntry) {
+          return null;
+        }
+        let pricePerSqm = Number(resolvedEntry.pricePerSqm);
+        let totalPrice = Number(resolvedEntry.price);
+        let area = Number(resolvedEntry.area);
+        if (!(area > 0)) {
+          area = extractPlotAreaFromOffer(datasetEntry?.offer);
+        }
+        if (!(pricePerSqm > 0) && totalPrice > 0 && area > 0) {
+          pricePerSqm = totalPrice / area;
+        }
+        if (!(totalPrice > 0) && pricePerSqm > 0 && area > 0) {
+          totalPrice = pricePerSqm * area;
+        }
+        if (!(pricePerSqm > 0) && !(totalPrice > 0)) {
+          return null;
+        }
+        return {
+          pricePerSqm: pricePerSqm > 0 ? pricePerSqm : 0,
+          totalPrice: totalPrice > 0 ? totalPrice : 0,
+          fallback: Array.isArray(resolvedEntry.fallbackSources) && resolvedEntry.fallbackSources.length > 0
+        };
+      })();
+
+      if (summaryData) {
+        const avgText = summaryData.pricePerSqm > 0
+          ? `${formatPriceValue(summaryData.pricePerSqm)} zł/m²`
+          : '—';
+        const totalText = summaryData.totalPrice > 0
+          ? `${formatPriceValue(summaryData.totalPrice)} zł`
+          : '—';
+        summaryAvg && (summaryAvg.textContent = avgText);
+        summaryEstimate && (summaryEstimate.textContent = totalText);
+        if (summaryBadge) {
+          if (summaryData.fallback) {
+            summaryBadge.removeAttribute('hidden');
+          } else {
+            summaryBadge.setAttribute('hidden', 'true');
+          }
+        }
+        summary.removeAttribute('hidden');
+      } else {
+        summary.setAttribute('hidden', 'true');
+        summaryAvg && (summaryAvg.textContent = '—');
+        summaryEstimate && (summaryEstimate.textContent = '—');
+        summaryBadge && summaryBadge.setAttribute('hidden', 'true');
+      }
+    }
 
     if (!offerTags.length) {
       emptyState.textContent = 'Brak tagów dla tej działki.';

--- a/oferty.html
+++ b/oferty.html
@@ -225,7 +225,23 @@ window.showConfirmModal = showConfirmModal;
       <div id="map-controls">
         <div class="voronoi-toggle-control">
           <input type="checkbox" id="toggleVoronoiLayer" />
-          <label for="toggleVoronoiLayer">Wycena nieruchomości</label>
+          <label for="toggleVoronoiLayer">Wycena nieruchomości (beta)</label>
+        </div>
+        <div
+          class="voronoi-inspector"
+          id="voronoiInspector"
+          aria-hidden="true"
+          hidden
+        >
+          <div class="voronoi-inspector__title">Tagi i wagi</div>
+          <p
+            class="voronoi-inspector__empty"
+            id="voronoiInspectorEmpty"
+            data-default-message="Kliknij poligon, aby zobaczyć tagi i ich wagi."
+          >
+            Kliknij poligon, aby zobaczyć tagi i ich wagi.
+          </p>
+          <ul class="voronoi-inspector__list" id="voronoiInspectorList"></ul>
         </div>
       </div>
     </div>
@@ -555,6 +571,100 @@ window.showConfirmModal = showConfirmModal;
     return rawKey != null ? String(rawKey) : null;
   }
 
+  function getVoronoiInspectorElements() {
+    const container = document.getElementById('voronoiInspector');
+    const list = document.getElementById('voronoiInspectorList');
+    const emptyState = document.getElementById('voronoiInspectorEmpty');
+    if (!container || !list || !emptyState) {
+      return null;
+    }
+    return { container, list, emptyState };
+  }
+
+  function hideVoronoiTagInspector() {
+    const elements = getVoronoiInspectorElements();
+    if (!elements) return;
+    const { container, list, emptyState } = elements;
+    list.innerHTML = '';
+    const defaultMessage = emptyState.dataset.defaultMessage || emptyState.textContent || '';
+    emptyState.textContent = defaultMessage;
+    emptyState.hidden = false;
+    container.setAttribute('hidden', 'true');
+    container.setAttribute('aria-hidden', 'true');
+  }
+
+  function updateVoronoiTagInspector(index) {
+    const elements = getVoronoiInspectorElements();
+    if (!elements) return;
+    const { container, list, emptyState } = elements;
+
+    if (!Number.isInteger(index) || index < 0) {
+      hideVoronoiTagInspector();
+      return;
+    }
+
+    const datasetEntry = Array.isArray(voronoiLayerState.datasetSnapshot)
+      ? voronoiLayerState.datasetSnapshot[index]
+      : null;
+    const offerTags = Array.isArray(datasetEntry?.offer?.tags)
+      ? datasetEntry.offer.tags.filter(tag => typeof tag === 'string' && tag.trim().length)
+      : [];
+
+    container.removeAttribute('hidden');
+    container.setAttribute('aria-hidden', 'false');
+    list.innerHTML = '';
+
+    if (!offerTags.length) {
+      emptyState.textContent = 'Brak tagów dla tej działki.';
+      emptyState.hidden = false;
+      return;
+    }
+
+    emptyState.hidden = true;
+
+    const uniqueTags = Array.from(new Set(offerTags));
+    uniqueTags.sort((a, b) => a.localeCompare(b, 'pl', { sensitivity: 'base' }));
+
+    const weightMap = voronoiLayerState.tagWeights instanceof Map
+      ? voronoiLayerState.tagWeights
+      : new Map();
+    const maxValue = Math.max(Number(voronoiLayerState.maxTagValue) || 1, 1);
+
+    uniqueTags.forEach(tag => {
+      const weight = Number(weightMap.get(tag)) || 1;
+      const rawPercent = Math.round((weight / maxValue) * 100);
+      const normalized = Math.max(6, Math.min(100, rawPercent));
+
+      const item = document.createElement('li');
+      item.className = 'voronoi-inspector__item';
+
+      const header = document.createElement('div');
+      header.className = 'voronoi-inspector__item-header';
+
+      const tagLabel = document.createElement('span');
+      tagLabel.className = 'voronoi-inspector__tag';
+      tagLabel.textContent = formatTagLabel(tag);
+
+      const value = document.createElement('span');
+      value.className = 'voronoi-inspector__value';
+      value.textContent = `${weight}/${maxValue} (${rawPercent}%)`;
+
+      const meter = document.createElement('div');
+      meter.className = 'voronoi-inspector__meter';
+
+      const meterFill = document.createElement('span');
+      meterFill.className = 'voronoi-inspector__meter-fill';
+      meterFill.style.width = `${normalized}%`;
+
+      header.appendChild(tagLabel);
+      header.appendChild(value);
+      meter.appendChild(meterFill);
+      item.appendChild(header);
+      item.appendChild(meter);
+      list.appendChild(item);
+    });
+  }
+
   function clearVoronoiHighlights(options = {}) {
     const { resetSelection = true } = options || {};
     const highlight = voronoiLayerState.highlight;
@@ -571,6 +681,7 @@ window.showConfirmModal = showConfirmModal;
       highlight.selectedOfferKey = null;
       highlight.selectedIndexHint = null;
       highlight.ignoreNextMapClear = false;
+      hideVoronoiTagInspector();
     }
   }
 
@@ -629,6 +740,8 @@ window.showConfirmModal = showConfirmModal;
         highlight.connectors.add(connector);
       });
     }
+
+    updateVoronoiTagInspector(index);
   }
 
   const VORONOI_FREEZE_ZOOM_LEVEL = 14;
@@ -1679,26 +1792,38 @@ window.showConfirmModal = showConfirmModal;
       .map(neighbor => ({ index: neighbor, metrics: buildPriceMetrics(baseValues[neighbor]) }))
       .filter(entry => !!entry.metrics);
 
-    if (pricedNeighbors.length) {
-      const validPerSqm = pricedNeighbors
-        .map(entry => entry.metrics.pricePerSqm)
-        .filter(value => Number.isFinite(value) && value > 0);
-      const avgPerSqm = validPerSqm.length
-        ? validPerSqm.reduce((sum, value) => sum + value, 0) / validPerSqm.length
-        : 0;
+    const buildFallbackFromSource = (sourceIndex, path, metrics) => {
+      if (!Number.isInteger(sourceIndex) || !metrics) {
+        return null;
+      }
 
-      const validPrices = pricedNeighbors
-        .map(entry => entry.metrics.price)
-        .filter(value => Number.isFinite(value) && value > 0);
+      const normalizedPath = Array.isArray(path) && path.length >= 2
+        ? path.slice()
+        : [index, sourceIndex];
+      if (normalizedPath[0] !== index) {
+        normalizedPath.unshift(index);
+      }
+      if (normalizedPath[normalizedPath.length - 1] !== sourceIndex) {
+        normalizedPath.push(sourceIndex);
+      }
+
+      const sourceArea = Number(baseValues[sourceIndex]?.area);
+      const fallbackArea = Number.isFinite(baseArea) && baseArea > 0
+        ? baseArea
+        : (Number.isFinite(sourceArea) && sourceArea > 0 ? sourceArea : 0);
+
+      let resolvedPricePerSqm = metrics.pricePerSqm > 0 ? metrics.pricePerSqm : 0;
+      if (!(resolvedPricePerSqm > 0) && metrics.price > 0 && fallbackArea > 0) {
+        resolvedPricePerSqm = metrics.price / fallbackArea;
+      }
+
       let resolvedPrice = 0;
-      let resolvedPricePerSqm = avgPerSqm > 0 ? avgPerSqm : 0;
-
       if (resolvedPricePerSqm > 0 && Number.isFinite(baseArea) && baseArea > 0) {
         resolvedPrice = resolvedPricePerSqm * baseArea;
-      } else if (validPrices.length) {
-        resolvedPrice = validPrices.reduce((sum, value) => sum + value, 0) / validPrices.length;
-        if (!(resolvedPricePerSqm > 0) && Number.isFinite(baseArea) && baseArea > 0) {
-          resolvedPricePerSqm = resolvedPrice / baseArea;
+      } else if (metrics.price > 0) {
+        resolvedPrice = metrics.price;
+        if (!(resolvedPricePerSqm > 0) && fallbackArea > 0) {
+          resolvedPricePerSqm = metrics.price / fallbackArea;
         }
       }
 
@@ -1706,16 +1831,39 @@ window.showConfirmModal = showConfirmModal;
         return null;
       }
 
-      const sources = pricedNeighbors.map(entry => ({
-        sourceIndex: entry.index,
-        directPath: [index, entry.index]
-      }));
-
       return {
         price: resolvedPrice > 0 ? resolvedPrice : 0,
         pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-        sources
+        sources: [{
+          sourceIndex,
+          directPath: [index, sourceIndex],
+          fullPath: normalizedPath
+        }]
       };
+    };
+
+    if (pricedNeighbors.length) {
+      let bestDirect = null;
+      pricedNeighbors.forEach(entry => {
+        const path = [index, entry.index];
+        const distance = computePathDistance(path, dataset);
+        const normalizedDistance = Number.isFinite(distance) ? distance : Infinity;
+        if (!bestDirect || normalizedDistance < bestDirect.distance) {
+          bestDirect = {
+            sourceIndex: entry.index,
+            metrics: entry.metrics,
+            path,
+            distance: normalizedDistance
+          };
+        }
+      });
+
+      if (bestDirect) {
+        const fallback = buildFallbackFromSource(bestDirect.sourceIndex, bestDirect.path, bestDirect.metrics);
+        if (fallback) {
+          return fallback;
+        }
+      }
     }
 
     const reconstructPath = (targetIndex, parentsMap) => {
@@ -1802,49 +1950,7 @@ window.showConfirmModal = showConfirmModal;
       return null;
     }
 
-    const path = Array.isArray(bestSource.path) && bestSource.path.length
-      ? bestSource.path.slice()
-      : [index, bestSource.sourceIndex];
-    if (path[0] !== index) {
-      path.unshift(index);
-    }
-    if (path[path.length - 1] !== bestSource.sourceIndex) {
-      path.push(bestSource.sourceIndex);
-    }
-
-    const sourceArea = Number(baseValues[bestSource.sourceIndex]?.area);
-    const fallbackArea = Number.isFinite(baseArea) && baseArea > 0
-      ? baseArea
-      : (Number.isFinite(sourceArea) && sourceArea > 0 ? sourceArea : 0);
-
-    let resolvedPricePerSqm = metrics.pricePerSqm > 0 ? metrics.pricePerSqm : 0;
-    if (!(resolvedPricePerSqm > 0) && metrics.price > 0 && fallbackArea > 0) {
-      resolvedPricePerSqm = metrics.price / fallbackArea;
-    }
-
-    let resolvedPrice = 0;
-    if (resolvedPricePerSqm > 0 && Number.isFinite(baseArea) && baseArea > 0) {
-      resolvedPrice = resolvedPricePerSqm * baseArea;
-    } else if (metrics.price > 0) {
-      resolvedPrice = metrics.price;
-      if (!(resolvedPricePerSqm > 0) && fallbackArea > 0) {
-        resolvedPricePerSqm = metrics.price / fallbackArea;
-      }
-    }
-
-    if (!(resolvedPrice > 0) && !(resolvedPricePerSqm > 0)) {
-      return null;
-    }
-
-    return {
-      price: resolvedPrice > 0 ? resolvedPrice : 0,
-      pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-      sources: [{
-        sourceIndex: bestSource.sourceIndex,
-        directPath: [index, bestSource.sourceIndex],
-        fullPath: path
-      }]
-    };
+    return buildFallbackFromSource(bestSource.sourceIndex, bestSource.path, metrics);
   }
 
   function resolveVoronoiValues(baseValues, adjacencyList, dataset) {
@@ -2336,11 +2442,12 @@ window.showConfirmModal = showConfirmModal;
       offers = getFrozenVoronoiOffers();
       usingFrozenCache = true;
     } else if (freezeActive) {
-      offers = getOffersMatchingFilters();
-      if (offers.length) {
-        usedFullFilteredOffers = true;
-      } else {
-        offers = getVoronoiSourceOffers();
+      offers = getVoronoiSourceOffers();
+      if (!offers.length) {
+        offers = getOffersMatchingFilters();
+        if (offers.length) {
+          usedFullFilteredOffers = true;
+        }
       }
     } else {
       offers = getVoronoiSourceOffers();
@@ -2580,6 +2687,7 @@ window.showConfirmModal = showConfirmModal;
       } else {
         voronoiLayerState.highlight.selectedOfferKey = null;
         voronoiLayerState.highlight.selectedIndexHint = null;
+        hideVoronoiTagInspector();
       }
     }
   }

--- a/oferty.html
+++ b/oferty.html
@@ -474,7 +474,7 @@ window.showConfirmModal = showConfirmModal;
     height: 42
   };
 
-  const VORONOI_FREEZE_ZOOM_LEVEL = 16;
+  const VORONOI_FREEZE_ZOOM_LEVEL = 15;
   const VORONOI_LABEL_BASE_MIN_ZOOM = 13;
   const VORONOI_LABEL_VISIBILITY_RULES = [
     { minCount: 220, minZoom: 16 },
@@ -1493,9 +1493,6 @@ window.showConfirmModal = showConfirmModal;
       return null;
     }
 
-    const contributions = [];
-    const usedSources = new Set();
-
     const buildPriceMetrics = (value) => {
       if (!value?.hasPrice || !(value.price > 0)) {
         return null;
@@ -1512,20 +1509,6 @@ window.showConfirmModal = showConfirmModal;
         price: sourcePrice > 0 ? sourcePrice : 0,
         pricePerSqm: normalizedPerSqm > 0 ? normalizedPerSqm : 0
       };
-    };
-
-    const pushContribution = (sourceIndex, pathIndices, value) => {
-      const metrics = buildPriceMetrics(value);
-      if (!metrics || !Array.isArray(pathIndices) || pathIndices.length < 2) {
-        return;
-      }
-      contributions.push({
-        sourceIndex,
-        path: pathIndices.slice(),
-        price: metrics.price,
-        pricePerSqm: metrics.pricePerSqm
-      });
-      usedSources.add(sourceIndex);
     };
 
     const reconstructPath = (targetIndex, parentsMap) => {
@@ -1547,42 +1530,45 @@ window.showConfirmModal = showConfirmModal;
       return path.reverse();
     };
 
-    const findSourceForNeighbor = (startIndex, disallowUsed = true) => {
-      if (!Number.isInteger(startIndex)) {
-        return null;
-      }
-
+    const findNearestPricedPolygon = () => {
       const visited = new Set([index]);
       const parents = new Map();
       const queue = [];
 
-      visited.add(startIndex);
-      parents.set(startIndex, index);
-      queue.push({ node: startIndex, depth: 0 });
+      directNeighbors.forEach(neighbor => {
+        if (!Number.isInteger(neighbor) || visited.has(neighbor)) {
+          return;
+        }
+        visited.add(neighbor);
+        parents.set(neighbor, index);
+        queue.push({ node: neighbor, depth: 1 });
+      });
 
-      let candidateDepth = null;
-      const candidates = [];
+      let best = null;
 
       while (queue.length) {
         const { node, depth } = queue.shift();
-
-        const value = baseValues[node];
-        const alreadyUsed = usedSources.has(node);
-        const isCandidate = node !== index
-          && value?.hasPrice
-          && value.price > 0
-          && (!disallowUsed || !alreadyUsed);
-
-        if (isCandidate) {
-          if (candidateDepth === null) {
-            candidateDepth = depth;
-          }
-          if (depth === candidateDepth) {
-            candidates.push(node);
-          }
+        if (best && depth > best.depth) {
+          break;
         }
 
-        if (candidateDepth !== null && depth >= candidateDepth) {
+        const value = baseValues[node];
+        if (value?.hasPrice && value.price > 0) {
+          const path = reconstructPath(node, parents);
+          const distance = computePathDistance(path, dataset);
+          const normalizedDistance = Number.isFinite(distance) ? distance : Infinity;
+          if (!best || depth < best.depth || (depth === best.depth && normalizedDistance < best.distance)) {
+            best = {
+              sourceIndex: node,
+              path,
+              depth,
+              distance: normalizedDistance
+            };
+          }
+          continue;
+        }
+
+        if (best && depth >= best.depth) {
           continue;
         }
 
@@ -1596,99 +1582,36 @@ window.showConfirmModal = showConfirmModal;
         });
       }
 
-      if (!candidates.length) {
-        return null;
-      }
-
-      let chosenIndex = candidates[0];
-      let chosenPath = reconstructPath(chosenIndex, parents);
-      let chosenDistance = computePathDistance(chosenPath, dataset);
-      if (!Number.isFinite(chosenDistance)) {
-        chosenDistance = Infinity;
-      }
-
-      candidates.slice(1).forEach(candidate => {
-        const path = reconstructPath(candidate, parents);
-        const distance = computePathDistance(path, dataset);
-        const normalizedDistance = Number.isFinite(distance) ? distance : Infinity;
-        if (normalizedDistance < chosenDistance) {
-          chosenDistance = normalizedDistance;
-          chosenIndex = candidate;
-          chosenPath = path;
-        }
-      });
-
-      return {
-        sourceIndex: chosenIndex,
-        path: chosenPath
-      };
+      return best;
     };
 
-    const neighborsNeedingSources = [];
-
-    directNeighbors.forEach(neighborIndex => {
-      const neighborValue = baseValues[neighborIndex];
-      if (neighborValue?.hasPrice && neighborValue.price > 0) {
-        pushContribution(neighborIndex, [index, neighborIndex], neighborValue);
-      } else {
-        neighborsNeedingSources.push(neighborIndex);
-      }
-    });
-
-    neighborsNeedingSources.forEach(neighborIndex => {
-      let result = findSourceForNeighbor(neighborIndex, true);
-      if (!result) {
-        result = findSourceForNeighbor(neighborIndex, false);
-      }
-      if (!result) {
-        return;
-      }
-      const sourceValue = baseValues[result.sourceIndex];
-      if (!sourceValue?.hasPrice || !(sourceValue.price > 0)) {
-        return;
-      }
-      pushContribution(result.sourceIndex, result.path, sourceValue);
-    });
-
-    if (!contributions.length) {
+    const bestSource = findNearestPricedPolygon();
+    if (!bestSource || !Array.isArray(bestSource.path) || bestSource.path.length < 2) {
       return null;
     }
 
-    const ppmValues = contributions
-      .map(entry => Number(entry.pricePerSqm))
-      .filter(value => Number.isFinite(value) && value > 0);
-    const priceValues = contributions
-      .map(entry => Number(entry.price))
-      .filter(value => Number.isFinite(value) && value > 0);
+    const metrics = buildPriceMetrics(baseValues[bestSource.sourceIndex]);
+    if (!metrics) {
+      return null;
+    }
 
-    const resolvedPricePerSqm = ppmValues.length
-      ? ppmValues.reduce((sum, value) => sum + value, 0) / ppmValues.length
-      : 0;
-
+    const resolvedPricePerSqm = metrics.pricePerSqm > 0 ? metrics.pricePerSqm : 0;
     let resolvedPrice = 0;
     if (resolvedPricePerSqm > 0 && Number.isFinite(baseArea) && baseArea > 0) {
       resolvedPrice = resolvedPricePerSqm * baseArea;
-    } else if (priceValues.length) {
-      resolvedPrice = priceValues.reduce((sum, value) => sum + value, 0) / priceValues.length;
+    } else {
+      resolvedPrice = metrics.price > 0 ? metrics.price : 0;
     }
 
     if (!(resolvedPrice > 0) && !(resolvedPricePerSqm > 0)) {
       return null;
     }
 
-    const connectorPaths = contributions
-      .map(entry => entry.path)
-      .filter(path => Array.isArray(path) && path.length >= 2)
-      .map(path => path.slice());
-
-    if (!connectorPaths.length) {
-      return null;
-    }
-
     return {
       price: resolvedPrice > 0 ? resolvedPrice : 0,
       pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-      paths: connectorPaths
+      path: bestSource.path.slice(),
+      paths: [bestSource.path.slice()]
     };
   }
 


### PR DESCRIPTION
## Summary
- cache Voronoi inputs and freeze them past a high zoom threshold so fallback prices remain intact when zooming in
- track neighbor traversal paths when borrowing prices and render dashed red connectors to show their provenance
- reset cached Voronoi data and connectors whenever the layer or visible offers change to avoid stale overlays

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db7932f258832ba968fe9231b1e910