### PR TITLE
Adjust Voronoi connector paths and selection

### DIFF
--- a/oferty.html
+++ b/oferty.html
@@ -1997,9 +1997,13 @@ window.showConfirmModal = showConfirmModal;
     return total;
   }
 
+  const MAX_FALLBACK_DISTANCE_METERS = 30000;
+
   function computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset, graphHasPrice) {
     const baseEntry = baseValues[index] || {};
     const baseArea = Number(baseEntry.area);
+    const baseDatasetEntry = Array.isArray(dataset) ? dataset[index] : null;
+    const basePosition = baseDatasetEntry?.position || null;
     const directNeighbors = (adjacencyList[index] || []).filter(i => Number.isInteger(i) && i !== index);
 
     if (!directNeighbors.length) {
@@ -2034,18 +2038,25 @@ window.showConfirmModal = showConfirmModal;
         return null;
       }
 
+      const neighborPosition = dataset?.[neighborIndex]?.position || null;
+      const initialDistance = computeDistanceBetweenPoints(basePosition, neighborPosition);
+      if (!Number.isFinite(initialDistance) || initialDistance > MAX_FALLBACK_DISTANCE_METERS) {
+        return null;
+      }
+
       const initialMetrics = buildPriceMetrics(baseValues[neighborIndex]);
       if (initialMetrics) {
         return {
           sourceIndex: neighborIndex,
           path: [index, neighborIndex],
-          metrics: initialMetrics
+          metrics: initialMetrics,
+          distance: initialDistance
         };
       }
 
-      const visited = new Set([index, neighborIndex]);
-      const queue = [{ node: neighborIndex, path: [index, neighborIndex] }];
       const guardLimit = Math.max(baseValues.length * 4, 16);
+      const queue = [{ node: neighborIndex, path: [index, neighborIndex], distance: initialDistance }];
+      const bestDistance = new Map([[neighborIndex, initialDistance]]);
       let guard = 0;
 
       while (queue.length && guard < guardLimit) {
@@ -2054,21 +2065,38 @@ window.showConfirmModal = showConfirmModal;
 
         const neighborsOfCurrent = adjacencyList[current.node] || [];
         for (const next of neighborsOfCurrent) {
-          if (!Number.isInteger(next) || visited.has(next)) {
+          if (!Number.isInteger(next) || next === index) {
             continue;
           }
+          const currentPosition = dataset?.[current.node]?.position || null;
+          const nextPosition = dataset?.[next]?.position || null;
+          const segmentDistance = computeDistanceBetweenPoints(currentPosition, nextPosition);
+          if (!Number.isFinite(segmentDistance)) {
+            continue;
+          }
+          const totalDistance = current.distance + segmentDistance;
+          if (totalDistance > MAX_FALLBACK_DISTANCE_METERS) {
+            continue;
+          }
+
+          const previousBest = bestDistance.get(next);
+          if (typeof previousBest === 'number' && previousBest <= totalDistance) {
+            continue;
+          }
+          bestDistance.set(next, totalDistance);
+
           const nextPath = current.path.concat(next);
           const metrics = buildPriceMetrics(baseValues[next]);
           if (metrics) {
             return {
               sourceIndex: next,
               path: nextPath,
-              metrics
+              metrics,
+              distance: totalDistance
             };
           }
 
-          visited.add(next);
-          queue.push({ node: next, path: nextPath });
+          queue.push({ node: next, path: nextPath, distance: totalDistance });
         }
       }
 
@@ -2093,6 +2121,13 @@ window.showConfirmModal = showConfirmModal;
         normalizedPath.push(contribution.sourceIndex);
       }
 
+      const pathDistance = Number.isFinite(contribution.distance)
+        ? contribution.distance
+        : computePathDistance(normalizedPath, dataset);
+      if (!Number.isFinite(pathDistance) || pathDistance > MAX_FALLBACK_DISTANCE_METERS) {
+        return;
+      }
+
       const pathKey = normalizedPath.join('>');
       if (contributionsByPath.has(pathKey)) {
         const existing = contributionsByPath.get(pathKey);
@@ -2102,7 +2137,8 @@ window.showConfirmModal = showConfirmModal;
           sourceIndex: contribution.sourceIndex,
           path: normalizedPath,
           metrics: contribution.metrics,
-          weight: 1
+          weight: 1,
+          distance: pathDistance
         });
       }
     });
