### PR TITLE
feat: enrich Voronoi layer coverage and indicators

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -858,33 +858,76 @@
 .gm-style-iw-c { padding:8px !important; }
 
 
-.voronoi-label {
-  background:rgba(15,23,42,0.88);
-  border:1px solid rgba(148,163,184,0.35);
-  border-radius:14px;
-  padding:8px 14px;
+.voronoi-label,
+.voronoi-pill,
+.voronoi-inspector__summary-value,
+.voronoi-inspector__percentage,
+.voronoi-connector-label {
+  border-radius:9999px;
+  background:#ffffff;
+  color:#111111;
+  border:1px solid #111111;
+  box-shadow:0 1px 2px rgba(0,0,0,0.08);
+  font-weight:600;
+  font-variant-numeric:tabular-nums;
+  transition:background-color 180ms ease, color 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.voronoi-pill,
+.voronoi-inspector__summary-value,
+.voronoi-inspector__percentage,
+.voronoi-connector-label {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:0.5rem;
+  padding:0.5rem 0.75rem;
+  line-height:1;
   font-size:0.82rem;
-  line-height:1.25;
-  color:#ffffff;
-  box-shadow:0 18px 34px rgba(15,23,42,0.25);
+  white-space:nowrap;
+}
+
+.voronoi-pill--compact,
+.voronoi-connector-label {
+  padding:0.4rem 0.65rem;
+  font-size:0.75rem;
+}
+
+.voronoi-connector-label {
+  box-shadow:0 4px 10px rgba(0,0,0,0.18);
+  pointer-events:none;
+}
+
+.voronoi-inspector__summary-value {
+  font-size:0.92rem;
+  padding:0.6rem 0.95rem;
+}
+
+.voronoi-inspector__percentage {
+  font-size:0.8rem;
+}
+
+.voronoi-label {
   min-width:auto;
   text-align:left;
-  font-weight:600;
-  white-space:normal;
   pointer-events:none;
   display:flex;
   flex-direction:column;
   align-items:flex-start;
   justify-content:flex-start;
-  gap:4px;
-  transition:transform 120ms ease, box-shadow 160ms ease;
+  gap:0.35rem;
+  padding:0.65rem 0.95rem;
+  font-size:0.82rem;
+  line-height:1.2;
+  white-space:normal;
+  box-shadow:0 6px 18px rgba(0,0,0,0.12);
 }
 
 .voronoi-label__stack {
   display:flex;
   flex-direction:column;
   align-items:flex-start;
-  gap:2px;
+  gap:0.2rem;
   width:100%;
 }
 
@@ -905,27 +948,33 @@
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:2px 8px;
-  border-radius:999px;
-  background:rgba(248,250,252,0.16);
-  color:#f8fafc;
+  padding:0.2rem 0.55rem;
+  border-radius:9999px;
+  background:#111111;
+  color:#ffffff;
   font-size:0.62rem;
   font-weight:600;
   letter-spacing:0.08em;
   text-transform:uppercase;
+  line-height:1;
   align-self:flex-start;
 }
 
 .voronoi-label[data-fallback="true"] {
-  background:rgba(220,38,38,0.88);
-  border-color:rgba(248,113,113,0.5);
-  box-shadow:0 18px 36px rgba(220,38,38,0.3);
+  background:#fff4f4;
+  border-color:#dc2626;
+  color:#7f1d1d;
+  box-shadow:0 6px 18px rgba(220,38,38,0.16);
+}
+
+.voronoi-label[data-fallback="true"] .voronoi-label__badge {
+  background:#dc2626;
 }
 
 .voronoi-label[data-density="compact"] {
-  padding:6px 10px;
+  padding:0.5rem 0.75rem;
   font-size:0.74rem;
-  gap:3px;
+  gap:0.25rem;
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__price {
@@ -933,51 +982,8 @@
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__badge {
-  padding:1px 6px;
+  padding:0.15rem 0.45rem;
   font-size:0.56rem;
-}
-
-.voronoi-pill,
-.voronoi-inspector__summary-value,
-.voronoi-inspector__percentage,
-.voronoi-connector-label {
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  gap:0.35rem;
-  padding:6px 12px;
-  border-radius:9999px;
-  background:#ffffff;
-  color:#111111;
-  border:1px solid rgba(15,23,42,0.16);
-  box-shadow:0 1px 2px rgba(15,23,42,0.12);
-  font-weight:600;
-  line-height:1;
-  font-size:0.82rem;
-  font-variant-numeric:tabular-nums;
-  white-space:nowrap;
-}
-
-.voronoi-pill--compact,
-.voronoi-connector-label {
-  padding:4px 10px;
-  font-size:0.75rem;
-}
-
-.voronoi-connector-label {
-  box-shadow:0 4px 10px rgba(15,23,42,0.2);
-  pointer-events:none;
-  white-space:nowrap;
-}
-
-.voronoi-inspector__summary-value {
-  font-size:0.92rem;
-  padding:8px 14px;
-}
-
-.voronoi-inspector__percentage {
-  font-size:0.8rem;
-  padding:6px 12px;
 }
 
 .voronoi-indicator {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -859,132 +859,218 @@
 .gm-style-iw-c { padding:8px !important; }
 
 
-.voronoi-label,
-.voronoi-pill,
-.voronoi-connector-label {
-  background:transparent;
-  border:none;
-  color:#111111;
-  font-weight:700;
-  font-variant-numeric:tabular-nums;
-  letter-spacing:0.012em;
-  text-transform:none;
-  -webkit-text-fill-color:#111111;
-  -webkit-text-stroke:2.2px rgba(255,255,255,0.95);
-  paint-order:stroke fill;
-  text-shadow:0 0 1px rgba(255,255,255,0.95),
-              0 0 2px rgba(255,255,255,0.95),
-              0 0 4px rgba(255,255,255,0.9),
-              0 0 8px rgba(255,255,255,0.85),
-              0 2px 6px rgba(15,23,42,0.35);
-  filter:drop-shadow(0 4px 10px rgba(15,23,42,0.28));
-  transition:color 180ms ease;
-}
-
-.voronoi-pill,
-.voronoi-connector-label {
+.voronoi-pill {
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:0.35rem;
-  padding:0.1rem 0.25rem;
-  line-height:1.08;
-  font-size:0.95rem;
+  gap:0.4rem;
+  padding:0.38rem 0.7rem;
+  border-radius:9999px;
+  border:1px solid rgba(17,17,17,0.85);
+  background:rgba(255,255,255,0.97);
+  color:#111111;
+  font-weight:600;
+  font-size:0.9rem;
+  line-height:1.12;
+  font-variant-numeric:tabular-nums;
+  letter-spacing:0.01em;
   white-space:nowrap;
-}
-
-.voronoi-pill--compact,
-.voronoi-connector-label {
-  font-size:0.88rem;
-}
-
-.voronoi-connector-label {
+  box-shadow:0 1px 2px rgba(15,23,42,0.18), 0 10px 26px rgba(15,23,42,0.18);
+  text-shadow:none;
   pointer-events:none;
+}
+
+.voronoi-pill--compact {
+  padding:0.32rem 0.6rem;
+  font-size:0.84rem;
+  gap:0.32rem;
 }
 
 .voronoi-label {
-  min-width:auto;
-  text-align:center;
-  pointer-events:none;
   display:flex;
   flex-direction:column;
   align-items:center;
   justify-content:center;
-  gap:0.12rem;
-  padding:0;
-  font-size:0.92rem;
-  line-height:1.18;
+  text-align:center;
+  gap:0.16rem;
+  padding:0.45rem 0.7rem;
   white-space:normal;
-  filter:drop-shadow(0 6px 12px rgba(15,23,42,0.28));
+  min-width:0;
+  color:inherit;
+}
+
+.voronoi-label[data-density="compact"] {
+  font-size:0.86rem;
+  padding:0.35rem 0.6rem;
+  gap:0.12rem;
 }
 
 .voronoi-label__stack {
   display:flex;
   flex-direction:column;
   align-items:center;
-  justify-content:center;
-  gap:0.08rem;
-  width:100%;
+  gap:0.12rem;
 }
 
 .voronoi-label__value {
-  color:inherit;
-  -webkit-text-fill-color:inherit;
-  font-weight:800;
-  letter-spacing:0.016em;
-  font-size:1.05rem;
-  line-height:1.12;
+  font-weight:700;
+  font-size:1rem;
+  letter-spacing:0.018em;
+}
+
+.voronoi-label[data-density="compact"] .voronoi-label__value {
+  font-size:0.94rem;
 }
 
 .voronoi-label__price {
   font-size:0.82rem;
-  font-weight:700;
-  letter-spacing:0.012em;
-  line-height:1.12;
-  opacity:0.96;
+  font-weight:600;
+  opacity:0.92;
 }
 
 .voronoi-label__badge {
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:0.08rem 0.24rem;
-  border-radius:0.25rem;
-  color:inherit;
-  -webkit-text-fill-color:inherit;
-  font-size:0.68rem;
-  font-weight:800;
-  letter-spacing:0.06em;
+  padding:0.08rem 0.35rem;
+  border-radius:9999px;
+  border:1px solid rgba(220,38,38,0.45);
+  background:rgba(248,113,113,0.18);
+  color:#991b1b;
+  font-size:0.64rem;
+  font-weight:700;
+  letter-spacing:0.08em;
   text-transform:uppercase;
-  line-height:1.05;
-  align-self:center;
 }
 
 .voronoi-label[data-fallback="true"] {
+  border-color:rgba(153,27,27,0.75);
   color:#7f1d1d;
-  -webkit-text-fill-color:#7f1d1d;
+  box-shadow:0 1px 2px rgba(153,27,27,0.22), 0 12px 28px rgba(153,27,27,0.18);
 }
 
 .voronoi-label[data-fallback="true"] .voronoi-label__badge {
-  color:#991b1b;
-  -webkit-text-fill-color:#991b1b;
+  background:rgba(248,113,113,0.24);
+  border-color:rgba(185,28,28,0.55);
+  color:#7f1d1d;
 }
 
-.voronoi-label[data-density="compact"] {
-  font-size:0.86rem;
-  gap:0.1rem;
+.voronoi-connector-label {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:0.28rem;
+  color:#111111;
 }
 
-.voronoi-label[data-density="compact"] .voronoi-label__price {
-  font-size:0.76rem;
+.voronoi-connector-label strong {
+  font-weight:700;
 }
 
-.voronoi-label[data-density="compact"] .voronoi-label__value {
-  font-size:0.98rem;
+.maps-key-prompt {
+  position:absolute;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:32px 20px;
+  background:linear-gradient(180deg, rgba(15,23,42,0.55), rgba(15,23,42,0.45));
+  backdrop-filter:blur(6px);
+  z-index:210;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity 200ms ease;
 }
 
-.voronoi-label[data-density="compact"] .voronoi-label__badge {
-  font-size:0.6rem;
+.maps-key-prompt--visible {
+  opacity:1;
+  pointer-events:auto;
+}
+
+.maps-key-prompt__card {
+  width:min(420px, 100%);
+  background:#ffffff;
+  border:1px solid rgba(15,23,42,0.08);
+  border-radius:18px;
+  padding:22px 24px;
+  box-shadow:0 18px 40px rgba(15,23,42,0.22);
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+  color:#0f172a;
+}
+
+.maps-key-prompt__title {
+  margin:0;
+  font-size:1.05rem;
+  font-weight:700;
+}
+
+.maps-key-prompt__message {
+  margin:0;
+  font-size:0.92rem;
+  line-height:1.4;
+  color:#1f2937;
+}
+
+.maps-key-prompt__form {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.maps-key-prompt__input {
+  width:100%;
+  padding:0.55rem 0.75rem;
+  border-radius:12px;
+  border:1px solid rgba(148,163,184,0.6);
+  font-size:0.95rem;
+  font-family:inherit;
+  color:#0f172a;
+  background:#f9fafb;
+}
+
+.maps-key-prompt__input:focus {
+  outline:3px solid rgba(59,130,246,0.35);
+  outline-offset:2px;
+}
+
+.maps-key-prompt__actions {
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+  justify-content:flex-end;
+}
+
+.maps-key-prompt__submit,
+.maps-key-prompt__dismiss {
+  border-radius:9999px;
+  border:1px solid #111111;
+  background:#ffffff;
+  color:#111111;
+  font-size:0.9rem;
+  font-weight:600;
+  padding:0.45rem 0.9rem;
+  cursor:pointer;
+  box-shadow:0 1px 2px rgba(15,23,42,0.12);
+  transition:transform 160ms ease, box-shadow 160ms ease;
+}
+
+.maps-key-prompt__submit:hover,
+.maps-key-prompt__dismiss:hover {
+  transform:translateY(-1px);
+  box-shadow:0 6px 18px rgba(15,23,42,0.18);
+}
+
+.maps-key-prompt__dismiss {
+  border-color:rgba(148,163,184,0.8);
+  color:#1f2937;
+}
+
+.maps-key-prompt__hint {
+  margin:0;
+  font-size:0.78rem;
+  color:#475569;
 }
 
 .voronoi-indicator {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -864,11 +864,12 @@
 .voronoi-connector-label {
   border-radius:9999px;
   background:#ffffff;
-  color:#111111;
-  border:1px solid #111111;
-  box-shadow:0 1px 2px rgba(0,0,0,0.08);
+  color:#0f172a;
+  border:1px solid #0f172a;
+  box-shadow:0 14px 32px rgba(15,23,42,0.22);
   font-weight:600;
   font-variant-numeric:tabular-nums;
+  letter-spacing:0.01em;
   transition:background-color 180ms ease, color 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
 }
 
@@ -877,101 +878,105 @@
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:0.5rem;
-  padding:0.5rem 0.75rem;
-  line-height:1;
-  font-size:0.82rem;
+  gap:0.4rem;
+  padding:0.45rem 0.85rem;
+  line-height:1.12;
+  font-size:0.85rem;
   white-space:nowrap;
 }
 
 .voronoi-pill--compact,
 .voronoi-connector-label {
-  padding:0.4rem 0.65rem;
-  font-size:0.75rem;
+  padding:0.4rem 0.75rem;
+  font-size:0.78rem;
 }
 
 .voronoi-connector-label {
-  box-shadow:0 4px 10px rgba(0,0,0,0.18);
   pointer-events:none;
 }
 
 .voronoi-label {
   min-width:auto;
-  text-align:left;
+  text-align:center;
   pointer-events:none;
   display:flex;
   flex-direction:column;
-  align-items:flex-start;
-  justify-content:flex-start;
-  gap:0.35rem;
-  padding:0.65rem 0.95rem;
-  font-size:0.82rem;
-  line-height:1.2;
+  align-items:center;
+  justify-content:center;
+  gap:0.28rem;
+  padding:0.75rem 1.05rem;
+  font-size:0.9rem;
+  line-height:1.18;
+  letter-spacing:0.012em;
   white-space:normal;
-  box-shadow:0 6px 18px rgba(0,0,0,0.12);
 }
 
 .voronoi-label__stack {
   display:flex;
   flex-direction:column;
-  align-items:flex-start;
-  gap:0.2rem;
+  align-items:center;
+  justify-content:center;
+  gap:0.16rem;
   width:100%;
 }
 
 .voronoi-label__value {
   color:inherit;
-  font-weight:600;
-  letter-spacing:0.01em;
+  font-weight:700;
+  letter-spacing:0.014em;
+  font-size:1rem;
+  line-height:1.12;
 }
 
 .voronoi-label__price {
-  font-size:0.7rem;
-  font-weight:500;
-  opacity:0.85;
-  letter-spacing:0.015em;
+  font-size:0.8rem;
+  font-weight:600;
+  opacity:0.92;
+  letter-spacing:0.01em;
+  line-height:1.1;
 }
 
 .voronoi-label__badge {
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:0.2rem 0.55rem;
+  padding:0.25rem 0.7rem;
   border-radius:9999px;
   background:#111111;
   color:#ffffff;
-  font-size:0.62rem;
-  font-weight:600;
-  letter-spacing:0.08em;
+  font-size:0.7rem;
+  font-weight:700;
+  letter-spacing:0.02em;
   text-transform:uppercase;
   line-height:1;
-  align-self:flex-start;
+  align-self:center;
 }
 
 .voronoi-label[data-fallback="true"] {
-  background:#fff4f4;
+  background:#fee2e2;
   border-color:#dc2626;
   color:#7f1d1d;
-  box-shadow:0 6px 18px rgba(220,38,38,0.16);
+  box-shadow:0 12px 28px rgba(220,38,38,0.24);
 }
 
 .voronoi-label[data-fallback="true"] .voronoi-label__badge {
   background:#dc2626;
+  color:#ffffff;
 }
 
 .voronoi-label[data-density="compact"] {
-  padding:0.5rem 0.75rem;
-  font-size:0.74rem;
-  gap:0.25rem;
+  padding:0.55rem 0.85rem;
+  font-size:0.8rem;
+  gap:0.22rem;
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__price {
-  font-size:0.64rem;
+  font-size:0.72rem;
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__badge {
-  padding:0.15rem 0.45rem;
-  font-size:0.56rem;
+  padding:0.2rem 0.55rem;
+  font-size:0.62rem;
 }
 
 .voronoi-indicator {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -185,11 +185,12 @@
   display:flex;
   flex-direction:column;
   gap:10px;
-  background:linear-gradient(135deg,#0b1f3a,#12284f);
-  color:#f8fafc;
-  padding:12px 14px;
-  border-radius:14px;
-  box-shadow:0 6px 14px rgba(15,23,42,0.18);
+  background:#ffffff;
+  color:#0f172a;
+  padding:14px 16px;
+  border-radius:16px;
+  border:1px solid rgba(15,23,42,0.08);
+  box-shadow:0 8px 24px rgba(15,23,42,0.08);
 }
 
 .voronoi-inspector__summary[hidden] {
@@ -208,21 +209,23 @@
   font-weight:600;
   text-transform:uppercase;
   letter-spacing:0.05em;
-  color:rgba(248,250,252,0.78);
+  color:#1f2937;
 }
 
 .voronoi-inspector__summary-badge {
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:2px 8px;
+  padding:4px 10px;
   border-radius:999px;
-  background:rgba(248,250,252,0.2);
-  color:#f8fafc;
+  background:#ffffff;
+  color:#111111;
   font-size:0.68rem;
   font-weight:600;
   text-transform:uppercase;
   letter-spacing:0.08em;
+  border:1px solid rgba(15,23,42,0.16);
+  box-shadow:0 1px 2px rgba(15,23,42,0.12);
 }
 
 .voronoi-inspector__summary-badge[hidden] {
@@ -245,14 +248,14 @@
 .voronoi-inspector__summary-label {
   font-size:0.75rem;
   font-weight:500;
-  color:rgba(226,232,240,0.82);
+  color:#475569;
 }
 
 .voronoi-inspector__summary-value {
   font-size:0.9rem;
   font-weight:700;
   font-variant-numeric:tabular-nums;
-  color:#ffffff;
+  color:#111111;
 }
 
 .voronoi-inspector[hidden] {
@@ -291,7 +294,7 @@
 
 .voronoi-inspector__percentage {
   font-weight:600;
-  color:#1d4ed8;
+  color:#111111;
   font-variant-numeric:tabular-nums;
 }
 
@@ -934,20 +937,47 @@
   font-size:0.56rem;
 }
 
+.voronoi-pill,
+.voronoi-inspector__summary-value,
+.voronoi-inspector__percentage,
 .voronoi-connector-label {
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:2px 8px;
-  border-radius:999px;
+  gap:0.35rem;
+  padding:6px 12px;
+  border-radius:9999px;
   background:#ffffff;
-  color:#111827;
-  font-size:11px;
+  color:#111111;
+  border:1px solid rgba(15,23,42,0.16);
+  box-shadow:0 1px 2px rgba(15,23,42,0.12);
   font-weight:600;
-  border:1px solid rgba(148,163,184,0.45);
-  box-shadow:0 2px 6px rgba(15,23,42,0.25);
+  line-height:1;
+  font-size:0.82rem;
+  font-variant-numeric:tabular-nums;
+  white-space:nowrap;
+}
+
+.voronoi-pill--compact,
+.voronoi-connector-label {
+  padding:4px 10px;
+  font-size:0.75rem;
+}
+
+.voronoi-connector-label {
+  box-shadow:0 4px 10px rgba(15,23,42,0.2);
   pointer-events:none;
   white-space:nowrap;
+}
+
+.voronoi-inspector__summary-value {
+  font-size:0.92rem;
+  padding:8px 14px;
+}
+
+.voronoi-inspector__percentage {
+  font-size:0.8rem;
+  padding:6px 12px;
 }
 
 .voronoi-indicator {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -293,6 +293,7 @@
 }
 
 .voronoi-inspector__percentage {
+  font-size:0.8rem;
   font-weight:600;
   color:#111111;
   font-variant-numeric:tabular-nums;
@@ -860,8 +861,6 @@
 
 .voronoi-label,
 .voronoi-pill,
-.voronoi-inspector__summary-value,
-.voronoi-inspector__percentage,
 .voronoi-connector-label {
   border-radius:9999px;
   background:#ffffff;
@@ -874,8 +873,6 @@
 }
 
 .voronoi-pill,
-.voronoi-inspector__summary-value,
-.voronoi-inspector__percentage,
 .voronoi-connector-label {
   display:inline-flex;
   align-items:center;
@@ -896,15 +893,6 @@
 .voronoi-connector-label {
   box-shadow:0 4px 10px rgba(0,0,0,0.18);
   pointer-events:none;
-}
-
-.voronoi-inspector__summary-value {
-  font-size:0.92rem;
-  padding:0.6rem 0.95rem;
-}
-
-.voronoi-inspector__percentage {
-  font-size:0.8rem;
 }
 
 .voronoi-label {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -862,15 +862,23 @@
 .voronoi-label,
 .voronoi-pill,
 .voronoi-connector-label {
-  border-radius:9999px;
-  background:#ffffff;
+  background:transparent;
+  border:none;
   color:#111111;
-  border:1px solid #111111;
-  box-shadow:0 1px 2px rgba(0,0,0,0.08);
-  font-weight:600;
+  font-weight:700;
   font-variant-numeric:tabular-nums;
-  letter-spacing:0.01em;
-  transition:background-color 180ms ease, color 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+  letter-spacing:0.012em;
+  text-transform:none;
+  -webkit-text-fill-color:#111111;
+  -webkit-text-stroke:2.2px rgba(255,255,255,0.95);
+  paint-order:stroke fill;
+  text-shadow:0 0 1px rgba(255,255,255,0.95),
+              0 0 2px rgba(255,255,255,0.95),
+              0 0 4px rgba(255,255,255,0.9),
+              0 0 8px rgba(255,255,255,0.85),
+              0 2px 6px rgba(15,23,42,0.35);
+  filter:drop-shadow(0 4px 10px rgba(15,23,42,0.28));
+  transition:color 180ms ease;
 }
 
 .voronoi-pill,
@@ -878,17 +886,16 @@
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:0.5rem;
-  padding:0.5rem 0.8rem;
-  line-height:1;
-  font-size:0.875rem;
+  gap:0.35rem;
+  padding:0.1rem 0.25rem;
+  line-height:1.08;
+  font-size:0.95rem;
   white-space:nowrap;
 }
 
 .voronoi-pill--compact,
 .voronoi-connector-label {
-  padding:0.45rem 0.7rem;
-  font-size:0.8rem;
+  font-size:0.88rem;
 }
 
 .voronoi-connector-label {
@@ -903,12 +910,12 @@
   flex-direction:column;
   align-items:center;
   justify-content:center;
-  gap:0.22rem;
-  padding:0.65rem 0.9rem;
-  font-size:0.88rem;
+  gap:0.12rem;
+  padding:0;
+  font-size:0.92rem;
   line-height:1.18;
-  letter-spacing:0.012em;
   white-space:normal;
+  filter:drop-shadow(0 6px 12px rgba(15,23,42,0.28));
 }
 
 .voronoi-label__stack {
@@ -916,67 +923,68 @@
   flex-direction:column;
   align-items:center;
   justify-content:center;
-  gap:0.16rem;
+  gap:0.08rem;
   width:100%;
 }
 
 .voronoi-label__value {
   color:inherit;
-  font-weight:700;
-  letter-spacing:0.014em;
-  font-size:1rem;
+  -webkit-text-fill-color:inherit;
+  font-weight:800;
+  letter-spacing:0.016em;
+  font-size:1.05rem;
   line-height:1.12;
 }
 
 .voronoi-label__price {
-  font-size:0.78rem;
-  font-weight:600;
-  opacity:0.92;
-  letter-spacing:0.01em;
-  line-height:1.1;
+  font-size:0.82rem;
+  font-weight:700;
+  letter-spacing:0.012em;
+  line-height:1.12;
+  opacity:0.96;
 }
 
 .voronoi-label__badge {
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  padding:0.25rem 0.7rem;
-  border-radius:9999px;
-  background:#111111;
-  color:#ffffff;
-  font-size:0.7rem;
-  font-weight:700;
-  letter-spacing:0.02em;
+  padding:0.08rem 0.24rem;
+  border-radius:0.25rem;
+  color:inherit;
+  -webkit-text-fill-color:inherit;
+  font-size:0.68rem;
+  font-weight:800;
+  letter-spacing:0.06em;
   text-transform:uppercase;
-  line-height:1;
+  line-height:1.05;
   align-self:center;
 }
 
 .voronoi-label[data-fallback="true"] {
-  background:#fef2f2;
-  border-color:#dc2626;
   color:#7f1d1d;
-  box-shadow:0 1px 2px rgba(220,38,38,0.18);
+  -webkit-text-fill-color:#7f1d1d;
 }
 
 .voronoi-label[data-fallback="true"] .voronoi-label__badge {
-  background:#dc2626;
-  color:#ffffff;
+  color:#991b1b;
+  -webkit-text-fill-color:#991b1b;
 }
 
 .voronoi-label[data-density="compact"] {
-  padding:0.5rem 0.75rem;
-  font-size:0.82rem;
-  gap:0.18rem;
+  font-size:0.86rem;
+  gap:0.1rem;
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__price {
-  font-size:0.72rem;
+  font-size:0.76rem;
+}
+
+.voronoi-label[data-density="compact"] .voronoi-label__value {
+  font-size:0.98rem;
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__badge {
-  padding:0.2rem 0.55rem;
-  font-size:0.62rem;
+  font-size:0.6rem;
 }
 
 .voronoi-indicator {

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -934,6 +934,46 @@
   font-size:0.56rem;
 }
 
+.voronoi-connector-label {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:2px 8px;
+  border-radius:999px;
+  background:#ffffff;
+  color:#111827;
+  font-size:11px;
+  font-weight:600;
+  border:1px solid rgba(148,163,184,0.45);
+  box-shadow:0 2px 6px rgba(15,23,42,0.25);
+  pointer-events:none;
+  white-space:nowrap;
+}
+
+.voronoi-indicator {
+  width:18px;
+  height:18px;
+  border-radius:999px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:12px;
+  font-weight:700;
+  background:rgba(255,255,255,0.96);
+  border:1px solid currentColor;
+  color:#2563EB;
+  box-shadow:0 2px 6px rgba(15,23,42,0.3);
+  pointer-events:none;
+}
+
+.voronoi-indicator--hidden {
+  color:#2563EB;
+}
+
+.voronoi-indicator--supplementary {
+  color:#DC2626;
+}
+
 @media (max-width:768px){
   .map-info-window { font-size:.9rem; max-width:400px; }
   .map-info-window h3 { font-size:1rem; white-space:nowrap; text-align:center; }

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -864,9 +864,9 @@
 .voronoi-connector-label {
   border-radius:9999px;
   background:#ffffff;
-  color:#0f172a;
-  border:1px solid #0f172a;
-  box-shadow:0 14px 32px rgba(15,23,42,0.22);
+  color:#111111;
+  border:1px solid #111111;
+  box-shadow:0 1px 2px rgba(0,0,0,0.08);
   font-weight:600;
   font-variant-numeric:tabular-nums;
   letter-spacing:0.01em;
@@ -878,17 +878,17 @@
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:0.4rem;
-  padding:0.45rem 0.85rem;
-  line-height:1.12;
-  font-size:0.85rem;
+  gap:0.5rem;
+  padding:0.5rem 0.8rem;
+  line-height:1;
+  font-size:0.875rem;
   white-space:nowrap;
 }
 
 .voronoi-pill--compact,
 .voronoi-connector-label {
-  padding:0.4rem 0.75rem;
-  font-size:0.78rem;
+  padding:0.45rem 0.7rem;
+  font-size:0.8rem;
 }
 
 .voronoi-connector-label {
@@ -903,9 +903,9 @@
   flex-direction:column;
   align-items:center;
   justify-content:center;
-  gap:0.28rem;
-  padding:0.75rem 1.05rem;
-  font-size:0.9rem;
+  gap:0.22rem;
+  padding:0.65rem 0.9rem;
+  font-size:0.88rem;
   line-height:1.18;
   letter-spacing:0.012em;
   white-space:normal;
@@ -929,7 +929,7 @@
 }
 
 .voronoi-label__price {
-  font-size:0.8rem;
+  font-size:0.78rem;
   font-weight:600;
   opacity:0.92;
   letter-spacing:0.01em;
@@ -953,10 +953,10 @@
 }
 
 .voronoi-label[data-fallback="true"] {
-  background:#fee2e2;
+  background:#fef2f2;
   border-color:#dc2626;
   color:#7f1d1d;
-  box-shadow:0 12px 28px rgba(220,38,38,0.24);
+  box-shadow:0 1px 2px rgba(220,38,38,0.18);
 }
 
 .voronoi-label[data-fallback="true"] .voronoi-label__badge {
@@ -965,9 +965,9 @@
 }
 
 .voronoi-label[data-density="compact"] {
-  padding:0.55rem 0.85rem;
-  font-size:0.8rem;
-  gap:0.22rem;
+  padding:0.5rem 0.75rem;
+  font-size:0.82rem;
+  gap:0.18rem;
 }
 
 .voronoi-label[data-density="compact"] .voronoi-label__price {

--- a/oferty.html
+++ b/oferty.html
@@ -525,6 +525,15 @@ window.showConfirmModal = showConfirmModal;
   let randomPreviewTags = [];
   let randomPreviewSignature = '';
   let currentVisibleOffers = [];
+  let voronoiSupplementaryOffers = [];
+  let currentVoronoiOffers = [];
+  let currentVoronoiSupplementary = [];
+  let voronoiHiddenOffersInBounds = [];
+  let voronoiSupplementaryOffersInBounds = [];
+  const voronoiIndicatorState = {
+    hidden: [],
+    supplementary: []
+  };
   const voronoiLayerState = {
     enabled: false,
     polygons: [],
@@ -666,6 +675,102 @@ window.showConfirmModal = showConfirmModal;
     } else if ('map' in label) {
       label.map = targetMap || null;
     }
+  }
+
+  function setOverlayMap(overlay, targetMap) {
+    if (!overlay) return;
+    if (typeof overlay.setMap === 'function') {
+      overlay.setMap(targetMap || null);
+    } else if ('map' in overlay) {
+      overlay.map = targetMap || null;
+    }
+  }
+
+  function createVoronoiIndicatorMarker(position, type) {
+    if (!position) return null;
+    const isHidden = type === 'hidden';
+    const className = isHidden
+      ? 'voronoi-indicator voronoi-indicator--hidden'
+      : 'voronoi-indicator voronoi-indicator--supplementary';
+    const fallbackColor = isHidden ? '#2563EB' : '#DC2626';
+
+    try {
+      if (google?.maps?.marker?.AdvancedMarkerElement) {
+        const node = document.createElement('div');
+        node.className = className;
+        node.textContent = '×';
+        return new google.maps.marker.AdvancedMarkerElement({
+          position,
+          map: null,
+          content: node,
+          zIndex: 160
+        });
+      }
+    } catch (error) {
+      console.warn('Nie udało się utworzyć wskaźnika Voronoi w trybie AdvancedMarkerElement.', error);
+    }
+
+    return new google.maps.Marker({
+      position,
+      map: null,
+      icon: { path: google.maps.SymbolPath.CIRCLE, scale: 0.01, strokeWeight: 0 },
+      label: {
+        text: '×',
+        color: fallbackColor,
+        fontSize: '14px',
+        fontWeight: '700'
+      },
+      zIndex: 160
+    });
+  }
+
+  function clearVoronoiIndicators(type = null) {
+    const groups = [];
+    if (!type || type === 'hidden') {
+      groups.push(voronoiIndicatorState.hidden);
+    }
+    if (!type || type === 'supplementary') {
+      groups.push(voronoiIndicatorState.supplementary);
+    }
+    groups.forEach((collection) => {
+      collection.forEach(marker => setOverlayMap(marker, null));
+      collection.length = 0;
+    });
+  }
+
+  function rebuildVoronoiIndicatorMarkers(type, offers) {
+    const targetCollection = type === 'hidden'
+      ? voronoiIndicatorState.hidden
+      : voronoiIndicatorState.supplementary;
+
+    targetCollection.forEach(marker => setOverlayMap(marker, null));
+    targetCollection.length = 0;
+
+    if (!map || !Array.isArray(offers) || !offers.length) {
+      return;
+    }
+
+    offers.forEach(offer => {
+      const position = getMarkerPositionForOffer(offer);
+      if (!position) return;
+      const marker = createVoronoiIndicatorMarker(position, type);
+      if (!marker) return;
+      setOverlayMap(marker, map);
+      targetCollection.push(marker);
+    });
+  }
+
+  function refreshVoronoiIndicators() {
+    if (!map || !voronoiLayerState.enabled) {
+      clearVoronoiIndicators();
+      return;
+    }
+
+    const filterActive = filterState.selectedTags.size > 0;
+    const hiddenOffers = filterActive ? voronoiHiddenOffersInBounds : [];
+
+    rebuildVoronoiIndicatorMarkers('hidden', hiddenOffers);
+    rebuildVoronoiIndicatorMarkers('supplementary', voronoiSupplementaryOffersInBounds);
   }
 
   function hasVoronoiValuation(entry) {
@@ -978,6 +1083,9 @@ window.showConfirmModal = showConfirmModal;
         if (connector && typeof connector.setVisible === 'function') {
           connector.setVisible(false);
         }
+        if (connector?.__voronoiLabel) {
+          setOverlayMap(connector.__voronoiLabel, null);
+        }
       });
     }
     if (highlight.hiddenPolygons instanceof Map && highlight.hiddenPolygons.size) {
@@ -1057,11 +1165,14 @@ window.showConfirmModal = showConfirmModal;
       : [];
     const uniqueSources = new Set();
 
-    fallbackSources.forEach(path => {
-      if (!Array.isArray(path) || path.length < 2) return;
-      const sourceIndex = path[path.length - 1];
-      if (Number.isInteger(sourceIndex)) {
-        uniqueSources.add(sourceIndex);
+    fallbackSources.forEach(source => {
+      const resolvedSourceIndex = Number.isInteger(source?.sourceIndex)
+        ? source.sourceIndex
+        : (Array.isArray(source?.path) && source.path.length
+          ? source.path[source.path.length - 1]
+          : null);
+      if (Number.isInteger(resolvedSourceIndex)) {
+        uniqueSources.add(resolvedSourceIndex);
       }
     });
 
@@ -1094,6 +1205,9 @@ window.showConfirmModal = showConfirmModal;
         }
         if (connector && typeof connector.setVisible === 'function') {
           connector.setVisible(true);
+        }
+        if (connector?.__voronoiLabel && voronoiLayerState.enabled && map) {
+          setOverlayMap(connector.__voronoiLabel, map);
         }
         highlight.connectors.add(connector);
       });
@@ -1226,7 +1340,29 @@ window.showConfirmModal = showConfirmModal;
             return {
               ...value,
               fallbackSources: Array.isArray(value.fallbackSources)
-                ? value.fallbackSources.map(path => Array.isArray(path) ? path.slice() : [])
+                ? value.fallbackSources.map(source => {
+                    if (!source) {
+                      return null;
+                    }
+                    const path = Array.isArray(source.path)
+                      ? source.path.slice()
+                      : [];
+                    const sourceIndex = Number.isInteger(source.sourceIndex)
+                      ? source.sourceIndex
+                      : null;
+                    const distanceMeters = Number.isFinite(source.distanceMeters)
+                      ? source.distanceMeters
+                      : null;
+                    const weight = Number.isFinite(source.weight)
+                      ? source.weight
+                      : null;
+                    return {
+                      path,
+                      sourceIndex,
+                      distanceMeters,
+                      weight
+                    };
+                  }).filter(Boolean)
                 : []
             };
           })
@@ -1571,6 +1707,32 @@ window.showConfirmModal = showConfirmModal;
     return result;
   }
 
+  function getInactivePlotEntries(rawPlots) {
+    if (!Array.isArray(rawPlots)) return [];
+    const result = [];
+    rawPlots.forEach((plot, index) => {
+      if (!plot || typeof plot !== 'object') return;
+      if (plot.mock !== false) return;
+
+      const normalizedPlot = { ...plot };
+      normalizedPlot.mock = false;
+
+      const storedIndex = Number.isInteger(plot.__originalIndex)
+        ? plot.__originalIndex
+        : Number.isInteger(normalizedPlot.__originalIndex)
+          ? normalizedPlot.__originalIndex
+          : index;
+
+      delete normalizedPlot.__originalIndex;
+
+      result.push({
+        plot: normalizedPlot,
+        originalIndex: storedIndex
+      });
+    });
+    return result;
+  }
+
   function preparePlotsForCache(rawPlots) {
     return getActivePlotEntries(rawPlots)
       .map(({ plot, originalIndex }) => {
@@ -1581,6 +1743,20 @@ window.showConfirmModal = showConfirmModal;
         if (typeof safePlot.mock === 'undefined') {
           safePlot.mock = true;
         }
+        safePlot.__originalIndex = originalIndex;
+        return safePlot;
+      })
+      .filter(Boolean);
+  }
+
+  function prepareInactivePlotsForCache(rawPlots) {
+    return getInactivePlotEntries(rawPlots)
+      .map(({ plot, originalIndex }) => {
+        const safePlot = cloneForCache(plot) || { ...plot };
+        if (!safePlot || typeof safePlot !== 'object') {
+          return null;
+        }
+        safePlot.mock = false;
         safePlot.__originalIndex = originalIndex;
         return safePlot;
       })
@@ -1612,6 +1788,13 @@ window.showConfirmModal = showConfirmModal;
     }
 
     clonedData.plots = normalizedPlots;
+
+    const inactivePlots = prepareInactivePlotsForCache(rawData.plots);
+    if (inactivePlots.length) {
+      clonedData.__inactivePlots = inactivePlots;
+    } else if (clonedData.__inactivePlots) {
+      delete clonedData.__inactivePlots;
+    }
 
     return {
       id,
@@ -1849,6 +2032,12 @@ window.showConfirmModal = showConfirmModal;
     availableTags = [];
     tagMetrics = new Map();
     currentVisibleOffers = [];
+    voronoiSupplementaryOffers = [];
+    currentVoronoiOffers = [];
+    currentVoronoiSupplementary = [];
+    voronoiHiddenOffersInBounds = [];
+    voronoiSupplementaryOffersInBounds = [];
+    clearVoronoiIndicators();
     voronoiLayerState.cachedDataset = null;
     voronoiLayerState.cacheSignature = null;
     voronoiLayerState.frozenLayout = null;
@@ -1957,6 +2146,72 @@ window.showConfirmModal = showConfirmModal;
         };
 
         allOffers.push(hydratedEntry);
+      });
+
+      const inactivePlots = Array.isArray(data.__inactivePlots)
+        ? data.__inactivePlots
+        : [];
+      inactivePlots.forEach((inactivePlot, inactiveIndex) => {
+        if (!inactivePlot || typeof inactivePlot !== 'object') {
+          return;
+        }
+
+        const normalizedPlot = { ...inactivePlot };
+        if (typeof normalizedPlot.mock === 'undefined') {
+          normalizedPlot.mock = false;
+        } else {
+          normalizedPlot.mock = false;
+        }
+
+        const storedIndex = Number.isInteger(inactivePlot.__originalIndex)
+          ? inactivePlot.__originalIndex
+          : Number.isInteger(normalizedPlot.__originalIndex)
+            ? normalizedPlot.__originalIndex
+            : inactiveIndex;
+
+        delete normalizedPlot.__originalIndex;
+
+        let lat = Number(normalizedPlot.lat);
+        let lng = Number(normalizedPlot.lng);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+          return;
+        }
+
+        let voronoiPoint = { lat, lng };
+        let polygonCoords = [];
+        const geometry = normalizedPlot.geometry_uldk;
+        if (geometry) {
+          const coords = parseGeometry(geometry);
+          if (coords.length) {
+            polygonCoords = coords;
+            const interiorPoint = getPolygonInteriorPoint(coords, voronoiPoint);
+            if (interiorPoint) {
+              voronoiPoint = interiorPoint;
+            }
+          }
+        }
+
+        const tags = normalizeTags(normalizedPlot.tags);
+        const uniquePlotTags = Array.from(new Set(tags));
+
+        const normalizedIndex = Number.isInteger(storedIndex)
+          ? storedIndex
+          : voronoiSupplementaryOffers.length + inactiveIndex;
+
+        const supplementaryEntry = {
+          id: offerId,
+          key: `${offerId || 'unknown'}__inactive__${normalizedIndex}`,
+          data,
+          plot: normalizedPlot,
+          index: normalizedIndex,
+          marker: null,
+          polygon: null,
+          polygonCoords,
+          voronoiPoint,
+          tags: uniquePlotTags
+        };
+
+        voronoiSupplementaryOffers.push(supplementaryEntry);
       });
     });
 
@@ -2139,6 +2394,7 @@ window.showConfirmModal = showConfirmModal;
     } else {
       clearVoronoiLayer();
     }
+    refreshVoronoiIndicators();
     syncVoronoiToggleUI();
   });
 
@@ -2241,6 +2497,13 @@ window.showConfirmModal = showConfirmModal;
         });
       }
     });
+    voronoiSupplementaryOffers.forEach(offer => {
+      if (Array.isArray(offer.tags)) {
+        offer.tags.forEach(tag => {
+          if (tag) uniqueTags.add(tag);
+        });
+      }
+    });
 
     const tags = Array.from(uniqueTags);
     const maxValue = tags.length || 1;
@@ -2324,6 +2587,97 @@ window.showConfirmModal = showConfirmModal;
       total += segment;
     }
     return total;
+  }
+
+  function computeConnectorMidpoint(path) {
+    if (!Array.isArray(path) || path.length === 0) {
+      return null;
+    }
+    if (path.length === 1) {
+      return path[0];
+    }
+
+    let totalDistance = 0;
+    const segments = [];
+    for (let i = 1; i < path.length; i++) {
+      const start = path[i - 1];
+      const end = path[i];
+      const segmentDistance = computeDistanceBetweenPoints(start, end);
+      if (!Number.isFinite(segmentDistance) || segmentDistance <= 0) {
+        continue;
+      }
+      segments.push({ start, end, distance: segmentDistance });
+      totalDistance += segmentDistance;
+    }
+
+    if (!segments.length || !(totalDistance > 0)) {
+      const first = path[0];
+      const last = path[path.length - 1];
+      if (first && last) {
+        return {
+          lat: (Number(first.lat) + Number(last.lat)) / 2,
+          lng: (Number(first.lng) + Number(last.lng)) / 2
+        };
+      }
+      return first || null;
+    }
+
+    const half = totalDistance / 2;
+    let accumulated = 0;
+
+    for (const segment of segments) {
+      if (accumulated + segment.distance >= half) {
+        const remaining = half - accumulated;
+        const ratio = segment.distance > 0 ? remaining / segment.distance : 0;
+        const lat = Number(segment.start.lat) + (Number(segment.end.lat) - Number(segment.start.lat)) * ratio;
+        const lng = Number(segment.start.lng) + (Number(segment.end.lng) - Number(segment.start.lng)) * ratio;
+        if (Number.isFinite(lat) && Number.isFinite(lng)) {
+          return { lat, lng };
+        }
+        break;
+      }
+      accumulated += segment.distance;
+    }
+
+    const lastSegment = segments[segments.length - 1];
+    return lastSegment ? lastSegment.end : path[path.length - 1];
+  }
+
+  function formatDistanceValue(distanceMeters) {
+    if (!(distanceMeters > 0) || !Number.isFinite(distanceMeters)) {
+      return '—';
+    }
+    if (distanceMeters >= 1000) {
+      const km = distanceMeters / 1000;
+      const precision = km >= 10 ? 0 : 1;
+      return `${km.toFixed(precision)} km`;
+    }
+    return `${Math.round(distanceMeters)} m`;
+  }
+
+  function formatWeightValue(weight) {
+    if (!(weight > 0) || !Number.isFinite(weight)) {
+      return '—';
+    }
+    if (weight >= 0.1) {
+      return weight.toFixed(2);
+    }
+    return weight.toPrecision(2);
+  }
+
+  function buildConnectorLabelText(weight, distanceMeters) {
+    const weightText = formatWeightValue(weight);
+    const distanceText = formatDistanceValue(distanceMeters);
+    if (weightText === '—' && distanceText === '—') {
+      return '';
+    }
+    if (weightText === '—') {
+      return distanceText;
+    }
+    if (distanceText === '—') {
+      return `w=${weightText}`;
+    }
+    return `w=${weightText} • ${distanceText}`;
   }
 
   const MAX_FALLBACK_DISTANCE_METERS = 30000;
