### PR TITLE
Add listing preview thumbnails

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -460,6 +460,59 @@ body.lightbox-open {
   gap: 1.1rem;
 }
 
+.plan-preview-card {
+  background: linear-gradient(135deg, rgba(46,126,214,0.08), rgba(30,111,186,0.12));
+  border-radius: 18px;
+  padding: 1.1rem 1.2rem;
+  box-shadow: 0 18px 35px rgba(15,23,42,0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.plan-preview-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.plan-preview-media {
+  position: relative;
+  width: 100%;
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #eef4ff, #dbe8ff);
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.plan-preview-media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(15,23,42,0.08);
+  border-radius: 14px;
+}
+
+.plan-preview-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.plan-preview-placeholder {
+  margin: 0;
+  font-size: .92rem;
+  color: #475569;
+  text-align: center;
+  padding: 0 1rem;
+}
+
 .section-header h2,
 .section-header h3 {
   margin: 0;

--- a/assets/details.js
+++ b/assets/details.js
@@ -110,6 +110,8 @@ const elements = {
   mapImageContainer: document.getElementById('mapImageContainer'),
   mapImageElement: document.getElementById('mapImage'),
   mapImagePlaceholder: document.getElementById('mapImagePlaceholder'),
+  plotPreviewImage: document.getElementById('plotPreviewImage'),
+  plotPreviewPlaceholder: document.getElementById('plotPreviewPlaceholder'),
   mapModeButtons: Array.from(document.querySelectorAll('.map-mode-btn')),
   mapImageLightbox: document.getElementById('mapImageLightbox'),
   mapImageLightboxStage: document.getElementById('mapImageLightboxStage'),
@@ -1013,11 +1015,42 @@ function handleLightboxKeydown(event) {
   }
 }
 
+function getPreferredPreviewUrl(images) {
+  if (!images || typeof images !== 'object') return '';
+  for (const key of ['lokalizacja', 'teren', 'media', 'mpzp', 'mpzpskan', 'studium', 'uzytkigruntowe']) {
+    const candidate = images[key];
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  const fallback = Object.values(images)
+    .map(value => (typeof value === 'string' ? value.trim() : ''))
+    .find(value => value);
+  return fallback || '';
+}
+
+function updatePlotPreviewImage(images) {
+  const img = elements.plotPreviewImage;
+  const placeholder = elements.plotPreviewPlaceholder;
+  if (!img || !placeholder) return;
+  const url = getPreferredPreviewUrl(images);
+  if (url) {
+    img.src = url;
+    img.classList.remove('hidden');
+    placeholder.classList.add('hidden');
+  } else {
+    img.src = '';
+    img.classList.add('hidden');
+    placeholder.classList.remove('hidden');
+  }
+}
+
 function updateMapImages(images) {
   const nextImages = images && typeof images === 'object' && !Array.isArray(images)
     ? { ...images }
     : {};
   state.mapImages = nextImages;
+  updatePlotPreviewImage(nextImages);
   elements.mapModeButtons.forEach(btn => {
     const mode = btn.dataset.mode;
     const config = MAP_MODES[mode];

--- a/assets/main.css
+++ b/assets/main.css
@@ -110,7 +110,7 @@ a{color:var(--primary);text-decoration:none;transition:var(--transition);}
 .offer-card--stacked{flex-direction:column;}
 .offer-card--reverse{flex-direction:row-reverse;}
 .offer-card__media{position:relative;flex:0 0 180px;min-height:120px;border-radius:12px;overflow:hidden;background:linear-gradient(135deg,#eef4ff,#d9e6ff);display:flex;align-items:center;justify-content:center;color:#41557a;font-weight:600;font-size:.82rem;text-align:center;padding:.75rem;}
-.offer-card__media img{width:100%;height:100%;object-fit:cover;display:block;}
+.offer-card__media img{width:100%;height:100%;object-fit:cover;display:block;border-radius:inherit;}
 .offer-card--stacked .offer-card__media{flex:0 0 auto;width:100%;aspect-ratio:16/9;min-height:0;}
 .offer-card__media::after{content:"";position:absolute;inset:0;box-shadow:inset 0 0 0 1px rgba(15,23,42,.08);border-radius:12px;pointer-events:none;}
 .offer-card__media--empty{background:linear-gradient(135deg,#f3f4f6,#e5e7eb);color:#4b5563;}

--- a/assets/main.css
+++ b/assets/main.css
@@ -105,14 +105,23 @@ a{color:var(--primary);text-decoration:none;transition:var(--transition);}
 .offers-section-note{font-size:.85rem;color:#6d7686;}
 .dashboard-empty{margin:0;padding:1rem;border-radius:10px;background:#f7f9fd;border:1px dashed #c8d4e5;font-size:.9rem;color:#5b6575;}
 .offers-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:1rem;}
-.offer-card{background:#fff;border-radius:10px;box-shadow:0 4px 8px rgba(0,0,0,.08);padding:1rem;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease;margin-bottom:1rem;}
-.offer-card:hover{transform:translateY(-4px);box-shadow:0 6px 14px rgba(0,0,0,.12);}
-.offer-title{font-size:.95rem;font-weight:600;margin-bottom:.5rem;color:#222;}
-.offer-card h5{margin:0 0 .5rem;font-size:1.05rem;color:var(--primary);}
-.offer-details{font-size:.82rem;color:#666;line-height:1.4;margin-bottom:.75rem;}
-.offer-card p{margin:.25rem 0;font-size:.9rem;color:#555;}
-.offer-actions{display:flex;gap:.5rem;}
+.offer-card{background:#fff;border-radius:14px;box-shadow:0 4px 12px rgba(15,23,42,.08);padding:1rem;cursor:pointer;transition:transform .2s ease,box-shadow .2s ease;margin-bottom:1rem;display:flex;flex-direction:row;align-items:stretch;gap:1rem;overflow:hidden;}
+.offer-card:hover{transform:translateY(-4px);box-shadow:0 8px 22px rgba(15,23,42,.12);}
+.offer-card--stacked{flex-direction:column;}
+.offer-card--reverse{flex-direction:row-reverse;}
+.offer-card__media{position:relative;flex:0 0 180px;min-height:120px;border-radius:12px;overflow:hidden;background:linear-gradient(135deg,#eef4ff,#d9e6ff);display:flex;align-items:center;justify-content:center;color:#41557a;font-weight:600;font-size:.82rem;text-align:center;padding:.75rem;}
+.offer-card__media img{width:100%;height:100%;object-fit:cover;display:block;}
+.offer-card--stacked .offer-card__media{flex:0 0 auto;width:100%;aspect-ratio:16/9;min-height:0;}
+.offer-card__media::after{content:"";position:absolute;inset:0;box-shadow:inset 0 0 0 1px rgba(15,23,42,.08);border-radius:12px;pointer-events:none;}
+.offer-card__media--empty{background:linear-gradient(135deg,#f3f4f6,#e5e7eb);color:#4b5563;}
+.offer-card__body{flex:1;display:flex;flex-direction:column;gap:.65rem;min-width:0;}
+.offer-title{font-size:1rem;font-weight:600;margin:0;color:#1f2937;}
+.offer-card h5{margin:0;font-size:1.05rem;color:var(--primary);}
+.offer-details{font-size:.86rem;color:#4b5563;line-height:1.5;margin:0;display:flex;flex-direction:column;gap:.35rem;}
+.offer-card p{margin:0;font-size:.9rem;color:#4b5563;}
+.offer-actions{display:flex;gap:.5rem;flex-wrap:wrap;}
 .offer-actions.center{justify-content:center;}
+.offer-card__body .offer-actions{margin-top:auto;}
 .favorites-grid .offer-card{background:#e9f3ff;border:1px solid #c7ddf8;box-shadow:none;}
 .favorites-grid .offer-card:hover{box-shadow:0 6px 14px rgba(30,111,186,.2);transform:translateY(-2px);}
 .favorites-grid .offer-title{color:#1a4f85;}
@@ -138,10 +147,9 @@ body.home-page .offers-grid{
 body.home-page .offer-card{
   margin-bottom:0;
   height:100%;
-  display:flex;
-  flex-direction:column;
   border:1px solid #e5effa;
 }
+body.home-page .offer-card .offer-card__media{aspect-ratio:16/9;}
 
 body.home-page .offer-card .offer-actions{
   margin-top:auto;

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -684,6 +684,18 @@
   gap:1rem;
 }
 
+.offers-list .offer-card__media{
+  flex-basis:240px;
+  min-height:160px;
+}
+
+.offers-list .offer-card{align-items:stretch;}
+
+@media (max-width: 900px){
+  .offers-list .offer-card{flex-direction:column;}
+  .offers-list .offer-card__media{flex-basis:auto;width:100%;aspect-ratio:16/9;min-height:0;}
+}
+
 .offer-tags {
   margin-top:0.75rem;
   font-size:0.82rem;

--- a/details.html
+++ b/details.html
@@ -205,6 +205,13 @@
         </div>
 
         <aside class="plan-panel">
+          <div class="plan-preview-card">
+            <h3>Podgląd działki</h3>
+            <div class="plan-preview-media">
+              <img id="plotPreviewImage" class="plan-preview-image hidden" alt="Podgląd działki" loading="lazy">
+              <p id="plotPreviewPlaceholder" class="plan-preview-placeholder">Brak podglądu działki.</p>
+            </div>
+          </div>
           <div class="section-header">
             <h3>Plan zagospodarowania</h3>
           </div>

--- a/index.html
+++ b/index.html
@@ -749,6 +749,325 @@ window.showConfirmModal = showConfirmModal;
       return trimmed ? trimmed.toLowerCase() : null;
     };
 
+    const MAP_LAYER_BASE_URLS = {
+      lokalizacja: 'https://grunteo.s3.eu-west-3.amazonaws.com/Orto_Esri%2BGrunty/MARGE_Orto_Esri%2BGrunty',
+      media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri%2BGESUT/MARGE_Cyclosm_Esri%2BGESUT',
+      teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID%2BGrunty/MARGE_GRID%2BGrunty',
+      mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP%2BGrunty/MARGE_MPZP%2BGrunty',
+      mpzpskan: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP_rastrowe%2BGrunty/MARGE_MPZP_rastrowe%2BGrunty',
+      studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty',
+      uzytkigruntowe: 'https://grunteo.s3.eu-west-3.amazonaws.com/Uzytki%2BGrunty/MARGE_Uzytki%2BGrunty'
+    };
+
+    const PREVIEW_PRIORITY_KEYS = ['lokalizacja', 'teren', 'media', 'mpzp', 'mpzpskan', 'studium', 'uzytkigruntowe'];
+
+    const isUrlLike = (value) => typeof value === 'string'
+      && /^(https?:)?\/\//i.test(value.trim());
+
+    function resolveImageUrl(value) {
+      if (!value) return '';
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) return '';
+        if (isUrlLike(trimmed) || trimmed.startsWith('data:') || trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../')) {
+          return trimmed;
+        }
+        return '';
+      }
+      if (typeof value === 'object') {
+        const candidate = value.url ?? value.href ?? value.src ?? value.value ?? value.link;
+        if (typeof candidate === 'string') {
+          return resolveImageUrl(candidate);
+        }
+      }
+      return '';
+    }
+
+    function normalizeLayerKey(key) {
+      return String(key || '')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
+    }
+
+    function matchLayerKey(rawKey) {
+      const normalized = normalizeLayerKey(rawKey);
+      if (!normalized) return '';
+      const aliasMap = {
+        lokalizacja: ['lokalizacja', 'location', 'localization', 'orto', 'orthophoto', 'aerial'],
+        media: ['media', 'uzbrojenie', 'utilities', 'gesut', 'cyclosm'],
+        teren: ['teren', 'terrain', 'grid', 'ground', 'siatka'],
+        mpzp: ['mpzp', 'plan', 'zoning', 'miejscowyplan'],
+        mpzpskan: ['mpzpskan', 'mpzpraster', 'mpzprastrowe', 'mpzpscan', 'planraster', 'planrasterowy', 'planzdjecie', 'skanmpzp', 'scanplanu'],
+        studium: ['studium', 'study', 'uwarunkowania', 'kierunki'],
+        uzytkigruntowe: ['uzytkigruntowe', 'uzytki', 'uzytkirolne', 'landuse', 'landusage', 'pokryciegruntu']
+      };
+
+      for (const [target, aliases] of Object.entries(aliasMap)) {
+        if (normalized === target) return target;
+        for (const alias of aliases) {
+          if (normalized === alias || normalized.includes(alias) || alias.includes(normalized)) {
+            return target;
+          }
+        }
+      }
+      return '';
+    }
+
+    function extractLayerImages(source) {
+      const result = {};
+      if (!source) return result;
+      if (Array.isArray(source)) {
+        source.forEach(item => Object.assign(result, extractLayerImages(item)));
+        return result;
+      }
+      if (typeof source !== 'object') return result;
+
+      const candidateKey = source.key ?? source.type ?? source.layer ?? source.name ?? source.label;
+      const candidateUrl = source.url ?? source.href ?? source.src ?? source.value ?? source.link;
+      const matchedKey = matchLayerKey(candidateKey);
+      const resolvedUrl = resolveImageUrl(candidateUrl);
+      if (matchedKey && resolvedUrl) {
+        result[matchedKey] = resolvedUrl;
+      }
+
+      Object.entries(source).forEach(([key, value]) => {
+        const layerKey = matchLayerKey(key);
+        if (!layerKey) return;
+        const url = resolveImageUrl(value);
+        if (url) {
+          result[layerKey] = url;
+        }
+      });
+
+      return result;
+    }
+
+    function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '') {
+      const sources = [
+        plot.mapImages,
+        plot.mapTiles,
+        plot.mapLayers,
+        plot.planImages,
+        plot.planTiles,
+        plot.mapPreviews,
+        plot.mapGallery,
+        offer.mapImages,
+        offer.mapTiles,
+        offer.mapLayers,
+        offer.planImages,
+        offer.planTiles,
+        offer.mapPreviews,
+        offer.mapGallery
+      ];
+
+      const result = {};
+      sources.forEach(source => Object.assign(result, extractLayerImages(source)));
+
+      const directFields = {
+        lokalizacja: [
+          plot.mapLokalizacja,
+          plot.lokalizacjaMap,
+          plot.mapLocation,
+          plot.locationMap,
+          offer.mapLokalizacja,
+          offer.lokalizacjaMap,
+          offer.mapLocation,
+          offer.locationMap
+        ],
+        media: [
+          plot.mapMedia,
+          plot.mediaMap,
+          plot.mapUzbrojenie,
+          plot.mapGesut,
+          offer.mapMedia,
+          offer.mediaMap,
+          offer.mapUzbrojenie,
+          offer.mapGesut
+        ],
+        teren: [
+          plot.mapTeren,
+          plot.terrainMap,
+          plot.mapGrid,
+          plot.gridMap,
+          offer.mapTeren,
+          offer.terrainMap,
+          offer.mapGrid,
+          offer.gridMap
+        ],
+        mpzp: [
+          plot.mapMpzp,
+          plot.mapMPZP,
+          plot.mpzpMap,
+          plot.planMap,
+          offer.mapMpzp,
+          offer.mapMPZP,
+          offer.mpzpMap,
+          offer.planMap
+        ],
+        mpzpskan: [
+          plot.mapMpzpSkan,
+          plot.mapMpzpScan,
+          plot.mapMpzpRaster,
+          plot.mapMpzpRastrowe,
+          plot.mapMPZPSkan,
+          plot.mapMPZPScan,
+          plot.mapMPZPRaster,
+          plot.mpzpSkan,
+          plot.mpzpScan,
+          plot.mpzpRaster,
+          plot.planRaster,
+          plot.planScan,
+          plot.planSkan,
+          offer.mapMpzpSkan,
+          offer.mapMpzpScan,
+          offer.mapMpzpRaster,
+          offer.mapMpzpRastrowe,
+          offer.mapMPZPSkan,
+          offer.mapMPZPScan,
+          offer.mapMPZPRaster,
+          offer.mpzpSkan,
+          offer.mpzpScan,
+          offer.mpzpRaster,
+          offer.planRaster,
+          offer.planScan,
+          offer.planSkan
+        ],
+        studium: [
+          plot.mapStudium,
+          plot.studiumMap,
+          offer.mapStudium,
+          offer.studiumMap
+        ],
+        uzytkigruntowe: [
+          plot.mapUzytki,
+          plot.mapUzytkiGruntowe,
+          plot.mapUzytkiGruntu,
+          plot.mapUzytkiRolne,
+          plot.uzytkiMap,
+          plot.uzytkiGruntoweMap,
+          plot.mapLandUse,
+          plot.landUseMap,
+          plot.landuseMap,
+          plot.mapLandcover,
+          offer.mapUzytki,
+          offer.mapUzytkiGruntowe,
+          offer.mapUzytkiGruntu,
+          offer.mapUzytkiRolne,
+          offer.uzytkiMap,
+          offer.uzytkiGruntoweMap,
+          offer.mapLandUse,
+          offer.landUseMap,
+          offer.landuseMap,
+          offer.mapLandcover
+        ]
+      };
+
+      Object.entries(directFields).forEach(([key, values]) => {
+        if (result[key]) return;
+        for (const value of values) {
+          const url = resolveImageUrl(value);
+          if (url) {
+            result[key] = url;
+            break;
+          }
+        }
+      });
+
+      const candidateIds = [
+        typeof fallbackId === 'string' ? fallbackId.trim() : fallbackId,
+        plot.mapImageId,
+        plot.mapId,
+        plot.imageId,
+        plot.imagesId,
+        plot.plotId,
+        plot.Id,
+        plot.id,
+        offer.mapImageId,
+        offer.mapId,
+        offer.plotId,
+        offer.Id,
+        offer.id
+      ];
+
+      const trimmedId = candidateIds
+        .map(value => {
+          if (value === undefined || value === null) return '';
+          const text = typeof value === 'string' ? value : String(value);
+          return text.trim();
+        })
+        .find(value => value && /^[A-Za-z0-9_-]+$/.test(value)) || '';
+
+      const indexNumber = Number.isFinite(plotIndex) && plotIndex >= 0 ? plotIndex : 0;
+      const indexSuffix = `_${String(indexNumber).padStart(3, '0')}`;
+
+      if (trimmedId) {
+        const expectedSuffix = `_${trimmedId}${indexSuffix}.png`;
+        Object.entries(MAP_LAYER_BASE_URLS).forEach(([key, baseUrl]) => {
+          const expectedUrl = `${baseUrl}${expectedSuffix}`;
+          const currentUrl = typeof result[key] === 'string' ? result[key].trim() : '';
+          if (!currentUrl) {
+            result[key] = expectedUrl;
+            return;
+          }
+          const normalizedCurrent = currentUrl.split('?')[0];
+          if (!normalizedCurrent.endsWith(expectedSuffix)) {
+            result[key] = expectedUrl;
+          }
+        });
+      }
+
+      return result;
+    }
+
+    function getPlotPreviewImage(plot, offer, plotIndex, fallbackId) {
+      const images = collectMapImages(plot, offer, plotIndex, fallbackId);
+      for (const key of PREVIEW_PRIORITY_KEYS) {
+        const url = images[key];
+        if (url) return url;
+      }
+
+      const miscCandidates = [
+        plot?.previewImage,
+        plot?.previewUrl,
+        plot?.thumbnail,
+        plot?.image,
+        plot?.imageUrl,
+        offer?.previewImage,
+        offer?.previewUrl,
+        offer?.thumbnail,
+        offer?.image,
+        offer?.imageUrl
+      ];
+
+      for (const candidate of miscCandidates) {
+        const url = resolveImageUrl(candidate);
+        if (url) return url;
+      }
+
+      const genericSources = [plot?.mapImage, plot?.mapPreview, offer?.mapImage, offer?.mapPreview];
+      for (const source of genericSources) {
+        if (!source) continue;
+        if (typeof source === 'string') {
+          const url = resolveImageUrl(source);
+          if (url) return url;
+        } else if (typeof source === 'object') {
+          const extracted = extractLayerImages(source);
+          for (const key of PREVIEW_PRIORITY_KEYS) {
+            const url = extracted[key];
+            if (url) return url;
+          }
+          const values = Object.values(source)
+            .map(resolveImageUrl)
+            .find(Boolean);
+          if (values) return values;
+        }
+      }
+
+      return '';
+    }
+
     function buildOwnerLookupKeys(email, uid) {
       const keys = new Set();
       const normalizedEmail = normalizeEmail(email);
@@ -1035,26 +1354,30 @@ window.showConfirmModal = showConfirmModal;
 
           activePlots.forEach(({ plot, originalIndex }, visibleIdx) => {
             const el = document.createElement('div');
-            el.className = 'offer-card';
+            el.className = 'offer-card offer-card--stacked';
 
             const price = Number(plot.price || 0);
             const area = Number(plot.pow_dzialki_m2_uldk || 0);
-              const ppm2 = price && area ? Math.round(price / area) : 0;
-              const city = offer.city || 'Nie podano';
-              const phone = offer.phone || 'Nie podano';
-              const title = plot.Id || `Działka ${visibleIdx + 1}`;
-              const safeTitle = (title || '').replace(/'/g, "\'");
-              const detailsUrl = `details.html?id=${offerId}&plot=${originalIndex}`;
+            const ppm2 = price && area ? Math.round(price / area) : 0;
+            const city = offer.city || 'Nie podano';
+            const phone = offer.phone || 'Nie podano';
+            const title = plot.Id || `Działka ${visibleIdx + 1}`;
+            const safeTitle = (title || '').replace(/'/g, "\'");
+            const detailsUrl = `details.html?id=${offerId}&plot=${originalIndex}`;
+            const previewUrl = getPlotPreviewImage(plot, offer, originalIndex, offerId);
+            const previewMarkup = previewUrl
+              ? `<div class="offer-card__media"><img src="${previewUrl}" alt="Podgląd działki" loading="lazy"></div>`
+              : `<div class="offer-card__media offer-card__media--empty">Brak podglądu</div>`;
 
-              el.innerHTML = `
+            el.innerHTML = `
+              ${previewMarkup}
+              <div class="offer-card__body">
                 <h3 class="offer-title">${title}</h3>
                 <div class="offer-details">
                   <p><strong>Lokalizacja:</strong> ${city}</p>
                   <p><strong>Telefon:</strong> ${phone}</p>
                   ${area ? `<p><strong>Powierzchnia:</strong> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
-                  ${price ? `<p><strong>Cena całkowita:</strong> ${price.toLocaleString('pl-PL')} zł
-                    ${ppm2 ? `<span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2.toLocaleString('pl-PL')} zł/m²</span>` : ''}
-                  </p>` : ''}
+                  ${price ? `<p><strong>Cena całkowita:</strong> ${price.toLocaleString('pl-PL')} zł${ppm2 ? `<span style="color:#5b6475;font-size:.82em;margin-left:6px;">${ppm2.toLocaleString('pl-PL')} zł/m²</span>` : ''}</p>` : ''}
                 </div>
                 <div class="offer-actions">
                   <a class="btn btn-accent btn-sm" href="${detailsUrl}">
@@ -1067,16 +1390,17 @@ window.showConfirmModal = showConfirmModal;
                     <i class="fas fa-trash"></i> Usuń
                   </button>
                 </div>
-              `;
+              </div>
+            `;
 
-              el.addEventListener('click', (event) => {
-                if (event.target.closest('.offer-actions')) return;
-                if (window.focusOfferOnMap) window.focusOfferOnMap(offerId, originalIndex);
-              });
-
-              ownedOffers.appendChild(el);
-              hasOwned = true;
+            el.addEventListener('click', (event) => {
+              if (event.target.closest('.offer-actions')) return;
+              if (window.focusOfferOnMap) window.focusOfferOnMap(offerId, originalIndex);
             });
+
+            ownedOffers.appendChild(el);
+            hasOwned = true;
+          });
         });
 
         if (!hasOwned) {
@@ -1157,24 +1481,31 @@ window.showConfirmModal = showConfirmModal;
       const detailsUrl = offerId ? `details.html?id=${offerId}&plot=${plotIndex}` : '#';
 
       const card = document.createElement('div');
-      card.className = 'offer-card';
+      card.className = 'offer-card offer-card--stacked';
+      const previewUrl = getPlotPreviewImage(favorite, favorite, plotIndex, favorite?.offerId || favorite?.plotId || title);
+      const previewMarkup = previewUrl
+        ? `<div class="offer-card__media"><img src="${previewUrl}" alt="Podgląd działki" loading="lazy"></div>`
+        : `<div class="offer-card__media offer-card__media--empty">Brak podglądu</div>`;
       card.innerHTML = `
-        <h3 class="offer-title">${title}</h3>
-        <div class="offer-details">
-          <p><strong>Lokalizacja:</strong> ${city}</p>
-          ${favorite?.contactName ? `<p><strong>Kontakt:</strong> ${favorite.contactName}</p>` : ''}
-          ${favorite?.contactPhone ? `<p><strong>Telefon:</strong> ${favorite.contactPhone}</p>` : ''}
-          ${areaText ? `<p><strong>Powierzchnia:</strong> ${areaText}</p>` : ''}
-          ${priceText ? `<p><strong>Cena:</strong> ${priceText}${ppmText ? ` <span class="favorite-ppm">(${ppmText})</span>` : ''}</p>` : ''}
-          ${savedAtText ? `<p class="favorite-meta"><strong>Zapisano:</strong> ${savedAtText}</p>` : ''}
-        </div>
-        <div class="offer-actions">
-          <a class="btn btn-accent btn-sm" ${offerId ? `href="${detailsUrl}"` : 'href="#" aria-disabled="true" style="pointer-events:none;opacity:.6;"'}>
-            <i class="fas fa-info-circle"></i> Szczegóły
-          </a>
-          <button class="btn btn-secondary btn-sm favorite-remove" type="button">
-            <i class="fas fa-times"></i> Usuń
-          </button>
+        ${previewMarkup}
+        <div class="offer-card__body">
+          <h3 class="offer-title">${title}</h3>
+          <div class="offer-details">
+            <p><strong>Lokalizacja:</strong> ${city}</p>
+            ${favorite?.contactName ? `<p><strong>Kontakt:</strong> ${favorite.contactName}</p>` : ''}
+            ${favorite?.contactPhone ? `<p><strong>Telefon:</strong> ${favorite.contactPhone}</p>` : ''}
+            ${areaText ? `<p><strong>Powierzchnia:</strong> ${areaText}</p>` : ''}
+            ${priceText ? `<p><strong>Cena:</strong> ${priceText}${ppmText ? ` <span class="favorite-ppm">(${ppmText})</span>` : ''}</p>` : ''}
+            ${savedAtText ? `<p class="favorite-meta"><strong>Zapisano:</strong> ${savedAtText}</p>` : ''}
+          </div>
+          <div class="offer-actions">
+            <a class="btn btn-accent btn-sm" ${offerId ? `href="${detailsUrl}"` : 'href="#" aria-disabled="true" style="pointer-events:none;opacity:.6;"'}>
+              <i class="fas fa-info-circle"></i> Szczegóły
+            </a>
+            <button class="btn btn-secondary btn-sm favorite-remove" type="button">
+              <i class="fas fa-times"></i> Usuń
+            </button>
+          </div>
         </div>
       `;
 

--- a/oferty.html
+++ b/oferty.html
@@ -572,6 +572,324 @@ window.showConfirmModal = showConfirmModal;
     }
   };
 
+  const MAP_LAYER_BASE_URLS = {
+    lokalizacja: 'https://grunteo.s3.eu-west-3.amazonaws.com/Orto_Esri%2BGrunty/MARGE_Orto_Esri%2BGrunty',
+    media: 'https://grunteo.s3.eu-west-3.amazonaws.com/Cyclosm_Esri%2BGESUT/MARGE_Cyclosm_Esri%2BGESUT',
+    teren: 'https://grunteo.s3.eu-west-3.amazonaws.com/GRID%2BGrunty/MARGE_GRID%2BGrunty',
+    mpzp: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP%2BGrunty/MARGE_MPZP%2BGrunty',
+    mpzpskan: 'https://grunteo.s3.eu-west-3.amazonaws.com/MPZP_rastrowe%2BGrunty/MARGE_MPZP_rastrowe%2BGrunty',
+    studium: 'https://grunteo.s3.eu-west-3.amazonaws.com/Studium%2BGrunty/MARGE_Studium%2BGrunty',
+    uzytkigruntowe: 'https://grunteo.s3.eu-west-3.amazonaws.com/Uzytki%2BGrunty/MARGE_Uzytki%2BGrunty'
+  };
+
+  const PREVIEW_PRIORITY_KEYS = ['lokalizacja', 'teren', 'media', 'mpzp', 'mpzpskan', 'studium', 'uzytkigruntowe'];
+
+  const isUrlLike = (value) => typeof value === 'string' && /^(https?:)?\/\//i.test(value.trim());
+
+  function resolveImageUrl(value) {
+    if (!value) return '';
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return '';
+      if (isUrlLike(trimmed) || trimmed.startsWith('data:') || trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../')) {
+        return trimmed;
+      }
+      return '';
+    }
+    if (typeof value === 'object') {
+      const candidate = value.url ?? value.href ?? value.src ?? value.value ?? value.link;
+      if (typeof candidate === 'string') {
+        return resolveImageUrl(candidate);
+      }
+    }
+    return '';
+  }
+
+  function normalizeLayerKey(key) {
+    return String(key || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '');
+  }
+
+  function matchLayerKey(rawKey) {
+    const normalized = normalizeLayerKey(rawKey);
+    if (!normalized) return '';
+    const aliasMap = {
+      lokalizacja: ['lokalizacja', 'location', 'localization', 'orto', 'orthophoto', 'aerial'],
+      media: ['media', 'uzbrojenie', 'utilities', 'gesut', 'cyclosm'],
+      teren: ['teren', 'terrain', 'grid', 'ground', 'siatka'],
+      mpzp: ['mpzp', 'plan', 'zoning', 'miejscowyplan'],
+      mpzpskan: ['mpzpskan', 'mpzpraster', 'mpzprastrowe', 'mpzpscan', 'planraster', 'planrasterowy', 'planzdjecie', 'skanmpzp', 'scanplanu'],
+      studium: ['studium', 'study', 'uwarunkowania', 'kierunki'],
+      uzytkigruntowe: ['uzytkigruntowe', 'uzytki', 'uzytkirolne', 'landuse', 'landusage', 'pokryciegruntu']
+    };
+
+    for (const [target, aliases] of Object.entries(aliasMap)) {
+      if (normalized === target) return target;
+      for (const alias of aliases) {
+        if (normalized === alias || normalized.includes(alias) || alias.includes(normalized)) {
+          return target;
+        }
+      }
+    }
+    return '';
+  }
+
+  function extractLayerImages(source) {
+    const result = {};
+    if (!source) return result;
+    if (Array.isArray(source)) {
+      source.forEach(item => Object.assign(result, extractLayerImages(item)));
+      return result;
+    }
+    if (typeof source !== 'object') return result;
+
+    const candidateKey = source.key ?? source.type ?? source.layer ?? source.name ?? source.label;
+    const candidateUrl = source.url ?? source.href ?? source.src ?? source.value ?? source.link;
+    const matchedKey = matchLayerKey(candidateKey);
+    const resolvedUrl = resolveImageUrl(candidateUrl);
+    if (matchedKey && resolvedUrl) {
+      result[matchedKey] = resolvedUrl;
+    }
+
+    Object.entries(source).forEach(([key, value]) => {
+      const layerKey = matchLayerKey(key);
+      if (!layerKey) return;
+      const url = resolveImageUrl(value);
+      if (url) {
+        result[layerKey] = url;
+      }
+    });
+
+    return result;
+  }
+
+  function collectMapImages(plot = {}, offer = {}, plotIndex = 0, fallbackId = '') {
+    const sources = [
+      plot.mapImages,
+      plot.mapTiles,
+      plot.mapLayers,
+      plot.planImages,
+      plot.planTiles,
+      plot.mapPreviews,
+      plot.mapGallery,
+      offer.mapImages,
+      offer.mapTiles,
+      offer.mapLayers,
+      offer.planImages,
+      offer.planTiles,
+      offer.mapPreviews,
+      offer.mapGallery
+    ];
+
+    const result = {};
+    sources.forEach(source => Object.assign(result, extractLayerImages(source)));
+
+    const directFields = {
+      lokalizacja: [
+        plot.mapLokalizacja,
+        plot.lokalizacjaMap,
+        plot.mapLocation,
+        plot.locationMap,
+        offer.mapLokalizacja,
+        offer.lokalizacjaMap,
+        offer.mapLocation,
+        offer.locationMap
+      ],
+      media: [
+        plot.mapMedia,
+        plot.mediaMap,
+        plot.mapUzbrojenie,
+        plot.mapGesut,
+        offer.mapMedia,
+        offer.mediaMap,
+        offer.mapUzbrojenie,
+        offer.mapGesut
+      ],
+      teren: [
+        plot.mapTeren,
+        plot.terrainMap,
+        plot.mapGrid,
+        plot.gridMap,
+        offer.mapTeren,
+        offer.terrainMap,
+        offer.mapGrid,
+        offer.gridMap
+      ],
+      mpzp: [
+        plot.mapMpzp,
+        plot.mapMPZP,
+        plot.mpzpMap,
+        plot.planMap,
+        offer.mapMpzp,
+        offer.mapMPZP,
+        offer.mpzpMap,
+        offer.planMap
+      ],
+      mpzpskan: [
+        plot.mapMpzpSkan,
+        plot.mapMpzpScan,
+        plot.mapMpzpRaster,
+        plot.mapMpzpRastrowe,
+        plot.mapMPZPSkan,
+        plot.mapMPZPScan,
+        plot.mapMPZPRaster,
+        plot.mpzpSkan,
+        plot.mpzpScan,
+        plot.mpzpRaster,
+        plot.planRaster,
+        plot.planScan,
+        plot.planSkan,
+        offer.mapMpzpSkan,
+        offer.mapMpzpScan,
+        offer.mapMpzpRaster,
+        offer.mapMpzpRastrowe,
+        offer.mapMPZPSkan,
+        offer.mapMPZPScan,
+        offer.mapMPZPRaster,
+        offer.mpzpSkan,
+        offer.mpzpScan,
+        offer.mpzpRaster,
+        offer.planRaster,
+        offer.planScan,
+        offer.planSkan
+      ],
+      studium: [
+        plot.mapStudium,
+        plot.studiumMap,
+        offer.mapStudium,
+        offer.studiumMap
+      ],
+      uzytkigruntowe: [
+        plot.mapUzytki,
+        plot.mapUzytkiGruntowe,
+        plot.mapUzytkiGruntu,
+        plot.mapUzytkiRolne,
+        plot.uzytkiMap,
+        plot.uzytkiGruntoweMap,
+        plot.mapLandUse,
+        plot.landUseMap,
+        plot.landuseMap,
+        plot.mapLandcover,
+        offer.mapUzytki,
+        offer.mapUzytkiGruntowe,
+        offer.mapUzytkiGruntu,
+        offer.mapUzytkiRolne,
+        offer.uzytkiMap,
+        offer.uzytkiGruntoweMap,
+        offer.mapLandUse,
+        offer.landUseMap,
+        offer.landuseMap,
+        offer.mapLandcover
+      ]
+    };
+
+    Object.entries(directFields).forEach(([key, values]) => {
+      if (result[key]) return;
+      for (const value of values) {
+        const url = resolveImageUrl(value);
+        if (url) {
+          result[key] = url;
+          break;
+        }
+      }
+    });
+
+    const candidateIds = [
+      typeof fallbackId === 'string' ? fallbackId.trim() : fallbackId,
+      plot.mapImageId,
+      plot.mapId,
+      plot.imageId,
+      plot.imagesId,
+      plot.plotId,
+      plot.Id,
+      plot.id,
+      offer.mapImageId,
+      offer.mapId,
+      offer.plotId,
+      offer.Id,
+      offer.id
+    ];
+
+    const trimmedId = candidateIds
+      .map(value => {
+        if (value === undefined || value === null) return '';
+        const text = typeof value === 'string' ? value : String(value);
+        return text.trim();
+      })
+      .find(value => value && /^[A-Za-z0-9_-]+$/.test(value)) || '';
+
+    const indexNumber = Number.isFinite(plotIndex) && plotIndex >= 0 ? plotIndex : 0;
+    const indexSuffix = `_${String(indexNumber).padStart(3, '0')}`;
+
+    if (trimmedId) {
+      const expectedSuffix = `_${trimmedId}${indexSuffix}.png`;
+      Object.entries(MAP_LAYER_BASE_URLS).forEach(([key, baseUrl]) => {
+        const expectedUrl = `${baseUrl}${expectedSuffix}`;
+        const currentUrl = typeof result[key] === 'string' ? result[key].trim() : '';
+        if (!currentUrl) {
+          result[key] = expectedUrl;
+          return;
+        }
+        const normalizedCurrent = currentUrl.split('?')[0];
+        if (!normalizedCurrent.endsWith(expectedSuffix)) {
+          result[key] = expectedUrl;
+        }
+      });
+    }
+
+    return result;
+  }
+
+  function getPlotPreviewImage(plot, offer, plotIndex, fallbackId) {
+    const images = collectMapImages(plot, offer, plotIndex, fallbackId);
+    for (const key of PREVIEW_PRIORITY_KEYS) {
+      const url = images[key];
+      if (url) return url;
+    }
+
+    const miscCandidates = [
+      plot?.previewImage,
+      plot?.previewUrl,
+      plot?.thumbnail,
+      plot?.image,
+      plot?.imageUrl,
+      offer?.previewImage,
+      offer?.previewUrl,
+      offer?.thumbnail,
+      offer?.image,
+      offer?.imageUrl
+    ];
+
+    for (const candidate of miscCandidates) {
+      const url = resolveImageUrl(candidate);
+      if (url) return url;
+    }
+
+    const genericSources = [plot?.mapImage, plot?.mapPreview, offer?.mapImage, offer?.mapPreview];
+    for (const source of genericSources) {
+      if (!source) continue;
+      if (typeof source === 'string') {
+        const url = resolveImageUrl(source);
+        if (url) return url;
+      } else if (typeof source === 'object') {
+        const extracted = extractLayerImages(source);
+        for (const key of PREVIEW_PRIORITY_KEYS) {
+          const url = extracted[key];
+          if (url) return url;
+        }
+        const values = Object.values(source)
+          .map(resolveImageUrl)
+          .find(Boolean);
+        if (values) return values;
+      }
+    }
+
+    return '';
+  }
+
   const VORONOI_LABEL_SIZE = {
     width: 160,
     height: 64
@@ -4806,7 +5124,7 @@ window.showConfirmModal = showConfirmModal;
 
     sortedOffers.forEach(o => {
       const card = document.createElement("div");
-      card.className = "offer-card";
+      card.className = "offer-card offer-card--reverse";
       const price = Number(o.plot.price || 0);
       const area  = Number(o.plot.pow_dzialki_m2_uldk || 0);
       const ppm2  = price && area ? (price/area).toFixed(2) : "0.00";
@@ -4815,25 +5133,32 @@ window.showConfirmModal = showConfirmModal;
       const tagsMarkup = tagList.length
         ? `<div class="offer-tags">${tagList.map(tag => formatTagLabel(tag)).join(' ')}</div>`
         : '';
+      const previewUrl = getPlotPreviewImage(o.plot || {}, o.data || {}, o.index, o.id);
+      const previewMarkup = previewUrl
+        ? `<div class="offer-card__media"><img src="${previewUrl}" alt="Podgląd działki" loading="lazy"></div>`
+        : `<div class="offer-card__media offer-card__media--empty">Brak podglądu</div>`;
 
       card.innerHTML = `
-        <h5>${o.plot.Id || "Brak identyfikatora"}</h5>
-        ${o.data.city ? `<p><b>Miejscowość:</b> ${o.data.city}</p>` : ""}
-        ${o.data.firstName ? `<p><b>Imię:</b> ${o.data.firstName}</p>` : ""}
-        <p><b>Telefon:</b> ${formatPhone(o.data.phone) || "-"}</p>
-        ${price ? `<p><b>Cena całkowita:</b> ${price.toLocaleString('pl-PL')} zł <span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2} zł/m²</span></p>` : ""}
-        ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ""}
-        ${tagsMarkup}
-        <div class="offer-actions center">
-          <a
-            class="btn btn-accent btn-sm"
-            href="${detailsUrl}"
-            data-preserve-map-state="true"
-            ${o.id ? `data-offer-id="${o.id}"` : ''}
-            ${Number.isInteger(o.index) ? `data-plot-index="${o.index}"` : ''}
-          >
-            <i class="fas fa-info-circle"></i> Szczegóły
-          </a>
+        ${previewMarkup}
+        <div class="offer-card__body">
+          <h5>${o.plot.Id || "Brak identyfikatora"}</h5>
+          ${o.data.city ? `<p><b>Miejscowość:</b> ${o.data.city}</p>` : ""}
+          ${o.data.firstName ? `<p><b>Imię:</b> ${o.data.firstName}</p>` : ""}
+          <p><b>Telefon:</b> ${formatPhone(o.data.phone) || "-"}</p>
+          ${price ? `<p><b>Cena całkowita:</b> ${price.toLocaleString('pl-PL')} zł <span style="color:#5b6475;font-size:.85em;margin-left:5px;">${ppm2} zł/m²</span></p>` : ""}
+          ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ""}
+          ${tagsMarkup}
+          <div class="offer-actions center">
+            <a
+              class="btn btn-accent btn-sm"
+              href="${detailsUrl}"
+              data-preserve-map-state="true"
+              ${o.id ? `data-offer-id="${o.id}"` : ''}
+              ${Number.isInteger(o.index) ? `data-plot-index="${o.index}"` : ''}
+            >
+              <i class="fas fa-info-circle"></i> Szczegóły
+            </a>
+          </div>
         </div>
       `;
 

--- a/oferty.html
+++ b/oferty.html
@@ -5782,33 +5782,41 @@ async function loadUserOffers(email, uid) {
         }
         const locationLabel = pickDisplayValue(locationSources, 'Nie podano');
 
+        const previewUrl = getPlotPreviewImage(plot || {}, offer || {}, originalIndex, offerId);
+        const previewMarkup = previewUrl
+          ? `<div class="offer-card__media"><img src="${previewUrl}" alt="Podgląd działki" loading="lazy"></div>`
+          : `<div class="offer-card__media offer-card__media--empty">Brak podglądu</div>`;
+
         const el = document.createElement('div');
         el.className = 'offer-card';
         el.innerHTML = `
-          <h3 class="offer-title">${plot.Id || `Działka ${i+1}`}</h3>
-          <div class="offer-details">
-            <p><strong>Lokalizacja:</strong> ${locationLabel}</p>
-            ${area  ? `<p><strong>Powierzchnia:</strong> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
-            ${price ? `<p><strong>Cena całkowita:</strong> ${price.toLocaleString('pl-PL')} zł
-              ${ppm2 ? `<span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2.toLocaleString('pl-PL')} zł/m²</span>`:''}
-            </p>` : ''}
-          </div>
-          <div class="offer-actions">
-            <a
-              class="btn btn-accent btn-sm"
-              href="${detailsUrl}"
-              data-preserve-map-state="true"
-              ${offerId ? `data-offer-id="${offerId}"` : ''}
-              ${Number.isInteger(originalIndex) ? `data-plot-index="${originalIndex}"` : ''}
-            >
-              <i class="fas fa-info-circle"></i> Szczegóły
-            </a>
-            <button class="btn btn-primary btn-sm" onclick="window.location.href='edit.html?id=${offerId}&plot=${originalIndex}'">
-              <i class="fas fa-edit"></i> Edytuj
-            </button>
-            <button class="btn btn-secondary btn-sm" onclick="deletePlot && deletePlot('${offerId}', ${originalIndex}, '${(plot.Id||`Działka ${i+1}`).replace(/'/g,"\\'")}')">
-              <i class="fas fa-trash"></i> Usuń
-            </button>
+          ${previewMarkup}
+          <div class="offer-card__body">
+            <h3 class="offer-title">${plot.Id || `Działka ${i+1}`}</h3>
+            <div class="offer-details">
+              <p><strong>Lokalizacja:</strong> ${locationLabel}</p>
+              ${area  ? `<p><strong>Powierzchnia:</strong> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
+              ${price ? `<p><strong>Cena całkowita:</strong> ${price.toLocaleString('pl-PL')} zł
+                ${ppm2 ? `<span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2.toLocaleString('pl-PL')} zł/m²</span>`:''}
+              </p>` : ''}
+            </div>
+            <div class="offer-actions">
+              <a
+                class="btn btn-accent btn-sm"
+                href="${detailsUrl}"
+                data-preserve-map-state="true"
+                ${offerId ? `data-offer-id="${offerId}"` : ''}
+                ${Number.isInteger(originalIndex) ? `data-plot-index="${originalIndex}"` : ''}
+              >
+                <i class="fas fa-info-circle"></i> Szczegóły
+              </a>
+              <button class="btn btn-primary btn-sm" onclick="window.location.href='edit.html?id=${offerId}&plot=${originalIndex}'">
+                <i class="fas fa-edit"></i> Edytuj
+              </button>
+              <button class="btn btn-secondary btn-sm" onclick="deletePlot && deletePlot('${offerId}', ${originalIndex}, '${(plot.Id||`Działka ${i+1}`).replace(/'/g,"\\'")}')">
+                <i class="fas fa-trash"></i> Usuń
+              </button>
+            </div>
           </div>
         `;
         el.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- add shared helper functions to resolve map preview images for listings
- embed preview thumbnails into dashboard, favourites, and offers list cards with refreshed styling
- show a dedicated plot preview card on the offer details page with matching styling

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e1b42895cc832b8e07656e1cef340b