### PR TITLE
Round plot areas to tenths and restore valuation markers

### DIFF
--- a/assets/property-common.js
+++ b/assets/property-common.js
@@ -90,9 +90,39 @@ export function formatCurrency(value) {
   return formatted ? `${formatted} zł` : null;
 }
 
+export function roundAreaValue(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  let number;
+  if (typeof value === "number") {
+    number = value;
+  } else {
+    number = parseNumberFromText(value);
+  }
+
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+
+  const rounded = Math.round(number * 10) / 10;
+  if (!Number.isFinite(rounded) || rounded <= 0) {
+    return null;
+  }
+  return rounded;
+}
+
 export function formatArea(value) {
-  const formatted = formatNumber(value);
-  return formatted ? `${formatted} m²` : null;
+  const rounded = roundAreaValue(value);
+  if (!Number.isFinite(rounded)) {
+    return null;
+  }
+  const formatted = new Intl.NumberFormat("pl-PL", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+  }).format(rounded);
+  return `${formatted} m²`;
 }
 
 export function toDate(value) {

--- a/index.html
+++ b/index.html
@@ -743,6 +743,26 @@ window.showConfirmModal = showConfirmModal;
 
     const formatNumberPL = (value) => Number.isFinite(value) ? value.toLocaleString('pl-PL') : null;
 
+    const roundAreaValue = (value) => {
+      const number = Number(value);
+      if (!Number.isFinite(number) || number <= 0) {
+        return null;
+      }
+      const rounded = Math.round(number * 10) / 10;
+      return rounded > 0 ? rounded : null;
+    };
+
+    const formatAreaValue = (value) => {
+      const rounded = roundAreaValue(value);
+      if (!Number.isFinite(rounded)) {
+        return null;
+      }
+      return rounded.toLocaleString('pl-PL', {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1
+      });
+    };
+
     const normalizeEmail = (value) => {
       if (typeof value !== 'string') return null;
       const trimmed = value.trim();
@@ -1357,8 +1377,9 @@ window.showConfirmModal = showConfirmModal;
             el.className = 'offer-card offer-card--stacked';
 
             const price = Number(plot.price || 0);
-            const area = Number(plot.pow_dzialki_m2_uldk || 0);
-            const ppm2 = price && area ? Math.round(price / area) : 0;
+            const areaRaw = Number(plot.pow_dzialki_m2_uldk || 0);
+            const areaDisplay = formatAreaValue(areaRaw);
+            const ppm2 = price && areaRaw > 0 ? Math.round(price / areaRaw) : 0;
             const city = offer.city || 'Nie podano';
             const phone = offer.phone || 'Nie podano';
             const title = plot.Id || `Działka ${visibleIdx + 1}`;
@@ -1376,7 +1397,7 @@ window.showConfirmModal = showConfirmModal;
                 <div class="offer-details">
                   <p><strong>Lokalizacja:</strong> ${city}</p>
                   <p><strong>Telefon:</strong> ${phone}</p>
-                  ${area ? `<p><strong>Powierzchnia:</strong> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
+                  ${areaDisplay ? `<p><strong>Powierzchnia:</strong> ${areaDisplay} m²</p>` : ''}
                   ${price ? `<p><strong>Cena całkowita:</strong> ${price.toLocaleString('pl-PL')} zł${ppm2 ? `<span style="color:#5b6475;font-size:.82em;margin-left:6px;">${ppm2.toLocaleString('pl-PL')} zł/m²</span>` : ''}</p>` : ''}
                 </div>
                 <div class="offer-actions">
@@ -1471,11 +1492,12 @@ window.showConfirmModal = showConfirmModal;
       const plotIndex = Number.isFinite(favorite?.plotIndex) ? favorite.plotIndex : Number(favorite?.plotIndex) || 0;
       const title = favorite?.title || (favorite?.plotNumber ? `Działka ${favorite.plotNumber}` : `Działka ${plotIndex + 1}`);
       const city = favorite?.city || 'Nie podano';
-      const area = Number(favorite?.area || 0);
+      const areaRaw = Number(favorite?.area || 0);
       const price = Number(favorite?.price || 0);
-      const areaText = Number.isFinite(area) && area > 0 ? `${area.toLocaleString('pl-PL')} m²` : '';
+      const areaDisplay = formatAreaValue(areaRaw);
+      const areaText = areaDisplay ? `${areaDisplay} m²` : '';
       const priceText = Number.isFinite(price) && price > 0 ? `${price.toLocaleString('pl-PL')} zł` : '';
-      const ppm = Number.isFinite(price) && Number.isFinite(area) && area > 0 ? Math.round(price / area) : null;
+      const ppm = Number.isFinite(price) && Number.isFinite(areaRaw) && areaRaw > 0 ? Math.round(price / areaRaw) : null;
       const ppmText = Number.isFinite(ppm) ? `${ppm.toLocaleString('pl-PL')} zł/m²` : '';
       const savedAtText = formatDateTime(favorite?.savedAt);
       const detailsUrl = offerId ? `details.html?id=${offerId}&plot=${plotIndex}` : '#';

--- a/oferty.html
+++ b/oferty.html
@@ -2770,10 +2770,31 @@ window.showConfirmModal = showConfirmModal;
     return fallback;
   }
 
+  function roundAreaValue(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number) || number <= 0) {
+      return null;
+    }
+    const rounded = Math.round(number * 10) / 10;
+    return rounded > 0 ? rounded : null;
+  }
+
+  function formatAreaValue(value) {
+    const rounded = roundAreaValue(value);
+    if (!Number.isFinite(rounded)) {
+      return null;
+    }
+    return rounded.toLocaleString('pl-PL', {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1
+    });
+  }
+
   function infoHTML(plot, data, offerId, plotIndex) {
     const price = Number(plot.price || 0);
-    const area  = Number(plot.pow_dzialki_m2_uldk || 0);
-    const ppm2  = price && area ? (price/area).toFixed(0) : null;
+    const areaRaw = Number(plot.pow_dzialki_m2_uldk || 0);
+    const areaDisplay = formatAreaValue(areaRaw);
+    const ppm2  = price && areaRaw > 0 ? (price/areaRaw).toFixed(0) : null;
     const locationLabel = pickDisplayValue(
       [plot.location, plot.city, data.city, data.location],
       "brak"
@@ -2788,7 +2809,7 @@ window.showConfirmModal = showConfirmModal;
         <h3>${plot.Id || "Brak identyfikatora"}</h3>
         <p><b>Miejscowość:</b> ${locationLabel}</p>
         ${price ? `<p><b>Cena:</b> ${price.toLocaleString('pl-PL')} zł${ppm2 ? ` <span style="color:#718096;">(${ppm2} zł/m²)</span>` : ''}</p>` : ''}
-        ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
+        ${areaDisplay ? `<p><b>Powierzchnia:</b> ${areaDisplay} m²</p>` : ''}
         ${shortName ? `<p><b>Imię:</b> ${shortName}</p>` : ''}
         <p><b>Telefon:</b> ${phone || 'brak'}</p>
         <div class="mini-actions center">
@@ -5134,8 +5155,9 @@ window.showConfirmModal = showConfirmModal;
       const card = document.createElement("div");
       card.className = "offer-card offer-card--reverse";
       const price = Number(o.plot.price || 0);
-      const area  = Number(o.plot.pow_dzialki_m2_uldk || 0);
-      const ppm2  = price && area ? (price/area).toFixed(2) : "0.00";
+      const areaRaw = Number(o.plot.pow_dzialki_m2_uldk || 0);
+      const areaDisplay = formatAreaValue(areaRaw);
+      const ppm2  = price && areaRaw > 0 ? (price/areaRaw).toFixed(2) : "0.00";
       const detailsUrl = `details.html?id=${o.id}&plot=${o.index}`;
       const tagList = Array.isArray(o.tags) ? o.tags : [];
       const tagsMarkup = tagList.length
@@ -5154,7 +5176,7 @@ window.showConfirmModal = showConfirmModal;
           ${o.data.firstName ? `<p><b>Imię:</b> ${o.data.firstName}</p>` : ""}
           <p><b>Telefon:</b> ${formatPhone(o.data.phone) || "-"}</p>
           ${price ? `<p><b>Cena całkowita:</b> ${price.toLocaleString('pl-PL')} zł <span style="color:#5b6475;font-size:.85em;margin-left:5px;">${ppm2} zł/m²</span></p>` : ""}
-          ${area  ? `<p><b>Powierzchnia:</b> ${area.toLocaleString('pl-PL')} m²</p>` : ""}
+          ${areaDisplay ? `<p><b>Powierzchnia:</b> ${areaDisplay} m²</p>` : ""}
           ${tagsMarkup}
           <div class="offer-actions center">
             <a
@@ -5351,6 +5373,7 @@ window.showConfirmModal = showConfirmModal;
       key: apiKey,
       callback: 'initMap'
     });
+    params.set('libraries', 'marker');
     script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
     script.async = true;
     script.defer = true;
@@ -5779,8 +5802,9 @@ async function loadUserOffers(email, uid) {
 
       activePlots.forEach(({ plot, originalIndex }, i) => {
         const price = Number(plot.price || 0);
-        const area  = Number(plot.pow_dzialki_m2_uldk || plot.area || plot.areaM2 || 0);
-        const ppm2  = price && area ? Math.round(price/area) : 0;
+        const areaRaw  = Number(plot.pow_dzialki_m2_uldk || plot.area || plot.areaM2 || 0);
+        const areaDisplay = formatAreaValue(areaRaw);
+        const ppm2  = price && areaRaw > 0 ? Math.round(price/areaRaw) : 0;
         const detailsUrl = `details.html?id=${offerId}&plot=${originalIndex}`;
         const locationSources = [plot.location, plot.city, offer.city];
         if (typeof offer.location === 'string') {
@@ -5803,7 +5827,7 @@ async function loadUserOffers(email, uid) {
             <h3 class="offer-title">${plot.Id || `Działka ${i+1}`}</h3>
             <div class="offer-details">
               <p><strong>Lokalizacja:</strong> ${locationLabel}</p>
-              ${area  ? `<p><strong>Powierzchnia:</strong> ${area.toLocaleString('pl-PL')} m²</p>` : ''}
+              ${areaDisplay  ? `<p><strong>Powierzchnia:</strong> ${areaDisplay} m²</p>` : ''}
               ${price ? `<p><strong>Cena całkowita:</strong> ${price.toLocaleString('pl-PL')} zł
                 ${ppm2 ? `<span style="color:#888;font-size:.85em;margin-left:5px;">${ppm2.toLocaleString('pl-PL')} zł/m²</span>`:''}
               </p>` : ''}

--- a/oferty.html
+++ b/oferty.html
@@ -538,6 +538,56 @@ window.showConfirmModal = showConfirmModal;
   let currentVoronoiSupplementary = [];
   let voronoiHiddenOffersInBounds = [];
   let voronoiSupplementaryOffersInBounds = [];
+
+  function normalizeMockFlag(value) {
+    if (value === true) return true;
+    if (value === false) return false;
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (!normalized) return null;
+      if (["false", "0", "no", "nie", "n", "f"].includes(normalized)) {
+        return false;
+      }
+      if (["true", "1", "yes", "tak", "t", "y"].includes(normalized)) {
+        return true;
+      }
+    }
+    if (typeof value === 'number') {
+      if (value === 0) return false;
+      if (value === 1) return true;
+    }
+    return null;
+  }
+
+  function shouldUseOfferForValuation(offer) {
+    if (!offer || typeof offer !== 'object') {
+      return false;
+    }
+
+    const plot = offer.plot && typeof offer.plot === 'object'
+      ? offer.plot
+      : null;
+
+    if (plot) {
+      const plotMock = normalizeMockFlag(plot.mock);
+      if (plotMock !== null) {
+        return plotMock === false;
+      }
+    }
+
+    const offerMock = normalizeMockFlag(offer.mock);
+    if (offerMock !== null) {
+      return offerMock === false;
+    }
+
+    return false;
+  }
+
+  function filterOffersForValuation(offers) {
+    return Array.isArray(offers)
+      ? offers.filter(shouldUseOfferForValuation)
+      : [];
+  }
   const voronoiIndicatorState = {
     hidden: [],
     supplementary: []
@@ -3952,12 +4002,12 @@ window.showConfirmModal = showConfirmModal;
   }
 
   function mergeVoronoiSupplementaryOffers(sourceOffers) {
-    const base = Array.isArray(sourceOffers)
-      ? sourceOffers.filter(Boolean).slice()
-      : [];
-    const supplementaryPool = (currentVoronoiSupplementary.length
+    const base = filterOffersForValuation(Array.isArray(sourceOffers)
+      ? sourceOffers.filter(Boolean)
+      : []);
+    const supplementaryPool = filterOffersForValuation((currentVoronoiSupplementary.length
       ? currentVoronoiSupplementary
-      : voronoiSupplementaryOffers).filter(Boolean);
+      : voronoiSupplementaryOffers).filter(Boolean));
     if (!supplementaryPool.length) {
       return base;
     }
@@ -5094,11 +5144,13 @@ window.showConfirmModal = showConfirmModal;
     currentVoronoiOffers = offersInBounds.slice();
     voronoiHiddenOffersInBounds = offersInBounds.filter(offer => !filteredKeys.has(offer?.key));
 
-    const supplementaryInBounds = voronoiSupplementaryOffers.filter(offer => {
-      const position = getMarkerPositionForOffer(offer);
-      if (!position) return false;
-      return withinBounds(Number(position.lat), Number(position.lng));
-    });
+    const supplementaryInBounds = filterOffersForValuation(
+      voronoiSupplementaryOffers.filter(offer => {
+        const position = getMarkerPositionForOffer(offer);
+        if (!position) return false;
+        return withinBounds(Number(position.lat), Number(position.lng));
+      })
+    );
 
     currentVoronoiSupplementary = supplementaryInBounds.slice();
     voronoiSupplementaryOffersInBounds = supplementaryInBounds.slice();


### PR DESCRIPTION
## Summary
- round plot areas to one decimal place in shared helpers and UI cards
- update offers and dashboard listings to use the new rounded formatting
- load the Google Maps marker library so supplementary valuation crosses render again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b83ce250832b8e3117949a92e77a