@@ -2542,7 +2896,8 @@ window.showConfirmModal = showConfirmModal;
         sourceIndex,
         directPath: [index, sourceIndex],
         fullPath: path,
-        distanceMeters: Number.isFinite(distance) ? distance : computePathDistance(path, dataset)
+        distanceMeters: Number.isFinite(distance) ? distance : computePathDistance(path, dataset),
+        weight
       });
     });
 
@@ -2600,26 +2955,47 @@ window.showConfirmModal = showConfirmModal;
         };
       }
 
-      const sourcePaths = Array.isArray(fallback.sources)
+      const normalizedSources = Array.isArray(fallback.sources)
         ? fallback.sources
             .map(source => {
-              if (Array.isArray(source?.directPath) && source.directPath.length >= 2) {
-                return source.directPath.slice();
+              let path = Array.isArray(source?.directPath) && source.directPath.length >= 2
+                ? source.directPath.slice()
+                : null;
+              if (!path && Array.isArray(source?.fullPath) && source.fullPath.length >= 2) {
+                path = source.fullPath.slice();
               }
-              if (Array.isArray(source?.fullPath) && source.fullPath.length >= 2) {
-                const path = source.fullPath.slice();
-                if (path[0] !== index) {
-                  path.unshift(index);
+              const sourceIndex = Number.isInteger(source?.sourceIndex)
+                ? source.sourceIndex
+                : null;
+              if (!path) {
+                if (!Number.isInteger(sourceIndex)) {
+                  return null;
                 }
-                return path;
+                path = [index, sourceIndex];
+              } else if (path[0] !== index) {
+                path.unshift(index);
               }
-              const sourceIndex = Number.isInteger(source?.sourceIndex) ? source.sourceIndex : null;
-              if (!Number.isInteger(sourceIndex)) {
+              const sanitizedPath = path
+                .map(value => (Number.isInteger(value) ? value : null))
+                .filter(value => Number.isInteger(value));
+              if (sanitizedPath.length < 2) {
                 return null;
               }
-              return [index, sourceIndex];
+              const resolvedSourceIndex = Number.isInteger(sourceIndex)
+                ? sourceIndex
+                : sanitizedPath[sanitizedPath.length - 1];
+              const distanceMeters = Number.isFinite(source?.distanceMeters)
+                ? source.distanceMeters
+                : computePathDistance(sanitizedPath, dataset);
+              const weightValue = Number(source?.weight);
+              return {
+                path: sanitizedPath,
+                sourceIndex: Number.isInteger(resolvedSourceIndex) ? resolvedSourceIndex : null,
+                distanceMeters: Number.isFinite(distanceMeters) ? distanceMeters : null,
+                weight: Number.isFinite(weightValue) && weightValue > 0 ? weightValue : null
+              };
             })
-            .filter(path => Array.isArray(path) && path.length >= 2)
+            .filter(entry => entry && Array.isArray(entry.path) && entry.path.length >= 2)
         : [];
 
       return {
@@ -2627,7 +3003,7 @@ window.showConfirmModal = showConfirmModal;
         price: fallback.price,
         pricePerSqm: fallback.pricePerSqm,
         hasPrice: true,
-        fallbackSources: sourcePaths
+        fallbackSources: normalizedSources
       };
     });
   }
@@ -2989,6 +3365,41 @@ window.showConfirmModal = showConfirmModal;
     });
   }
 
