### PR TITLE
Disable map tilt controls on offers page

### DIFF
--- a/oferty.html
+++ b/oferty.html
@@ -3994,7 +3994,8 @@ window.showConfirmModal = showConfirmModal;
       mapTypeId: google.maps.MapTypeId.HYBRID,
       tilt: 0,
       heading: 0,
-      tiltControl: false
+      tiltControl: false,
+      rotateControl: false
     });
 
     const keepMapFlat = () => {
@@ -4011,6 +4012,11 @@ window.showConfirmModal = showConfirmModal;
     ensureVoronoiLabelOverlay();
 
     applySavedMapView();
+
+    if (map?.addListener) {
+      map.addListener("tilt_changed", keepMapFlat);
+      map.addListener("heading_changed", keepMapFlat);
+    }
 
     google.maps.event.addListener(map, "idle", () => {
       keepMapFlat();


### PR DESCRIPTION
## Summary
- disable Google Maps rotate control on the offers page
- ensure the map automatically resets tilt and heading when they change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f1d28974832bb6135fda049f94b2