@@ -2119,7 +2155,7 @@ window.showConfirmModal = showConfirmModal;
     const fallbackSources = [];
 
     contributionsByPath.forEach(entry => {
-      const { metrics, weight, sourceIndex, path } = entry;
+      const { metrics, weight, sourceIndex, path, distance } = entry;
       const pricePerSqm = Number(metrics.pricePerSqm);
       const price = Number(metrics.price);
       const area = Number(metrics.area);
@@ -2141,7 +2177,8 @@ window.showConfirmModal = showConfirmModal;
       fallbackSources.push({
         sourceIndex,
         directPath: [index, sourceIndex],
-        fullPath: path
+        fullPath: path,
+        distanceMeters: Number.isFinite(distance) ? distance : computePathDistance(path, dataset)
       });
     });
 

--- a/oferty.html
+++ b/oferty.html
@@ -619,6 +619,65 @@ window.showConfirmModal = showConfirmModal;
     connector.setOptions(buildVoronoiConnectorStyle(mode));
   }
 
+  function extractLatLngFromGooglePosition(position) {
+    if (!position) return null;
+    try {
+      const lat = typeof position.lat === 'function' ? position.lat() : position.lat;
+      const lng = typeof position.lng === 'function' ? position.lng() : position.lng;
+      if (Number.isFinite(lat) && Number.isFinite(lng)) {
+        return { lat, lng };
+      }
+    } catch (_) {
+      /* ignore */
+    }
+    return null;
+  }
+
+  function getMarkerPositionForOffer(offer) {
+    if (!offer || typeof offer !== 'object') {
+      return null;
+    }
+
+    const marker = offer.marker;
+    if (marker && typeof marker.getPosition === 'function') {
+      const markerPosition = extractLatLngFromGooglePosition(marker.getPosition());
+      if (markerPosition) {
+        return markerPosition;
+      }
+    }
+
+    const plotLat = Number(offer.plot?.lat);
+    const plotLng = Number(offer.plot?.lng);
+    if (Number.isFinite(plotLat) && Number.isFinite(plotLng)) {
+      return { lat: plotLat, lng: plotLng };
+    }
+
+    const voronoiPoint = offer.voronoiPoint;
+    if (voronoiPoint && Number.isFinite(voronoiPoint.lat) && Number.isFinite(voronoiPoint.lng)) {
+      return { lat: voronoiPoint.lat, lng: voronoiPoint.lng };
+    }
+
+    return null;
+  }
+
+  function getMarkerPositionForDatasetEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+      return null;
+    }
+
+    const offerPosition = getMarkerPositionForOffer(entry.offer);
+    if (offerPosition) {
+      return offerPosition;
+    }
+
+    const datasetPosition = entry.position;
+    if (datasetPosition && Number.isFinite(datasetPosition.lat) && Number.isFinite(datasetPosition.lng)) {
+      return { lat: datasetPosition.lat, lng: datasetPosition.lng };
+    }
+
+    return null;
+  }
+
   function getVoronoiDatasetOfferKey(entry) {
     if (!entry || !entry.offer) {
       return null;
@@ -2843,10 +2902,16 @@ window.showConfirmModal = showConfirmModal;
       polygon.__voronoiIndex = index;
       polygon.addListener('click', () => {
         if (!voronoiLayerState.enabled) return;
-        voronoiLayerState.highlight.ignoreNextMapClear = true;
-        highlightVoronoiPolygon(index);
+        const highlightState = voronoiLayerState.highlight;
+        const isAlreadySelected = highlightState.baseIndex === index;
+        highlightState.ignoreNextMapClear = true;
+        if (isAlreadySelected) {
+          clearVoronoiHighlights({ resetSelection: true });
+        } else {
+          highlightVoronoiPolygon(index);
+        }
         window.setTimeout(() => {
-          voronoiLayerState.highlight.ignoreNextMapClear = false;
+          highlightState.ignoreNextMapClear = false;
         }, 0);
       });
       voronoiLayerState.polygons.push(polygon);
@@ -2867,16 +2932,31 @@ window.showConfirmModal = showConfirmModal;
       }
 
       fallbackSources.forEach(pathIndices => {
-        const connectorPath = Array.isArray(pathIndices)
+        let connectorPath = Array.isArray(pathIndices)
           ? pathIndices
               .map(i => {
+                const datasetEntry = dataset[i];
+                const markerPosition = getMarkerPositionForDatasetEntry(datasetEntry);
+                if (markerPosition) return markerPosition;
                 const targetCell = cells[i];
                 if (targetCell?.centroid) return targetCell.centroid;
-                const targetDataset = dataset[i];
-                return targetDataset?.position || null;
+                return datasetEntry?.position || null;
               })
-              .filter(Boolean)
+              .filter(point => point && Number.isFinite(point.lat) && Number.isFinite(point.lng))
           : [];
+
+        if (connectorPath.length < 2) {
+          const basePosition = getMarkerPositionForDatasetEntry(dataset[index]);
+          const sourceIndex = Array.isArray(pathIndices)
+            ? pathIndices[pathIndices.length - 1]
+            : null;
+          const sourcePosition = Number.isInteger(sourceIndex)
+            ? getMarkerPositionForDatasetEntry(dataset[sourceIndex])
+            : null;
+          connectorPath = [basePosition, sourcePosition]
+            .filter(point => point && Number.isFinite(point.lat) && Number.isFinite(point.lng));
+        }
+
         if (connectorPath.length < 2) return;
 
         const connector = new google.maps.Polyline({

--- a/oferty.html
+++ b/oferty.html
@@ -1997,12 +1997,16 @@ window.showConfirmModal = showConfirmModal;
     return total;
   }
 
-  function computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset) {
+  function computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset, graphHasPrice) {
     const baseEntry = baseValues[index] || {};
     const baseArea = Number(baseEntry.area);
-    const directNeighbors = (adjacencyList[index] || []).filter(i => Number.isInteger(i));
+    const directNeighbors = (adjacencyList[index] || []).filter(i => Number.isInteger(i) && i !== index);
 
     if (!directNeighbors.length) {
+      return null;
+    }
+
+    if (!graphHasPrice) {
       return null;
     }
 
@@ -2025,215 +2029,159 @@ window.showConfirmModal = showConfirmModal;
       };
     };
 
-    const pricedNeighbors = directNeighbors
-      .map(neighbor => ({ index: neighbor, metrics: buildPriceMetrics(baseValues[neighbor]) }))
-      .filter(entry => !!entry.metrics);
-
-    const buildFallbackFromSource = (sourceIndex, path, metrics) => {
-      if (!Number.isInteger(sourceIndex) || !metrics) {
+    const findFirstPricedFromNeighbor = (neighborIndex) => {
+      if (!Number.isInteger(neighborIndex)) {
         return null;
       }
 
-      const normalizedPath = Array.isArray(path) && path.length >= 2
-        ? path.slice()
-        : [index, sourceIndex];
+      const initialMetrics = buildPriceMetrics(baseValues[neighborIndex]);
+      if (initialMetrics) {
+        return {
+          sourceIndex: neighborIndex,
+          path: [index, neighborIndex],
+          metrics: initialMetrics
+        };
+      }
+
+      const visited = new Set([index, neighborIndex]);
+      const queue = [{ node: neighborIndex, path: [index, neighborIndex] }];
+      const guardLimit = Math.max(baseValues.length * 4, 16);
+      let guard = 0;
+
+      while (queue.length && guard < guardLimit) {
+        const current = queue.shift();
+        guard += 1;
+
+        const neighborsOfCurrent = adjacencyList[current.node] || [];
+        for (const next of neighborsOfCurrent) {
+          if (!Number.isInteger(next) || visited.has(next)) {
+            continue;
+          }
+          const nextPath = current.path.concat(next);
+          const metrics = buildPriceMetrics(baseValues[next]);
+          if (metrics) {
+            return {
+              sourceIndex: next,
+              path: nextPath,
+              metrics
+            };
+          }
+
+          visited.add(next);
+          queue.push({ node: next, path: nextPath });
+        }
+      }
+
+      return null;
+    };
+
+    const contributionsByPath = new Map();
+
+    directNeighbors.forEach(neighborIndex => {
+      const contribution = findFirstPricedFromNeighbor(neighborIndex);
+      if (!contribution) {
+        return;
+      }
+
+      const normalizedPath = Array.isArray(contribution.path) && contribution.path.length >= 2
+        ? contribution.path.slice()
+        : [index, contribution.sourceIndex];
       if (normalizedPath[0] !== index) {
         normalizedPath.unshift(index);
       }
-      if (normalizedPath[normalizedPath.length - 1] !== sourceIndex) {
-        normalizedPath.push(sourceIndex);
+      if (normalizedPath[normalizedPath.length - 1] !== contribution.sourceIndex) {
+        normalizedPath.push(contribution.sourceIndex);
       }
 
-      const sourceArea = Number(baseValues[sourceIndex]?.area);
-      const fallbackArea = Number.isFinite(baseArea) && baseArea > 0
-        ? baseArea
-        : (Number.isFinite(sourceArea) && sourceArea > 0 ? sourceArea : 0);
-
-      let resolvedPricePerSqm = metrics.pricePerSqm > 0 ? metrics.pricePerSqm : 0;
-      if (!(resolvedPricePerSqm > 0) && metrics.price > 0 && fallbackArea > 0) {
-        resolvedPricePerSqm = metrics.price / fallbackArea;
-      }
-
-      let resolvedPrice = 0;
-      if (resolvedPricePerSqm > 0 && Number.isFinite(baseArea) && baseArea > 0) {
-        resolvedPrice = resolvedPricePerSqm * baseArea;
-      } else if (metrics.price > 0) {
-        resolvedPrice = metrics.price;
-        if (!(resolvedPricePerSqm > 0) && fallbackArea > 0) {
-          resolvedPricePerSqm = metrics.price / fallbackArea;
-        }
-      }
-
-      if (!(resolvedPrice > 0) && !(resolvedPricePerSqm > 0)) {
-        return null;
-      }
-
-      return {
-        price: resolvedPrice > 0 ? resolvedPrice : 0,
-        pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-        sources: [{
-          sourceIndex,
-          directPath: [index, sourceIndex],
-          fullPath: normalizedPath
-        }]
-      };
-    };
-
-    if (pricedNeighbors.length) {
-      const fallbackSources = [];
-      const seenNeighborSources = new Set();
-      let weightedPerSqmSum = 0;
-      let weightSum = 0;
-      let totalPrice = 0;
-      let totalArea = 0;
-
-      pricedNeighbors.forEach(entry => {
-        const neighborIndex = entry.index;
-        if (seenNeighborSources.has(neighborIndex)) {
-          return;
-        }
-        seenNeighborSources.add(neighborIndex);
-        const { price, pricePerSqm, area } = entry.metrics;
-        fallbackSources.push({
-          sourceIndex: neighborIndex,
-          directPath: [index, neighborIndex],
-          fullPath: [index, neighborIndex]
-        });
-
-        if (pricePerSqm > 0) {
-          const weight = area > 0 ? area : 1;
-          weightedPerSqmSum += pricePerSqm * weight;
-          weightSum += weight;
-        }
-
-        if (price > 0) {
-          totalPrice += price;
-        }
-
-        if (area > 0) {
-          totalArea += area;
-        }
-      });
-
-      const fallbackArea = Number.isFinite(baseArea) && baseArea > 0
-        ? baseArea
-        : (totalArea > 0 ? totalArea / pricedNeighbors.length : 0);
-
-      let resolvedPricePerSqm = weightSum > 0 ? weightedPerSqmSum / weightSum : 0;
-      if (!(resolvedPricePerSqm > 0) && totalArea > 0 && totalPrice > 0) {
-        resolvedPricePerSqm = totalPrice / totalArea;
-      }
-      if (!(resolvedPricePerSqm > 0) && fallbackArea > 0 && totalPrice > 0 && pricedNeighbors.length) {
-        resolvedPricePerSqm = (totalPrice / pricedNeighbors.length) / fallbackArea;
-      }
-
-      let resolvedPrice = 0;
-      if (resolvedPricePerSqm > 0 && fallbackArea > 0) {
-        resolvedPrice = resolvedPricePerSqm * fallbackArea;
-      } else if (totalPrice > 0 && pricedNeighbors.length) {
-        resolvedPrice = totalPrice / pricedNeighbors.length;
-        if (!(resolvedPricePerSqm > 0) && fallbackArea > 0) {
-          resolvedPricePerSqm = resolvedPrice / fallbackArea;
-        }
-      }
-
-      if (resolvedPrice > 0 || resolvedPricePerSqm > 0) {
-        return {
-          price: resolvedPrice > 0 ? resolvedPrice : 0,
-          pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
-          sources: fallbackSources
-        };
-      }
-    }
-
-    const reconstructPath = (targetIndex, parentsMap) => {
-      const path = [targetIndex];
-      let current = targetIndex;
-      const guardLimit = Math.max(baseValues.length * 4, 16);
-      let guard = 0;
-      while (current !== index && guard < guardLimit) {
-        current = parentsMap.get(current);
-        if (!Number.isInteger(current)) {
-          break;
-        }
-        path.push(current);
-        guard += 1;
-      }
-      if (path[path.length - 1] !== index) {
-        path.push(index);
-      }
-      return path.reverse();
-    };
-
-    const findNearestPricedPolygon = () => {
-      const visited = new Set([index]);
-      const parents = new Map();
-      const queue = [];
-
-      directNeighbors.forEach(neighbor => {
-        if (!Number.isInteger(neighbor) || visited.has(neighbor)) {
-          return;
-        }
-        visited.add(neighbor);
-        parents.set(neighbor, index);
-        queue.push({ node: neighbor, depth: 1 });
-      });
-
-      let best = null;
-
-      while (queue.length) {
-        const { node, depth } = queue.shift();
-        if (best && depth > best.depth) {
-          break;
-        }
-
-        const value = baseValues[node];
-        if (value?.hasPrice && value.price > 0) {
-          const path = reconstructPath(node, parents);
-          const distance = computePathDistance(path, dataset);
-          const normalizedDistance = Number.isFinite(distance) ? distance : Infinity;
-          if (!best || depth < best.depth || (depth === best.depth && normalizedDistance < best.distance)) {
-            best = {
-              sourceIndex: node,
-              path,
-              depth,
-              distance: normalizedDistance
-            };
-          }
-          continue;
-        }
-
-        if (best && depth >= best.depth) {
-          continue;
-        }
-
-        (adjacencyList[node] || []).forEach(nextIndex => {
-          if (!Number.isInteger(nextIndex) || visited.has(nextIndex)) {
-            return;
-          }
-          visited.add(nextIndex);
-          parents.set(nextIndex, node);
-          queue.push({ node: nextIndex, depth: depth + 1 });
+      const pathKey = normalizedPath.join('>');
+      if (contributionsByPath.has(pathKey)) {
+        const existing = contributionsByPath.get(pathKey);
+        existing.weight += 1;
+      } else {
+        contributionsByPath.set(pathKey, {
+          sourceIndex: contribution.sourceIndex,
+          path: normalizedPath,
+          metrics: contribution.metrics,
+          weight: 1
         });
       }
+    });
 
-      return best;
-    };
-
-    const bestSource = findNearestPricedPolygon();
-    if (!bestSource) {
+    if (!contributionsByPath.size) {
       return null;
     }
 
-    const metrics = buildPriceMetrics(baseValues[bestSource.sourceIndex]);
-    if (!metrics) {
+    let weightedPerSqmSum = 0;
+    let perSqmWeight = 0;
+    let totalPrice = 0;
+    let priceWeight = 0;
+    let totalArea = 0;
+    const fallbackSources = [];
+
+    contributionsByPath.forEach(entry => {
+      const { metrics, weight, sourceIndex, path } = entry;
+      const pricePerSqm = Number(metrics.pricePerSqm);
+      const price = Number(metrics.price);
+      const area = Number(metrics.area);
+
+      if (pricePerSqm > 0) {
+        weightedPerSqmSum += pricePerSqm * weight;
+        perSqmWeight += weight;
+      }
+
+      if (price > 0) {
+        totalPrice += price * weight;
+        priceWeight += weight;
+      }
+
+      if (area > 0) {
+        totalArea += area * weight;
+      }
+
+      fallbackSources.push({
+        sourceIndex,
+        directPath: [index, sourceIndex],
+        fullPath: path
+      });
+    });
+
+    if (!perSqmWeight && !priceWeight) {
       return null;
     }
 
-    return buildFallbackFromSource(bestSource.sourceIndex, bestSource.path, metrics);
+    const fallbackArea = Number.isFinite(baseArea) && baseArea > 0
+      ? baseArea
+      : (totalArea > 0 ? totalArea / (perSqmWeight || priceWeight || 1) : 0);
+
+    let resolvedPricePerSqm = perSqmWeight > 0 ? (weightedPerSqmSum / perSqmWeight) : 0;
+    if (!(resolvedPricePerSqm > 0) && totalArea > 0 && totalPrice > 0) {
+      resolvedPricePerSqm = totalPrice / totalArea;
+    }
+
+    let resolvedPrice = 0;
+    if (resolvedPricePerSqm > 0 && fallbackArea > 0) {
+      resolvedPrice = resolvedPricePerSqm * fallbackArea;
+    } else if (priceWeight > 0) {
+      resolvedPrice = totalPrice / priceWeight;
+      if (!(resolvedPricePerSqm > 0) && fallbackArea > 0) {
+        resolvedPricePerSqm = resolvedPrice / fallbackArea;
+      }
+    }
+
+    if (!(resolvedPrice > 0) && !(resolvedPricePerSqm > 0)) {
+      return null;
+    }
+
+    return {
+      price: resolvedPrice > 0 ? resolvedPrice : 0,
+      pricePerSqm: resolvedPricePerSqm > 0 ? resolvedPricePerSqm : 0,
+      sources: fallbackSources
+    };
   }
 
   function resolveVoronoiValues(baseValues, adjacencyList, dataset) {
+    const graphHasPrice = baseValues.some(value => value?.hasPrice && value.price > 0);
+
     return baseValues.map((entry, index) => {
       if (!entry) return entry;
       if (entry.hasPrice && entry.price > 0) {
@@ -2243,7 +2191,7 @@ window.showConfirmModal = showConfirmModal;
         };
       }
 
-      const fallback = computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset);
+      const fallback = computeFallbackFromNeighbors(index, baseValues, adjacencyList, dataset, graphHasPrice);
       if (!fallback) {
         return {
           ...entry,


### PR DESCRIPTION
## Summary
- draw Voronoi fallback connectors between the marker locations of the base and source plots
- add helper utilities to resolve marker coordinates with graceful fallbacks
- allow clicking an already selected Voronoi polygon to clear its highlight

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de65834c0c832b95681eb3a40516fc