+  function createVoronoiConnectorLabel(text, position) {
+    if (!position || typeof text !== 'string' || !text.trim()) {
+      return null;
+    }
+
+    try {
+      if (google?.maps?.marker?.AdvancedMarkerElement) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'voronoi-connector-label';
+        wrapper.textContent = text;
+        return new google.maps.marker.AdvancedMarkerElement({
+          position,
+          map: null,
+          content: wrapper,
+          zIndex: 150
+        });
+      }
+    } catch (error) {
+      console.warn('Nie udało się utworzyć etykiety łącznika Voronoi w trybie AdvancedMarkerElement.', error);
+    }
+
+    return new google.maps.Marker({
+      position,
+      map: null,
+      icon: { path: google.maps.SymbolPath.CIRCLE, scale: 0.01, strokeWeight: 0 },
+      label: {
+        text,
+        color: '#111827',
+        fontSize: '11px',
+        fontWeight: '600'
+      },
+      zIndex: 150
+    });
+  }
+
   function clearVoronoiLayer(options = {}) {
     const {
       resetHighlight = true,
@@ -3007,6 +3418,12 @@ window.showConfirmModal = showConfirmModal;
     voronoiLayerState.connectors.forEach(connector => {
       if (connector && typeof connector.setMap === 'function') {
         connector.setMap(null);
+      }
+      if (connector && typeof connector.setVisible === 'function') {
+        connector.setVisible(false);
+      }
+      if (connector?.__voronoiLabel) {
+        setOverlayMap(connector.__voronoiLabel, null);
       }
     });
     voronoiLayerState.connectors = [];
@@ -3033,6 +3450,49 @@ window.showConfirmModal = showConfirmModal;
     if (!preserveFrozenLayout) {
       voronoiLayerState.frozenLayout = null;
     }
+
+    if (voronoiLayerState.enabled) {
+      refreshVoronoiIndicators();
+    } else {
+      clearVoronoiIndicators();
+    }
+  }
+
+  function mergeVoronoiSupplementaryOffers(sourceOffers) {
+    const base = Array.isArray(sourceOffers)
+      ? sourceOffers.filter(Boolean).slice()
+      : [];
+    const supplementaryPool = (currentVoronoiSupplementary.length
+      ? currentVoronoiSupplementary
+      : voronoiSupplementaryOffers).filter(Boolean);
+    if (!supplementaryPool.length) {
+      return base;
+    }
+
+    const keyFor = (offer) => {
+      if (!offer) return null;
+      if (typeof offer.key === 'string') {
+        return offer.key;
+      }
+      const rawId = offer?.id || '';
+      const rawIndex = Number.isInteger(offer?.index) ? offer.index : '';
+      return `${rawId}__${rawIndex}`;
+    };
+
+    const existingKeys = new Set(base.map(keyFor).filter(Boolean));
+
+    supplementaryPool.forEach(offer => {
+      const offerKey = keyFor(offer);
+      if (offerKey && existingKeys.has(offerKey)) {
+        return;
+      }
+      base.push(offer);
+      if (offerKey) {
+        existingKeys.add(offerKey);
+      }
+    });
+
+    return base;
   }
 
   function getVoronoiSourceOffers() {
@@ -3042,7 +3502,7 @@ window.showConfirmModal = showConfirmModal;
         ? selectionLock.layout.offers.filter(Boolean)
         : [];
       if (lockedOffers.length) {
-        return lockedOffers.slice();
+        return mergeVoronoiSupplementaryOffers(lockedOffers);
       }
     }
 
@@ -3052,23 +3512,22 @@ window.showConfirmModal = showConfirmModal;
         ? voronoiLayerState.frozenLayout.offers.filter(Boolean)
         : [];
       if (frozenOffers.length) {
-        return frozenOffers.slice();
+        return mergeVoronoiSupplementaryOffers(frozenOffers);
       }
       const preservedOffers = Array.isArray(voronoiLayerState.lastNonFrozenSource?.offers)
         ? voronoiLayerState.lastNonFrozenSource.offers.filter(Boolean)
         : [];
       if (preservedOffers.length) {
-        return preservedOffers.slice();
+        return mergeVoronoiSupplementaryOffers(preservedOffers);
       }
     }
