### PR TITLE
Improve Voronoi toggle styling and map layer labelling

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -272,6 +272,27 @@ main.property-wrapper {
   box-shadow: inset 0 0 0 1px rgba(30,111,186,.08);
 }
 
+.map-image-label {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  margin: 0;
+  padding: .4rem .9rem;
+  background: rgba(12, 13, 17, .82);
+  color: #fff;
+  font-size: .85rem;
+  font-weight: 600;
+  letter-spacing: .02em;
+  border-radius: 999px;
+  box-shadow: 0 12px 32px rgba(12, 13, 17, .25);
+  transition: opacity .2s ease;
+}
+
+.map-image-label.hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+
 .map-image-picture {
   display: block;
   width: 100%;
@@ -293,6 +314,15 @@ main.property-wrapper {
 
 .map-image-picture.is-interactive {
   cursor: zoom-in;
+}
+
+@media (max-width: 640px) {
+  .map-image-label {
+    top: 14px;
+    left: 14px;
+    padding: .35rem .75rem;
+    font-size: .78rem;
+  }
 }
 
 .image-lightbox {

--- a/assets/details.js
+++ b/assets/details.js
@@ -117,6 +117,7 @@ const elements = {
   mapSection: document.getElementById('mapSection'),
   mapElement: document.getElementById('propertyMap'),
   mapImageContainer: document.getElementById('mapImageContainer'),
+  mapImageLabel: document.getElementById('mapImageLabel'),
   mapImageElement: document.getElementById('mapImage'),
   mapImagePlaceholder: document.getElementById('mapImagePlaceholder'),
   plotPreviewImage: document.getElementById('plotPreviewImage'),
@@ -589,6 +590,20 @@ function getMapModeLabel(mode) {
   return button ? button.textContent.trim() : '';
 }
 
+function updateMapImageLabel(label) {
+  if (!elements.mapImageLabel) return;
+  const text = typeof label === 'string' ? label.trim() : '';
+  if (text) {
+    elements.mapImageLabel.textContent = text;
+    elements.mapImageLabel.classList.remove('hidden');
+    elements.mapImageLabel.setAttribute('aria-hidden', 'false');
+  } else {
+    elements.mapImageLabel.textContent = '';
+    elements.mapImageLabel.classList.add('hidden');
+    elements.mapImageLabel.setAttribute('aria-hidden', 'true');
+  }
+}
+
 function setActiveMapButton(mode) {
   elements.mapModeButtons.forEach(btn => {
     if (btn.dataset.mode === mode) {
@@ -603,6 +618,7 @@ function showMapCanvas(mapType) {
   if (elements.mapImageContainer) {
     elements.mapImageContainer.classList.add('hidden');
   }
+  updateMapImageLabel('');
   if (elements.mapImageElement) {
     elements.mapImageElement.src = '';
     elements.mapImageElement.alt = '';
@@ -640,6 +656,7 @@ function showMapImage(key, label) {
     elements.mapElement.classList.add('hidden');
   }
   elements.mapImageContainer.classList.remove('hidden');
+  updateMapImageLabel(label);
 
   if (hasUrl) {
     elements.mapImageElement.src = url;
@@ -1384,6 +1401,7 @@ function handleMapImageError() {
   if (!elements.mapImageElement || !elements.mapImagePlaceholder) return;
   const label = elements.mapImageElement.dataset?.layerLabel;
   const name = label ? `warstwy „${label}”` : 'tej warstwy';
+  updateMapImageLabel(label);
   elements.mapImageElement.src = '';
   elements.mapImageElement.alt = '';
   elements.mapImageElement.classList.add('hidden');

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -100,21 +100,32 @@
 .voronoi-toggle__option {
   position:relative;
   z-index:1;
-  border:0;
+  border:2px solid transparent;
   border-radius:999px;
-  padding:6px 12px;
+  padding:6px 14px;
   font-size:0.78rem;
   font-weight:600;
   color:#1d4ed8;
-  background:rgba(255,255,255,0.35);
+  background:transparent;
   cursor:pointer;
-  transition:color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  transition:color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.voronoi-toggle__option:hover,
+.voronoi-toggle__option:focus-visible {
+  background:rgba(255,255,255,0.45);
 }
 
 .voronoi-toggle__option--active {
-  color:#0b1c4a;
-  background:#e0f2ff;
-  box-shadow:0 6px 14px rgba(30,64,175,0.18);
+  color:#0c0d11;
+  background:#fff;
+  border-color:#0c0d11;
+  box-shadow:0 8px 20px rgba(12,13,17,0.16);
+}
+
+.voronoi-toggle__option--active:hover,
+.voronoi-toggle__option--active:focus-visible {
+  background:#fff;
 }
 
 @media (max-width: 640px) {

--- a/details.html
+++ b/details.html
@@ -189,6 +189,7 @@
           </div>
           <div id="propertyMap" role="region" aria-label="Mapa działki"></div>
           <div id="mapImageContainer" class="map-image hidden" aria-live="polite">
+            <p id="mapImageLabel" class="map-image-label hidden" aria-hidden="true"></p>
             <img id="mapImage" class="map-image-picture hidden" alt="Podgląd warstwy mapy" loading="lazy">
             <p id="mapImagePlaceholder" class="map-image-placeholder hidden">Brak obrazu dla wybranej warstwy.</p>
           </div>


### PR DESCRIPTION
## Summary
- restyled the Voronoi layer toggle so the active option is clearly highlighted with a white fill and dark outline
- added a caption above property map images that shows which map layer is currently displayed
- introduced supporting styles for the new map image caption component

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2cd4b3eb4832bba869957cb422369