### PR TITLE
Display archived plots with red map cross and round area values

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -233,6 +233,32 @@ main.property-wrapper {
   background: #dbe8f7;
 }
 
+#mapSection.is-archived #propertyMap {
+  box-shadow: 0 0 0 2px rgba(255, 59, 48, .35);
+}
+
+#mapSection.is-archived .map-panel {
+  position: relative;
+}
+
+#mapSection.is-archived .map-panel::after {
+  content: 'DANE ARCHIWALNE';
+  position: absolute;
+  top: 1.1rem;
+  right: 1.1rem;
+  background: rgba(255, 59, 48, .92);
+  color: #fff;
+  font-size: .7rem;
+  font-weight: 700;
+  letter-spacing: .08em;
+  padding: .35rem .75rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  z-index: 2;
+  box-shadow: 0 4px 14px rgba(255, 59, 48, .35);
+  pointer-events: none;
+}
+
 .map-image {
   width: 100%;
   height: 360px;

--- a/assets/property-common.js
+++ b/assets/property-common.js
@@ -91,7 +91,10 @@ export function formatCurrency(value) {
 }
 
 export function formatArea(value) {
-  const formatted = formatNumber(value);
+  const formatted = formatNumber(value, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+  });
   return formatted ? `${formatted} m²` : null;
 }
 


### PR DESCRIPTION
## Summary
- round all displayed plot areas to one decimal place for consistent 0.1 m² precision
- allow archived (mock: false) listings to load while flagging them across the UI and Google Map with a red X marker and banner

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2c47f13f0832b8bd900ba8431d125