-    if (currentVisibleOffers.length) {
-      return currentVisibleOffers.slice();
+    if (currentVoronoiOffers.length || currentVoronoiSupplementary.length) {
+      return mergeVoronoiSupplementaryOffers(currentVoronoiOffers);
     }
-    const filtered = getOffersMatchingFilters();
-    if (filtered.length) {
-      return filtered.slice();
+    if (allOffers.length || voronoiSupplementaryOffers.length) {
+      return mergeVoronoiSupplementaryOffers(allOffers);
     }
-    return allOffers.slice();
+    return [];
   }
 
   function getFrozenVoronoiOffers() {
@@ -3472,27 +3931,27 @@ window.showConfirmModal = showConfirmModal;
         }
       }
 
-      fallbackSources.forEach(pathIndices => {
-        let connectorPath = Array.isArray(pathIndices)
-          ? pathIndices
-              .map(i => {
-                const datasetEntry = dataset[i];
-                const markerPosition = getMarkerPositionForDatasetEntry(datasetEntry);
-                if (markerPosition) return markerPosition;
-                const targetCell = cells[i];
-                if (targetCell?.centroid) return targetCell.centroid;
-                return datasetEntry?.position || null;
-              })
-              .filter(point => point && Number.isFinite(point.lat) && Number.isFinite(point.lng))
-          : [];
+      fallbackSources.forEach(source => {
+        const pathIndices = Array.isArray(source?.path) ? source.path.slice() : [];
+        let connectorPath = pathIndices
+          .map(i => {
+            const datasetEntry = dataset[i];
+            const markerPosition = getMarkerPositionForDatasetEntry(datasetEntry);
+            if (markerPosition) return markerPosition;
+            const targetCell = cells[i];
+            if (targetCell?.centroid) return targetCell.centroid;
+            return datasetEntry?.position || null;
+          })
+          .filter(point => point && Number.isFinite(point.lat) && Number.isFinite(point.lng));
 
         if (connectorPath.length < 2) {
           const basePosition = getMarkerPositionForDatasetEntry(dataset[index]);
-          const sourceIndex = Array.isArray(pathIndices)
-            ? pathIndices[pathIndices.length - 1]
-            : null;
-          const sourcePosition = Number.isInteger(sourceIndex)
-            ? getMarkerPositionForDatasetEntry(dataset[sourceIndex])
+          const fallbackSourceIndex = pathIndices.length ? pathIndices[pathIndices.length - 1] : null;
+          const resolvedSourceIndex = Number.isInteger(source?.sourceIndex)
+            ? source.sourceIndex
+            : fallbackSourceIndex;
+          const sourcePosition = Number.isInteger(resolvedSourceIndex)
+            ? getMarkerPositionForDatasetEntry(dataset[resolvedSourceIndex])
             : null;
           connectorPath = [basePosition, sourcePosition]
             .filter(point => point && Number.isFinite(point.lat) && Number.isFinite(point.lng));
@@ -3507,8 +3966,23 @@ window.showConfirmModal = showConfirmModal;
           visible: false,
           ...buildVoronoiConnectorStyle('default')
         });
+        const resolvedSourceIndex = Number.isInteger(source?.sourceIndex)
+          ? source.sourceIndex
+          : (pathIndices.length ? pathIndices[pathIndices.length - 1] : null);
         connector.__voronoiBaseIndex = index;
-        connector.__voronoiSourceIndex = pathIndices[pathIndices.length - 1];
+        connector.__voronoiSourceIndex = Number.isInteger(resolvedSourceIndex) ? resolvedSourceIndex : null;
+        connector.__voronoiWeight = Number.isFinite(source?.weight) ? source.weight : null;
+        connector.__voronoiDistance = Number.isFinite(source?.distanceMeters) ? source.distanceMeters : null;
+
+        const labelText = buildConnectorLabelText(connector.__voronoiWeight, connector.__voronoiDistance);
+        if (labelText) {
+          const midpoint = computeConnectorMidpoint(connectorPath);
+          const label = createVoronoiConnectorLabel(labelText, midpoint);
+          if (label) {
+            connector.__voronoiLabel = label;
+          }
+        }
+
         voronoiLayerState.connectors.push(connector);
         const connectorsForBase = voronoiLayerState.connectorIndexMap.get(index) || [];
         connectorsForBase.push(connector);
@@ -4092,7 +4566,55 @@ window.showConfirmModal = showConfirmModal;
     if (!bounds) return;
 
     const base = Array.isArray(filteredOffers) ? filteredOffers : getOffersMatchingFilters();
-    const visibleOffers = base.filter(o => bounds.contains(o.marker.getPosition()));
+    const filteredKeys = new Set(base.map(o => o?.key));
+
+    const sw = bounds.getSouthWest();
+    const ne = bounds.getNorthEast();
+    const latMin = Math.min(sw.lat(), ne.lat());
+    const latMax = Math.max(sw.lat(), ne.lat());
+    const lngMin = Math.min(sw.lng(), ne.lng());
+    const lngMax = Math.max(sw.lng(), ne.lng());
+    const withinBounds = (lat, lng) => Number.isFinite(lat)
+      && Number.isFinite(lng)
+      && lat >= latMin && lat <= latMax
+      && lng >= lngMin && lng <= lngMax;
+
+    const offersInBounds = allOffers.filter(offer => {
+      if (offer?.marker && typeof offer.marker.getPosition === 'function') {
+        const position = offer.marker.getPosition();
+        if (position && typeof position.lat === 'function' && typeof position.lng === 'function') {
+          const lat = position.lat();
+          const lng = position.lng();
+          if (withinBounds(lat, lng)) {
+            return true;
+          }
+        }
+      }
+      const plot = offer?.plot;
+      const lat = Number(plot?.lat);
+      const lng = Number(plot?.lng);
+      return withinBounds(lat, lng);
+    });
+
+    currentVoronoiOffers = offersInBounds.slice();
+    voronoiHiddenOffersInBounds = offersInBounds.filter(offer => !filteredKeys.has(offer?.key));
+
+    const supplementaryInBounds = voronoiSupplementaryOffers.filter(offer => {
+      const position = getMarkerPositionForOffer(offer);
+      if (!position) return false;
+      return withinBounds(Number(position.lat), Number(position.lng));
+    });
+
+    currentVoronoiSupplementary = supplementaryInBounds.slice();
+    voronoiSupplementaryOffersInBounds = supplementaryInBounds.slice();
+
+    const visibleOffers = base.filter(o => {
+      if (!o?.marker || typeof o.marker.getPosition !== 'function') {
+        return false;
+      }
+      const position = o.marker.getPosition();
+      return position ? bounds.contains(position) : false;
+    });
     updateTagCollectionsForVisibleOffers(visibleOffers);
 
     const listContainer = document.getElementById("offersList");
@@ -4130,6 +4652,7 @@ window.showConfirmModal = showConfirmModal;
           };
         }
       }
+      refreshVoronoiIndicators();
       return;
     }
 
@@ -4181,6 +4704,8 @@ window.showConfirmModal = showConfirmModal;
     if (voronoiLayerState.enabled) {
       updateVoronoiLayer(true);
     }
+
+    refreshVoronoiIndicators();
   }
 
   // EPSG:2180 -> WGS84

--- a/oferty.html
+++ b/oferty.html
@@ -3208,37 +3208,64 @@ window.showConfirmModal = showConfirmModal;
     const isFallback = options.fallback === true;
     const density = options.density === 'compact' ? 'compact' : 'default';
 
-    const baseBg = '#ffffff';
-    const baseColor = '#111111';
-    const baseBorder = '#111111';
-    const fallbackBg = '#fef2f2';
-    const fallbackBorder = '#dc2626';
-    const fallbackColor = '#7f1d1d';
+    const baseColor = isFallback ? '#7f1d1d' : '#111111';
+    const accentColor = isFallback ? '#991b1b' : '#111111';
+    const haloColor = 'rgba(255, 255, 255, 0.95)';
+    const haloShadow = [
+      `0 0 1px ${haloColor}`,
+      `0 0 2px ${haloColor}`,
+      `0 0 3px ${haloColor}`,
+      `0 0 4px ${haloColor}`,
+      `0 0 6px ${haloColor}`,
+      `0 0 10px ${haloColor}`
+    ].join(', ');
+    const outerShadow = '0 6px 12px rgba(15, 23, 42, 0.35)';
+    const strokeWidth = isFallback ? 2.6 : 2.4;
 
-    wrapper.style.background = isFallback ? fallbackBg : baseBg;
-    wrapper.style.color = isFallback ? fallbackColor : baseColor;
-    wrapper.style.border = `1px solid ${isFallback ? fallbackBorder : baseBorder}`;
-    wrapper.style.borderRadius = '9999px';
-    wrapper.style.boxShadow = isFallback
-      ? '0 1px 2px rgba(220, 38, 38, 0.18)'
-      : '0 1px 2px rgba(0, 0, 0, 0.08)';
-    wrapper.style.display = 'inline-flex';
+    const applyHalo = (element, options = {}) => {
+      if (!element) return;
+      const fill = options.color || baseColor;
+      const weight = options.fontWeight || element.style.fontWeight || '700';
+      const size = options.fontSize || element.style.fontSize || '';
+      const spacing = options.letterSpacing || element.style.letterSpacing || '';
+      const lineHeight = options.lineHeight || element.style.lineHeight || '';
+      const elementStrokeWidth = options.strokeWidth || strokeWidth;
+
+      element.style.color = fill;
+      element.style.webkitTextFillColor = fill;
+      element.style.webkitTextStroke = `${elementStrokeWidth}px ${haloColor}`;
+      element.style.paintOrder = 'stroke fill';
+      element.style.textShadow = `${haloShadow}, ${outerShadow}`;
+      element.style.fontWeight = weight;
+      if (size) element.style.fontSize = size;
+      if (spacing) element.style.letterSpacing = spacing;
+      if (lineHeight) element.style.lineHeight = lineHeight;
+    };
+
+    wrapper.style.background = 'transparent';
+    wrapper.style.border = 'none';
+    wrapper.style.borderRadius = '0';
+    wrapper.style.boxShadow = 'none';
+    wrapper.style.display = 'flex';
     wrapper.style.flexDirection = 'column';
     wrapper.style.alignItems = 'center';
     wrapper.style.justifyContent = 'center';
     wrapper.style.textAlign = 'center';
-    wrapper.style.gap = density === 'compact' ? '0.18rem' : '0.22rem';
-    wrapper.style.padding = density === 'compact' ? '0.5rem 0.75rem' : '0.65rem 0.9rem';
-    wrapper.style.fontSize = density === 'compact' ? '0.82rem' : '0.88rem';
-    wrapper.style.fontWeight = '600';
+    wrapper.style.gap = density === 'compact' ? '0.1rem' : '0.14rem';
+    wrapper.style.padding = '0';
+    wrapper.style.fontSize = density === 'compact' ? '0.86rem' : '0.92rem';
+    wrapper.style.fontWeight = '700';
     wrapper.style.lineHeight = '1.18';
-    wrapper.style.letterSpacing = '0.01em';
+    wrapper.style.letterSpacing = '0.012em';
     wrapper.style.fontVariantNumeric = 'tabular-nums';
     wrapper.style.minWidth = 'auto';
     wrapper.style.pointerEvents = 'none';
     wrapper.style.whiteSpace = 'normal';
-    wrapper.style.backdropFilter = 'blur(0px)';
+    wrapper.style.backdropFilter = 'none';
     wrapper.style.transform = 'translateZ(0)';
+    wrapper.style.filter = 'drop-shadow(0 6px 12px rgba(15, 23, 42, 0.28))';
+
+    applyHalo(wrapper, { fontWeight: '700' });
 
     const stack = wrapper.querySelector('.voronoi-label__stack');
     if (stack) {
@@ -3247,26 +3274,30 @@ window.showConfirmModal = showConfirmModal;
       stack.style.alignItems = 'center';
       stack.style.justifyContent = 'center';
       stack.style.textAlign = 'center';
-      stack.style.gap = density === 'compact' ? '0.12rem' : '0.18rem';
+      stack.style.gap = density === 'compact' ? '0.08rem' : '0.12rem';
       stack.style.width = '100%';
+      applyHalo(stack, { fontWeight: '700' });
     }
 
     const value = wrapper.querySelector('.voronoi-label__value');
     if (value) {
-      value.style.color = 'inherit';
-      value.style.fontWeight = '700';
-      value.style.fontSize = density === 'compact' ? '0.9rem' : '1rem';
-      value.style.lineHeight = '1.12';
-      value.style.letterSpacing = '0.014em';
+      applyHalo(value, {
+        fontWeight: '800',
+        fontSize: density === 'compact' ? '0.98rem' : '1.05rem',
+        letterSpacing: '0.016em',
+        lineHeight: '1.12'
+      });
     }
 
     const price = wrapper.querySelector('.voronoi-label__price');
     if (price) {
-      price.style.fontSize = density === 'compact' ? '0.72rem' : '0.78rem';
-      price.style.fontWeight = '600';
-      price.style.opacity = '0.92';
-      price.style.letterSpacing = '0.01em';
-      price.style.lineHeight = '1.1';
+      applyHalo(price, {
+        fontWeight: '700',
+        fontSize: density === 'compact' ? '0.76rem' : '0.82rem',
+        letterSpacing: '0.012em',
+        lineHeight: '1.12'
+      });
+      price.style.opacity = '0.96';
     }
 
     const badge = wrapper.querySelector('.voronoi-label__badge');
@@ -3274,42 +3305,56 @@ window.showConfirmModal = showConfirmModal;
       badge.style.display = 'inline-flex';
       badge.style.alignItems = 'center';
       badge.style.justifyContent = 'center';
-      badge.style.padding = density === 'compact' ? '0.2rem 0.55rem' : '0.25rem 0.7rem';
-      badge.style.borderRadius = '9999px';
-      badge.style.background = '#111111';
-      badge.style.color = '#ffffff';
-      badge.style.fontSize = density === 'compact' ? '0.62rem' : '0.7rem';
-      badge.style.fontWeight = '700';
-      badge.style.letterSpacing = '0.02em';
+      badge.style.padding = density === 'compact' ? '0.06rem 0.2rem' : '0.08rem 0.24rem';
+      badge.style.borderRadius = '0.25rem';
       badge.style.textTransform = 'uppercase';
-      badge.style.lineHeight = '1';
       badge.style.alignSelf = 'center';
-      if (isFallback) {
-        badge.style.background = '#dc2626';
-      }
+      applyHalo(badge, {
+        fontWeight: '800',
+        fontSize: density === 'compact' ? '0.6rem' : '0.68rem',
+        letterSpacing: '0.06em',
+        color: accentColor,
+        strokeWidth: 2.2
+      });
     }
   }
 
   function applyVoronoiConnectorStyles(wrapper) {
     if (!wrapper) return;
 
-    wrapper.style.background = '#ffffff';
+    const haloColor = 'rgba(255, 255, 255, 0.95)';
+    const haloShadow = [
+      `0 0 1px ${haloColor}`,
+      `0 0 2px ${haloColor}`,
+      `0 0 3px ${haloColor}`,
+      `0 0 4px ${haloColor}`,
+      `0 0 6px ${haloColor}`,
+      `0 0 10px ${haloColor}`
+    ].join(', ');
+    const outerShadow = '0 6px 12px rgba(15, 23, 42, 0.35)';
+
+    wrapper.style.background = 'transparent';
     wrapper.style.color = '#111111';
-    wrapper.style.border = '1px solid #111111';
-    wrapper.style.borderRadius = '9999px';
-    wrapper.style.boxShadow = '0 1px 2px rgba(0, 0, 0, 0.08)';
+    wrapper.style.webkitTextFillColor = '#111111';
+    wrapper.style.webkitTextStroke = '2.3px rgba(255, 255, 255, 0.95)';
+    wrapper.style.paintOrder = 'stroke fill';
+    wrapper.style.border = 'none';
+    wrapper.style.borderRadius = '0';
+    wrapper.style.boxShadow = 'none';
     wrapper.style.display = 'inline-flex';
     wrapper.style.alignItems = 'center';
     wrapper.style.justifyContent = 'center';
-    wrapper.style.padding = '0.45rem 0.7rem';
-    wrapper.style.fontSize = '0.8rem';
-    wrapper.style.fontWeight = '600';
-    wrapper.style.lineHeight = '1';
+    wrapper.style.padding = '0';
+    wrapper.style.fontSize = '0.9rem';
+    wrapper.style.fontWeight = '700';
+    wrapper.style.lineHeight = '1.08';
     wrapper.style.fontVariantNumeric = 'tabular-nums';
     wrapper.style.letterSpacing = '0.012em';
     wrapper.style.whiteSpace = 'nowrap';
     wrapper.style.pointerEvents = 'none';
     wrapper.style.transform = 'translateZ(0)';
+    wrapper.style.textShadow = `${haloShadow}, ${outerShadow}`;
+    wrapper.style.filter = 'drop-shadow(0 6px 12px rgba(15, 23, 42, 0.28))';
   }
 
   function calculatePolygonCentroid(path) {

--- a/oferty.html
+++ b/oferty.html
@@ -4864,7 +4864,12 @@ window.showConfirmModal = showConfirmModal;
   function loadGoogleMaps() {
     const apiKey = localStorage.getItem('googleMapsApiKey') || 'AIzaSyCr5TmFxnT3enxmyr6vujF8leP995giw8I';
     const script = document.createElement("script");
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&callback=initMap`;
+    const params = new URLSearchParams({
+      key: apiKey,
+      callback: 'initMap',
+      libraries: 'marker'
+    });
+    script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
     script.async = true; script.defer = true;
     document.head.appendChild(script);
   }

--- a/oferty.html
+++ b/oferty.html
@@ -3208,49 +3208,65 @@ window.showConfirmModal = showConfirmModal;
     const isFallback = options.fallback === true;
     const density = options.density === 'compact' ? 'compact' : 'default';
 
-    wrapper.style.background = isFallback ? '#fff4f4' : '#ffffff';
-    wrapper.style.color = isFallback ? '#7f1d1d' : '#111111';
-    wrapper.style.border = isFallback ? '1px solid #dc2626' : '1px solid #111111';
+    const baseBg = '#ffffff';
+    const baseColor = '#0f172a';
+    const baseBorder = '#0f172a';
+    const fallbackBg = '#fee2e2';
+    const fallbackBorder = '#dc2626';
+    const fallbackColor = '#7f1d1d';
+
+    wrapper.style.background = isFallback ? fallbackBg : baseBg;
+    wrapper.style.color = isFallback ? fallbackColor : baseColor;
+    wrapper.style.border = `1px solid ${isFallback ? fallbackBorder : baseBorder}`;
     wrapper.style.borderRadius = '9999px';
     wrapper.style.boxShadow = isFallback
-      ? '0 6px 18px rgba(220, 38, 38, 0.16)'
-      : '0 1px 2px rgba(0, 0, 0, 0.08)';
-    wrapper.style.display = 'flex';
+      ? '0 12px 28px rgba(220, 38, 38, 0.24)'
+      : '0 14px 32px rgba(15, 23, 42, 0.22)';
+    wrapper.style.display = 'inline-flex';
     wrapper.style.flexDirection = 'column';
-    wrapper.style.alignItems = 'flex-start';
-    wrapper.style.justifyContent = 'flex-start';
-    wrapper.style.gap = density === 'compact' ? '0.25rem' : '0.35rem';
-    wrapper.style.padding = density === 'compact' ? '0.5rem 0.75rem' : '0.65rem 0.95rem';
-    wrapper.style.fontSize = density === 'compact' ? '0.74rem' : '0.82rem';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.justifyContent = 'center';
+    wrapper.style.textAlign = 'center';
+    wrapper.style.gap = density === 'compact' ? '0.18rem' : '0.28rem';
+    wrapper.style.padding = density === 'compact' ? '0.55rem 0.85rem' : '0.8rem 1.05rem';
+    wrapper.style.fontSize = density === 'compact' ? '0.8rem' : '0.92rem';
     wrapper.style.fontWeight = '600';
-    wrapper.style.lineHeight = '1.2';
+    wrapper.style.lineHeight = '1.18';
+    wrapper.style.letterSpacing = '0.01em';
     wrapper.style.fontVariantNumeric = 'tabular-nums';
     wrapper.style.minWidth = 'auto';
     wrapper.style.pointerEvents = 'none';
     wrapper.style.whiteSpace = 'normal';
+    wrapper.style.backdropFilter = 'blur(0px)';
+    wrapper.style.transform = 'translateZ(0)';
 
     const stack = wrapper.querySelector('.voronoi-label__stack');
     if (stack) {
       stack.style.display = 'flex';
       stack.style.flexDirection = 'column';
-      stack.style.alignItems = 'flex-start';
-      stack.style.gap = '0.2rem';
+      stack.style.alignItems = 'center';
+      stack.style.justifyContent = 'center';
+      stack.style.textAlign = 'center';
+      stack.style.gap = density === 'compact' ? '0.1rem' : '0.16rem';
       stack.style.width = '100%';
     }
 
     const value = wrapper.querySelector('.voronoi-label__value');
     if (value) {
       value.style.color = 'inherit';
-      value.style.fontWeight = '600';
-      value.style.letterSpacing = '0.01em';
+      value.style.fontWeight = '700';
+      value.style.fontSize = density === 'compact' ? '0.88rem' : '1rem';
+      value.style.lineHeight = '1.12';
+      value.style.letterSpacing = '0.012em';
     }
 
     const price = wrapper.querySelector('.voronoi-label__price');
     if (price) {
-      price.style.fontSize = density === 'compact' ? '0.64rem' : '0.7rem';
-      price.style.fontWeight = '500';
-      price.style.opacity = '0.85';
-      price.style.letterSpacing = '0.015em';
+      price.style.fontSize = density === 'compact' ? '0.72rem' : '0.8rem';
+      price.style.fontWeight = '600';
+      price.style.opacity = '0.92';
+      price.style.letterSpacing = '0.01em';
+      price.style.lineHeight = '1.1';
     }
 
     const badge = wrapper.querySelector('.voronoi-label__badge');
@@ -3258,16 +3274,16 @@ window.showConfirmModal = showConfirmModal;
       badge.style.display = 'inline-flex';
       badge.style.alignItems = 'center';
       badge.style.justifyContent = 'center';
-      badge.style.padding = density === 'compact' ? '0.15rem 0.45rem' : '0.2rem 0.55rem';
+      badge.style.padding = density === 'compact' ? '0.2rem 0.55rem' : '0.25rem 0.7rem';
       badge.style.borderRadius = '9999px';
       badge.style.background = '#111111';
       badge.style.color = '#ffffff';
-      badge.style.fontSize = density === 'compact' ? '0.56rem' : '0.62rem';
-      badge.style.fontWeight = '600';
-      badge.style.letterSpacing = '0.08em';
+      badge.style.fontSize = density === 'compact' ? '0.62rem' : '0.7rem';
+      badge.style.fontWeight = '700';
+      badge.style.letterSpacing = '0.02em';
       badge.style.textTransform = 'uppercase';
       badge.style.lineHeight = '1';
-      badge.style.alignSelf = 'flex-start';
+      badge.style.alignSelf = 'center';
       if (isFallback) {
         badge.style.background = '#dc2626';
       }
@@ -3278,21 +3294,22 @@ window.showConfirmModal = showConfirmModal;
     if (!wrapper) return;
 
     wrapper.style.background = '#ffffff';
-    wrapper.style.color = '#111111';
-    wrapper.style.border = '1px solid #111111';
+    wrapper.style.color = '#0f172a';
+    wrapper.style.border = '1px solid #0f172a';
     wrapper.style.borderRadius = '9999px';
-    wrapper.style.boxShadow = '0 4px 10px rgba(0, 0, 0, 0.18)';
+    wrapper.style.boxShadow = '0 14px 32px rgba(15, 23, 42, 0.22)';
     wrapper.style.display = 'inline-flex';
     wrapper.style.alignItems = 'center';
     wrapper.style.justifyContent = 'center';
-    wrapper.style.gap = '0.5rem';
-    wrapper.style.padding = '0.5rem 0.75rem';
-    wrapper.style.fontSize = '0.82rem';
-    wrapper.style.fontWeight = '500';
-    wrapper.style.lineHeight = '1';
+    wrapper.style.padding = '0.45rem 0.85rem';
+    wrapper.style.fontSize = '0.85rem';
+    wrapper.style.fontWeight = '600';
+    wrapper.style.lineHeight = '1.12';
     wrapper.style.fontVariantNumeric = 'tabular-nums';
+    wrapper.style.letterSpacing = '0.012em';
     wrapper.style.whiteSpace = 'nowrap';
     wrapper.style.pointerEvents = 'none';
+    wrapper.style.transform = 'translateZ(0)';
   }
 
   function calculatePolygonCentroid(path) {

--- a/oferty.html
+++ b/oferty.html
@@ -3209,9 +3209,9 @@ window.showConfirmModal = showConfirmModal;
     const density = options.density === 'compact' ? 'compact' : 'default';
 
     const baseBg = '#ffffff';
-    const baseColor = '#0f172a';
-    const baseBorder = '#0f172a';
-    const fallbackBg = '#fee2e2';
+    const baseColor = '#111111';
+    const baseBorder = '#111111';
+    const fallbackBg = '#fef2f2';
     const fallbackBorder = '#dc2626';
     const fallbackColor = '#7f1d1d';
 
@@ -3220,16 +3220,16 @@ window.showConfirmModal = showConfirmModal;
     wrapper.style.border = `1px solid ${isFallback ? fallbackBorder : baseBorder}`;
     wrapper.style.borderRadius = '9999px';
     wrapper.style.boxShadow = isFallback
-      ? '0 12px 28px rgba(220, 38, 38, 0.24)'
-      : '0 14px 32px rgba(15, 23, 42, 0.22)';
+      ? '0 1px 2px rgba(220, 38, 38, 0.18)'
+      : '0 1px 2px rgba(0, 0, 0, 0.08)';
     wrapper.style.display = 'inline-flex';
     wrapper.style.flexDirection = 'column';
     wrapper.style.alignItems = 'center';
     wrapper.style.justifyContent = 'center';
     wrapper.style.textAlign = 'center';
-    wrapper.style.gap = density === 'compact' ? '0.18rem' : '0.28rem';
-    wrapper.style.padding = density === 'compact' ? '0.55rem 0.85rem' : '0.8rem 1.05rem';
-    wrapper.style.fontSize = density === 'compact' ? '0.8rem' : '0.92rem';
+    wrapper.style.gap = density === 'compact' ? '0.18rem' : '0.22rem';
+    wrapper.style.padding = density === 'compact' ? '0.5rem 0.75rem' : '0.65rem 0.9rem';
+    wrapper.style.fontSize = density === 'compact' ? '0.82rem' : '0.88rem';
     wrapper.style.fontWeight = '600';
     wrapper.style.lineHeight = '1.18';
     wrapper.style.letterSpacing = '0.01em';
@@ -3247,7 +3247,7 @@ window.showConfirmModal = showConfirmModal;
       stack.style.alignItems = 'center';
       stack.style.justifyContent = 'center';
       stack.style.textAlign = 'center';
-      stack.style.gap = density === 'compact' ? '0.1rem' : '0.16rem';
+      stack.style.gap = density === 'compact' ? '0.12rem' : '0.18rem';
       stack.style.width = '100%';
     }
 
@@ -3255,14 +3255,14 @@ window.showConfirmModal = showConfirmModal;
     if (value) {
       value.style.color = 'inherit';
       value.style.fontWeight = '700';
-      value.style.fontSize = density === 'compact' ? '0.88rem' : '1rem';
+      value.style.fontSize = density === 'compact' ? '0.9rem' : '1rem';
       value.style.lineHeight = '1.12';
-      value.style.letterSpacing = '0.012em';
+      value.style.letterSpacing = '0.014em';
     }
 
     const price = wrapper.querySelector('.voronoi-label__price');
     if (price) {
-      price.style.fontSize = density === 'compact' ? '0.72rem' : '0.8rem';
+      price.style.fontSize = density === 'compact' ? '0.72rem' : '0.78rem';
       price.style.fontWeight = '600';
       price.style.opacity = '0.92';
       price.style.letterSpacing = '0.01em';
@@ -3294,17 +3294,17 @@ window.showConfirmModal = showConfirmModal;
     if (!wrapper) return;
 
     wrapper.style.background = '#ffffff';
-    wrapper.style.color = '#0f172a';
-    wrapper.style.border = '1px solid #0f172a';
+    wrapper.style.color = '#111111';
+    wrapper.style.border = '1px solid #111111';
     wrapper.style.borderRadius = '9999px';
-    wrapper.style.boxShadow = '0 14px 32px rgba(15, 23, 42, 0.22)';
+    wrapper.style.boxShadow = '0 1px 2px rgba(0, 0, 0, 0.08)';
     wrapper.style.display = 'inline-flex';
     wrapper.style.alignItems = 'center';
     wrapper.style.justifyContent = 'center';
-    wrapper.style.padding = '0.45rem 0.85rem';
-    wrapper.style.fontSize = '0.85rem';
+    wrapper.style.padding = '0.45rem 0.7rem';
+    wrapper.style.fontSize = '0.8rem';
     wrapper.style.fontWeight = '600';
-    wrapper.style.lineHeight = '1.12';
+    wrapper.style.lineHeight = '1';
     wrapper.style.fontVariantNumeric = 'tabular-nums';
     wrapper.style.letterSpacing = '0.012em';
     wrapper.style.whiteSpace = 'nowrap';

--- a/oferty.html
+++ b/oferty.html
@@ -573,8 +573,8 @@ window.showConfirmModal = showConfirmModal;
   };
 
   const VORONOI_LABEL_SIZE = {
-    width: 150,
-    height: 42
+    width: 160,
+    height: 64
   };
 
   function getVoronoiPolygonStyle(mode = 'default') {
@@ -695,11 +695,14 @@ window.showConfirmModal = showConfirmModal;
     const fallbackColor = isHidden ? '#2563EB' : '#DC2626';
 
     try {
-      if (google?.maps?.marker?.AdvancedMarkerElement) {
+      const advancedMarkerCtor = (typeof google !== 'undefined' && google && google.maps && google.maps.marker && google.maps.marker.AdvancedMarkerElement)
+        ? google.maps.marker.AdvancedMarkerElement
+        : null;
+      if (advancedMarkerCtor) {
         const node = document.createElement('div');
         node.className = className;
         node.textContent = '×';
-        return new google.maps.marker.AdvancedMarkerElement({
+        return new advancedMarkerCtor({
           position,
           map: null,
           content: node,
@@ -3206,155 +3209,28 @@ window.showConfirmModal = showConfirmModal;
     if (!wrapper) return;
 
     const isFallback = options.fallback === true;
-    const density = options.density === 'compact' ? 'compact' : 'default';
+    const density = options.density === 'compact' ? 'compact' : null;
 
-    const baseColor = isFallback ? '#7f1d1d' : '#111111';
-    const accentColor = isFallback ? '#991b1b' : '#111111';
-    const haloColor = 'rgba(255, 255, 255, 0.95)';
-    const haloShadow = [
-      `0 0 1px ${haloColor}`,
-      `0 0 2px ${haloColor}`,
-      `0 0 3px ${haloColor}`,
-      `0 0 4px ${haloColor}`,
-      `0 0 6px ${haloColor}`,
-      `0 0 10px ${haloColor}`
-    ].join(', ');
-    const outerShadow = '0 6px 12px rgba(15, 23, 42, 0.35)';
-    const strokeWidth = isFallback ? 2.6 : 2.4;
-
-    const applyHalo = (element, options = {}) => {
-      if (!element) return;
-      const fill = options.color || baseColor;
-      const weight = options.fontWeight || element.style.fontWeight || '700';
-      const size = options.fontSize || element.style.fontSize || '';
-      const spacing = options.letterSpacing || element.style.letterSpacing || '';
-      const lineHeight = options.lineHeight || element.style.lineHeight || '';
-      const elementStrokeWidth = options.strokeWidth || strokeWidth;
-
-      element.style.color = fill;
-      element.style.webkitTextFillColor = fill;
-      element.style.webkitTextStroke = `${elementStrokeWidth}px ${haloColor}`;
-      element.style.paintOrder = 'stroke fill';
-      element.style.textShadow = `${haloShadow}, ${outerShadow}`;
-      element.style.fontWeight = weight;
-      if (size) element.style.fontSize = size;
-      if (spacing) element.style.letterSpacing = spacing;
-      if (lineHeight) element.style.lineHeight = lineHeight;
-    };
-
-    wrapper.style.background = 'transparent';
-    wrapper.style.border = 'none';
-    wrapper.style.borderRadius = '0';
-    wrapper.style.boxShadow = 'none';
-    wrapper.style.display = 'flex';
-    wrapper.style.flexDirection = 'column';
-    wrapper.style.alignItems = 'center';
-    wrapper.style.justifyContent = 'center';
-    wrapper.style.textAlign = 'center';
-    wrapper.style.gap = density === 'compact' ? '0.1rem' : '0.14rem';
-    wrapper.style.padding = '0';
-    wrapper.style.fontSize = density === 'compact' ? '0.86rem' : '0.92rem';
-    wrapper.style.fontWeight = '700';
-    wrapper.style.lineHeight = '1.18';
-    wrapper.style.letterSpacing = '0.012em';
-    wrapper.style.fontVariantNumeric = 'tabular-nums';
-    wrapper.style.minWidth = 'auto';
+    wrapper.classList.add('voronoi-pill', 'voronoi-label');
+    wrapper.setAttribute('role', 'presentation');
     wrapper.style.pointerEvents = 'none';
-    wrapper.style.whiteSpace = 'normal';
-    wrapper.style.backdropFilter = 'none';
-    wrapper.style.transform = 'translateZ(0)';
-    wrapper.style.filter = 'drop-shadow(0 6px 12px rgba(15, 23, 42, 0.28))';
-
-    applyHalo(wrapper, { fontWeight: '700' });
-
-    const stack = wrapper.querySelector('.voronoi-label__stack');
-    if (stack) {
-      stack.style.display = 'flex';
-      stack.style.flexDirection = 'column';
-      stack.style.alignItems = 'center';
-      stack.style.justifyContent = 'center';
-      stack.style.textAlign = 'center';
-      stack.style.gap = density === 'compact' ? '0.08rem' : '0.12rem';
-      stack.style.width = '100%';
-      applyHalo(stack, { fontWeight: '700' });
+    if (isFallback) {
+      wrapper.dataset.fallback = 'true';
+    } else {
+      delete wrapper.dataset.fallback;
     }
-
-    const value = wrapper.querySelector('.voronoi-label__value');
-    if (value) {
-      applyHalo(value, {
-        fontWeight: '800',
-        fontSize: density === 'compact' ? '0.98rem' : '1.05rem',
-        letterSpacing: '0.016em',
-        lineHeight: '1.12'
-      });
-    }
-
-    const price = wrapper.querySelector('.voronoi-label__price');
-    if (price) {
-      applyHalo(price, {
-        fontWeight: '700',
-        fontSize: density === 'compact' ? '0.76rem' : '0.82rem',
-        letterSpacing: '0.012em',
-        lineHeight: '1.12'
-      });
-      price.style.opacity = '0.96';
-    }
-
-    const badge = wrapper.querySelector('.voronoi-label__badge');
-    if (badge) {
-      badge.style.display = 'inline-flex';
-      badge.style.alignItems = 'center';
-      badge.style.justifyContent = 'center';
-      badge.style.padding = density === 'compact' ? '0.06rem 0.2rem' : '0.08rem 0.24rem';
-      badge.style.borderRadius = '0.25rem';
-      badge.style.textTransform = 'uppercase';
-      badge.style.alignSelf = 'center';
-      applyHalo(badge, {
-        fontWeight: '800',
-        fontSize: density === 'compact' ? '0.6rem' : '0.68rem',
-        letterSpacing: '0.06em',
-        color: accentColor,
-        strokeWidth: 2.2
-      });
+    if (density) {
+      wrapper.dataset.density = density;
+    } else {
+      delete wrapper.dataset.density;
     }
   }
 
   function applyVoronoiConnectorStyles(wrapper) {
     if (!wrapper) return;
-
-    const haloColor = 'rgba(255, 255, 255, 0.95)';
-    const haloShadow = [
-      `0 0 1px ${haloColor}`,
-      `0 0 2px ${haloColor}`,
-      `0 0 3px ${haloColor}`,
-      `0 0 4px ${haloColor}`,
-      `0 0 6px ${haloColor}`,
-      `0 0 10px ${haloColor}`
-    ].join(', ');
-    const outerShadow = '0 6px 12px rgba(15, 23, 42, 0.35)';
-
-    wrapper.style.background = 'transparent';
-    wrapper.style.color = '#111111';
-    wrapper.style.webkitTextFillColor = '#111111';
-    wrapper.style.webkitTextStroke = '2.3px rgba(255, 255, 255, 0.95)';
-    wrapper.style.paintOrder = 'stroke fill';
-    wrapper.style.border = 'none';
-    wrapper.style.borderRadius = '0';
-    wrapper.style.boxShadow = 'none';
-    wrapper.style.display = 'inline-flex';
-    wrapper.style.alignItems = 'center';
-    wrapper.style.justifyContent = 'center';
-    wrapper.style.padding = '0';
-    wrapper.style.fontSize = '0.9rem';
-    wrapper.style.fontWeight = '700';
-    wrapper.style.lineHeight = '1.08';
-    wrapper.style.fontVariantNumeric = 'tabular-nums';
-    wrapper.style.letterSpacing = '0.012em';
-    wrapper.style.whiteSpace = 'nowrap';
+    wrapper.classList.add('voronoi-pill', 'voronoi-pill--compact', 'voronoi-connector-label');
+    wrapper.setAttribute('role', 'presentation');
     wrapper.style.pointerEvents = 'none';
-    wrapper.style.transform = 'translateZ(0)';
-    wrapper.style.textShadow = `${haloShadow}, ${outerShadow}`;
-    wrapper.style.filter = 'drop-shadow(0 6px 12px rgba(15, 23, 42, 0.28))';
   }
 
   function calculatePolygonCentroid(path) {
@@ -3491,31 +3367,134 @@ window.showConfirmModal = showConfirmModal;
     return first || fallback || null;
   }
 
+  function normalizeOverlayPosition(position) {
+    if (typeof google === 'undefined' || !google?.maps?.LatLng) {
+      return null;
+    }
+    if (!position) return null;
+    if (position instanceof google.maps.LatLng) {
+      return position;
+    }
+    const lat = Number(position.lat);
+    const lng = Number(position.lng);
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+      return new google.maps.LatLng(lat, lng);
+    }
+    return null;
+  }
+
+  let HtmlMapOverlayClass = null;
+
+  function getHtmlMapOverlayClass() {
+    const overlayCtor = (typeof google !== 'undefined' && google && google.maps && google.maps.OverlayView)
+      ? google.maps.OverlayView
+      : null;
+
+    if (HtmlMapOverlayClass && overlayCtor) {
+      return HtmlMapOverlayClass;
+    }
+    if (!overlayCtor) {
+      return null;
+    }
+
+    HtmlMapOverlayClass = class extends overlayCtor {
+      constructor(options = {}) {
+        super();
+        this.position = normalizeOverlayPosition(options.position);
+        this.element = options.element || document.createElement('div');
+        this.paneName = options.pane || 'floatPane';
+        this.zIndex = Number.isFinite(options.zIndex) ? options.zIndex : 0;
+        this.alwaysInteractive = options.pointerEvents === true;
+        this.ariaLabel = typeof options.ariaLabel === 'string' ? options.ariaLabel : '';
+
+        this.element.style.position = 'absolute';
+        this.element.style.transform = 'translate(-50%, -50%)';
+        if (!this.alwaysInteractive) {
+          this.element.style.pointerEvents = 'none';
+        }
+        if (this.ariaLabel) {
+          this.element.setAttribute('aria-label', this.ariaLabel);
+        }
+
+        if (options.map) {
+          this.setMap(options.map);
+        }
+      }
+
+      onAdd() {
+        const panes = this.getPanes();
+        const targetPane = panes?.[this.paneName] || panes?.floatPane || panes?.overlayMouseTarget || panes?.overlayLayer;
+        if (!targetPane) return;
+        if (Number.isFinite(this.zIndex)) {
+          this.element.style.zIndex = String(this.zIndex);
+        }
+        targetPane.appendChild(this.element);
+      }
+
+      draw() {
+        if (!this.element || !this.position) return;
+        const projection = this.getProjection();
+        if (!projection) return;
+        const point = projection.fromLatLngToDivPixel(normalizeOverlayPosition(this.position));
+        if (!point) return;
+        this.element.style.left = `${point.x}px`;
+        this.element.style.top = `${point.y}px`;
+      }
+
+      onRemove() {
+        if (this.element?.parentNode) {
+          this.element.parentNode.removeChild(this.element);
+        }
+      }
+
+      getPosition() {
+        return this.position || null;
+      }
+
+      setPosition(position) {
+        const normalized = normalizeOverlayPosition(position);
+        if (!normalized) return;
+        this.position = normalized;
+        this.draw();
+      }
+
+      setZIndex(zIndex) {
+        this.zIndex = Number.isFinite(zIndex) ? zIndex : 0;
+        if (this.element) {
+          this.element.style.zIndex = String(this.zIndex);
+        }
+      }
+    };
+
+    return HtmlMapOverlayClass;
+  }
+
+  function createHtmlMapOverlay(options = {}) {
+    const OverlayClass = getHtmlMapOverlayClass();
+    if (!OverlayClass) {
+      return null;
+    }
+    return new OverlayClass(options);
+  }
+
   function createVoronoiLabelNode(htmlContent, fallbackText, position, options = {}) {
     if (!position) return null;
     const isFallback = options.fallback === true;
     const density = typeof options.density === 'string' ? options.density : 'default';
-    try {
-      if (google?.maps?.marker?.AdvancedMarkerElement) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'voronoi-label';
-        wrapper.innerHTML = htmlContent;
-        if (isFallback) {
-          wrapper.dataset.fallback = 'true';
-        }
-        if (density && density !== 'default') {
-          wrapper.dataset.density = density;
-        }
-        applyVoronoiLabelStyles(wrapper, { fallback: isFallback, density });
-        return new google.maps.marker.AdvancedMarkerElement({
-          position,
-          map: voronoiLayerState.enabled ? map : null,
-          content: wrapper,
-          zIndex: 120
-        });
-      }
-    } catch (error) {
-      console.warn('Nie udało się utworzyć etykiety AdvancedMarkerElement dla Voronoi.', error);
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = htmlContent;
+    applyVoronoiLabelStyles(wrapper, { fallback: isFallback, density });
+
+    const overlay = createHtmlMapOverlay({
+      position,
+      element: wrapper,
+      map: voronoiLayerState.enabled ? map : null,
+      zIndex: 120,
+      ariaLabel: typeof fallbackText === 'string' ? fallbackText : ''
+    });
+
+    if (overlay) {
+      return overlay;
     }
 
     return new google.maps.Marker({
@@ -3524,7 +3503,7 @@ window.showConfirmModal = showConfirmModal;
       icon: { path: google.maps.SymbolPath.CIRCLE, scale: 0.01, strokeWeight: 0 },
       label: {
         text: fallbackText,
-        color: '#ffffff',
+        color: '#111827',
         fontSize: '12px',
         fontWeight: '600'
       },
@@ -3537,21 +3516,20 @@ window.showConfirmModal = showConfirmModal;
       return null;
     }
 
-    try {
-      if (google?.maps?.marker?.AdvancedMarkerElement) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'voronoi-connector-label voronoi-pill voronoi-pill--compact';
-        wrapper.textContent = text;
-        applyVoronoiConnectorStyles(wrapper);
-        return new google.maps.marker.AdvancedMarkerElement({
-          position,
-          map: null,
-          content: wrapper,
-          zIndex: 150
-        });
-      }
-    } catch (error) {
-      console.warn('Nie udało się utworzyć etykiety łącznika Voronoi w trybie AdvancedMarkerElement.', error);
+    const wrapper = document.createElement('span');
+    wrapper.textContent = text;
+    applyVoronoiConnectorStyles(wrapper);
+
+    const overlay = createHtmlMapOverlay({
+      position,
+      element: wrapper,
+      map: null,
+      zIndex: 150,
+      ariaLabel: text
+    });
+
+    if (overlay) {
+      return overlay;
     }
 
     return new google.maps.Marker({
@@ -4628,6 +4606,8 @@ window.showConfirmModal = showConfirmModal;
 
   // ====== MAPA ======
   async function initMap() {
+    hideMapsKeyPrompt();
+
     const mobileMediaQuery = typeof window !== 'undefined' && window.matchMedia
       ? window.matchMedia('(max-width: 768px)')
       : null;
@@ -4906,19 +4886,148 @@ window.showConfirmModal = showConfirmModal;
   };
 
   // ładowanie Google Maps
+  const DEFAULT_GOOGLE_MAPS_API_KEY = 'AIzaSyCr5TmFxnT3enxmyr6vujF8leP995giw8I';
+  const GOOGLE_MAPS_DEFAULT_HOSTS = ['grunteo.pl', 'www.grunteo.pl', 'trainingtwenty5.github.io'];
+
+  function isDefaultMapsHost(hostname) {
+    if (!hostname) return false;
+    return GOOGLE_MAPS_DEFAULT_HOSTS.some(allowed => {
+      if (hostname === allowed) return true;
+      return hostname.endsWith(`.${allowed}`);
+    });
+  }
+
+  function ensureMapsKeyPrompt() {
+    let prompt = document.getElementById('mapsKeyPrompt');
+    if (prompt) {
+      return prompt;
+    }
+    const container = document.querySelector('.map-container');
+    if (!container) return null;
+
+    prompt = document.createElement('div');
+    prompt.className = 'maps-key-prompt';
+    prompt.id = 'mapsKeyPrompt';
+    prompt.setAttribute('role', 'alertdialog');
+    prompt.setAttribute('aria-modal', 'true');
+
+    prompt.innerHTML = `
+      <div class="maps-key-prompt__card">
+        <h4 class="maps-key-prompt__title">Potrzebny klucz Google Maps</h4>
+        <p class="maps-key-prompt__message" data-role="maps-key-message">
+          Nie udało się wczytać mapy Google. Wprowadź własny klucz API, aby kontynuować.
+        </p>
+        <form class="maps-key-prompt__form" data-role="maps-key-form">
+          <input
+            type="text"
+            class="maps-key-prompt__input"
+            data-role="maps-key-input"
+            placeholder="Wklej klucz API Google Maps"
+            autocomplete="off"
+            spellcheck="false"
+            required
+          />
+          <div class="maps-key-prompt__actions">
+            <button type="button" class="maps-key-prompt__dismiss" data-action="dismiss">Zamknij</button>
+            <button type="submit" class="maps-key-prompt__submit">Zapisz klucz</button>
+          </div>
+          <p class="maps-key-prompt__hint">Klucz zostanie zapisany tylko w tej przeglądarce.</p>
+        </form>
+      </div>
+    `;
+
+    container.appendChild(prompt);
+
+    const form = prompt.querySelector('[data-role="maps-key-form"]');
+    const input = prompt.querySelector('[data-role="maps-key-input"]');
+    const dismiss = prompt.querySelector('[data-action="dismiss"]');
+
+    if (form) {
+      form.addEventListener('submit', event => {
+        event.preventDefault();
+        if (!input) return;
+        const value = input.value.trim();
+        if (!value) {
+          input.focus();
+          return;
+        }
+        localStorage.setItem('googleMapsApiKey', value);
+        hideMapsKeyPrompt();
+        if (typeof showToast === 'function') {
+          showToast('Zapisano klucz Google Maps. Odświeżam mapę…', 'success');
+        }
+        setTimeout(() => {
+          window.location.reload();
+        }, 300);
+      });
+    }
+
+    if (dismiss) {
+      dismiss.addEventListener('click', () => hideMapsKeyPrompt());
+    }
+
+    return prompt;
+  }
+
+  function showMapsKeyPrompt(message) {
+    const prompt = ensureMapsKeyPrompt();
+    if (!prompt) return;
+    const messageNode = prompt.querySelector('[data-role="maps-key-message"]');
+    const input = prompt.querySelector('[data-role="maps-key-input"]');
+    if (messageNode && typeof message === 'string' && message.trim()) {
+      messageNode.textContent = message.trim();
+    }
+    prompt.classList.add('maps-key-prompt--visible');
+    if (input) {
+      setTimeout(() => input.focus(), 120);
+    }
+  }
+
+  function hideMapsKeyPrompt() {
+    const prompt = document.getElementById('mapsKeyPrompt');
+    if (!prompt) return;
+    prompt.classList.remove('maps-key-prompt--visible');
+  }
+
+  function registerGoogleAuthFailureHandler() {
+    window.gm_authFailure = () => {
+      localStorage.removeItem('googleMapsApiKey');
+      showMapsKeyPrompt('Google Maps odrzuciło klucz API. Wprowadź nowy klucz, aby zobaczyć mapę.');
+    };
+  }
+
   function loadGoogleMaps() {
-    const apiKey = localStorage.getItem('googleMapsApiKey') || 'AIzaSyCr5TmFxnT3enxmyr6vujF8leP995giw8I';
-    const script = document.createElement("script");
+    if (document.getElementById('googleMapsApiScript')) {
+      return;
+    }
+
+    registerGoogleAuthFailureHandler();
+
+    const storedKey = localStorage.getItem('googleMapsApiKey');
+    const canUseDefault = isDefaultMapsHost(location.hostname);
+    const apiKey = storedKey || (canUseDefault ? DEFAULT_GOOGLE_MAPS_API_KEY : '');
+
+    if (!apiKey) {
+      showMapsKeyPrompt('Aby zobaczyć mapę Google, wprowadź swój klucz API.');
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = 'googleMapsApiScript';
     const params = new URLSearchParams({
       key: apiKey,
-      callback: 'initMap',
-      libraries: 'marker'
+      callback: 'initMap'
     });
     script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
-    script.async = true; script.defer = true;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener('error', () => {
+      localStorage.removeItem('googleMapsApiKey');
+      showMapsKeyPrompt('Nie udało się wczytać Map Google. Sprawdź klucz API i spróbuj ponownie.');
+    });
     document.head.appendChild(script);
   }
-  document.addEventListener("DOMContentLoaded", loadGoogleMaps);
+  document.addEventListener('DOMContentLoaded', loadGoogleMaps);
 </script>
 
 

--- a/oferty.html
+++ b/oferty.html
@@ -2650,9 +2650,14 @@ window.showConfirmModal = showConfirmModal;
     if (distanceMeters >= 1000) {
       const km = distanceMeters / 1000;
       const precision = km >= 10 ? 0 : 1;
-      return `${km.toFixed(precision)} km`;
+      const formattedKm = km.toLocaleString('pl-PL', {
+        minimumFractionDigits: precision,
+        maximumFractionDigits: precision
+      });
+      return `${formattedKm} km`;
     }
-    return `${Math.round(distanceMeters)} m`;
+    const meters = Math.round(distanceMeters);
+    return `${meters.toLocaleString('pl-PL')} m`;
   }
 
   function formatWeightValue(weight) {
@@ -2660,9 +2665,14 @@ window.showConfirmModal = showConfirmModal;
       return '—';
     }
     if (weight >= 0.1) {
-      return weight.toFixed(2);
+      return weight.toLocaleString('pl-PL', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      });
     }
-    return weight.toPrecision(2);
+    return weight.toLocaleString('pl-PL', {
+      maximumSignificantDigits: 2
+    });
   }
 
   function buildConnectorLabelText(weight, distanceMeters) {
@@ -2671,13 +2681,14 @@ window.showConfirmModal = showConfirmModal;
     if (weightText === '—' && distanceText === '—') {
       return '';
     }
-    if (weightText === '—') {
-      return distanceText;
+    const parts = [];
+    if (weightText !== '—') {
+      parts.push(`Waga ${weightText}`);
     }
-    if (distanceText === '—') {
-      return `w=${weightText}`;
+    if (distanceText !== '—') {
+      parts.push(distanceText);
     }
-    return `w=${weightText} • ${distanceText}`;
+    return parts.join(' • ');
   }
 
   const MAX_FALLBACK_DISTANCE_METERS = 30000;
@@ -3373,7 +3384,7 @@ window.showConfirmModal = showConfirmModal;
     try {
       if (google?.maps?.marker?.AdvancedMarkerElement) {
         const wrapper = document.createElement('div');
-        wrapper.className = 'voronoi-connector-label';
+        wrapper.className = 'voronoi-connector-label voronoi-pill voronoi-pill--compact';
         wrapper.textContent = text;
         return new google.maps.marker.AdvancedMarkerElement({
           position,

--- a/oferty.html
+++ b/oferty.html
@@ -3202,6 +3202,99 @@ window.showConfirmModal = showConfirmModal;
     };
   }
 
+  function applyVoronoiLabelStyles(wrapper, options = {}) {
+    if (!wrapper) return;
+
+    const isFallback = options.fallback === true;
+    const density = options.density === 'compact' ? 'compact' : 'default';
+
+    wrapper.style.background = isFallback ? '#fff4f4' : '#ffffff';
+    wrapper.style.color = isFallback ? '#7f1d1d' : '#111111';
+    wrapper.style.border = isFallback ? '1px solid #dc2626' : '1px solid #111111';
+    wrapper.style.borderRadius = '9999px';
+    wrapper.style.boxShadow = isFallback
+      ? '0 6px 18px rgba(220, 38, 38, 0.16)'
+      : '0 1px 2px rgba(0, 0, 0, 0.08)';
+    wrapper.style.display = 'flex';
+    wrapper.style.flexDirection = 'column';
+    wrapper.style.alignItems = 'flex-start';
+    wrapper.style.justifyContent = 'flex-start';
+    wrapper.style.gap = density === 'compact' ? '0.25rem' : '0.35rem';
+    wrapper.style.padding = density === 'compact' ? '0.5rem 0.75rem' : '0.65rem 0.95rem';
+    wrapper.style.fontSize = density === 'compact' ? '0.74rem' : '0.82rem';
+    wrapper.style.fontWeight = '600';
+    wrapper.style.lineHeight = '1.2';
+    wrapper.style.fontVariantNumeric = 'tabular-nums';
+    wrapper.style.minWidth = 'auto';
+    wrapper.style.pointerEvents = 'none';
+    wrapper.style.whiteSpace = 'normal';
+
+    const stack = wrapper.querySelector('.voronoi-label__stack');
+    if (stack) {
+      stack.style.display = 'flex';
+      stack.style.flexDirection = 'column';
+      stack.style.alignItems = 'flex-start';
+      stack.style.gap = '0.2rem';
+      stack.style.width = '100%';
+    }
+
+    const value = wrapper.querySelector('.voronoi-label__value');
+    if (value) {
+      value.style.color = 'inherit';
+      value.style.fontWeight = '600';
+      value.style.letterSpacing = '0.01em';
+    }
+
+    const price = wrapper.querySelector('.voronoi-label__price');
+    if (price) {
+      price.style.fontSize = density === 'compact' ? '0.64rem' : '0.7rem';
+      price.style.fontWeight = '500';
+      price.style.opacity = '0.85';
+      price.style.letterSpacing = '0.015em';
+    }
+
+    const badge = wrapper.querySelector('.voronoi-label__badge');
+    if (badge) {
+      badge.style.display = 'inline-flex';
+      badge.style.alignItems = 'center';
+      badge.style.justifyContent = 'center';
+      badge.style.padding = density === 'compact' ? '0.15rem 0.45rem' : '0.2rem 0.55rem';
+      badge.style.borderRadius = '9999px';
+      badge.style.background = '#111111';
+      badge.style.color = '#ffffff';
+      badge.style.fontSize = density === 'compact' ? '0.56rem' : '0.62rem';
+      badge.style.fontWeight = '600';
+      badge.style.letterSpacing = '0.08em';
+      badge.style.textTransform = 'uppercase';
+      badge.style.lineHeight = '1';
+      badge.style.alignSelf = 'flex-start';
+      if (isFallback) {
+        badge.style.background = '#dc2626';
+      }
+    }
+  }
+
+  function applyVoronoiConnectorStyles(wrapper) {
+    if (!wrapper) return;
+
+    wrapper.style.background = '#ffffff';
+    wrapper.style.color = '#111111';
+    wrapper.style.border = '1px solid #111111';
+    wrapper.style.borderRadius = '9999px';
+    wrapper.style.boxShadow = '0 4px 10px rgba(0, 0, 0, 0.18)';
+    wrapper.style.display = 'inline-flex';
+    wrapper.style.alignItems = 'center';
+    wrapper.style.justifyContent = 'center';
+    wrapper.style.gap = '0.5rem';
+    wrapper.style.padding = '0.5rem 0.75rem';
+    wrapper.style.fontSize = '0.82rem';
+    wrapper.style.fontWeight = '500';
+    wrapper.style.lineHeight = '1';
+    wrapper.style.fontVariantNumeric = 'tabular-nums';
+    wrapper.style.whiteSpace = 'nowrap';
+    wrapper.style.pointerEvents = 'none';
+  }
+
   function calculatePolygonCentroid(path) {
     if (!Array.isArray(path) || path.length === 0) return null;
     let signedArea = 0;
@@ -3351,6 +3444,7 @@ window.showConfirmModal = showConfirmModal;
         if (density && density !== 'default') {
           wrapper.dataset.density = density;
         }
+        applyVoronoiLabelStyles(wrapper, { fallback: isFallback, density });
         return new google.maps.marker.AdvancedMarkerElement({
           position,
           map: voronoiLayerState.enabled ? map : null,
@@ -3386,6 +3480,7 @@ window.showConfirmModal = showConfirmModal;
         const wrapper = document.createElement('div');
         wrapper.className = 'voronoi-connector-label voronoi-pill voronoi-pill--compact';
         wrapper.textContent = text;
+        applyVoronoiConnectorStyles(wrapper);
         return new google.maps.marker.AdvancedMarkerElement({
           position,
           map: null,


### PR DESCRIPTION
## Summary
- ensure Voronoi computations use all in-bounds offers and supplementary plots even when tag filters are active
- add blue and red map indicators for hidden filtered offers and mock=false plots when the valuation layer is enabled
- display weight and distance labels on fallback connectors and style the new indicators

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e15325ceb0832b843535e4c292ea5c