### PR TITLE
Add lightbox image source description

### DIFF
--- a/assets/details.css
+++ b/assets/details.css
@@ -351,6 +351,47 @@ main.property-wrapper {
   max-height: 100%;
 }
 
+.image-lightbox__stage.is-scrollable {
+  cursor: grab;
+}
+
+.image-lightbox__stage.is-panning {
+  cursor: grabbing;
+  user-select: none;
+}
+
+.image-lightbox__stage.is-panning .image-lightbox__picture {
+  pointer-events: none;
+}
+
+.image-lightbox__info {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(1rem, 3vw, 2.5rem);
+  transform: translateX(-50%);
+  padding: .5rem 1.25rem;
+  border-radius: 999px;
+  background: rgba(12, 13, 17, .85);
+  color: #fff;
+  font-size: .875rem;
+  font-weight: 500;
+  letter-spacing: .01em;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, .35);
+  pointer-events: none;
+  text-align: center;
+}
+
+.image-lightbox__mode-label {
+  display: inline-block;
+  font-weight: 600;
+}
+
+.image-lightbox--light .image-lightbox__info {
+  background: rgba(12, 13, 17, .8);
+  color: #fff;
+  box-shadow: 0 18px 40px rgba(12, 13, 17, .2);
+}
+
 .image-lightbox__controls {
   position: absolute;
   top: 1.5rem;

--- a/assets/details.css
+++ b/assets/details.css
@@ -381,6 +381,11 @@ main.property-wrapper {
   text-align: center;
 }
 
+.image-lightbox__mode-prefix {
+  margin-right: .375rem;
+  font-weight: 600;
+}
+
 .image-lightbox__mode-label {
   display: inline-block;
   font-weight: 600;

--- a/assets/details.js
+++ b/assets/details.js
@@ -831,8 +831,9 @@ function setLightboxModeLabel(label) {
   if (!info || !labelElement) return;
 
   const text = typeof label === 'string' ? label.trim() : '';
-  if (text) {
-    labelElement.textContent = text;
+  const normalized = text.replace(/^zakładka\s*:\s*/i, '').trim();
+  if (normalized) {
+    labelElement.textContent = normalized;
     info.classList.remove('hidden');
   } else {
     labelElement.textContent = '';

--- a/assets/details.js
+++ b/assets/details.js
@@ -130,6 +130,8 @@ const elements = {
   mapImageLightboxNext: document.getElementById('mapImageLightboxNext'),
   mapImageLightboxZoomIn: document.getElementById('mapImageLightboxZoomIn'),
   mapImageLightboxZoomOut: document.getElementById('mapImageLightboxZoomOut'),
+  mapImageLightboxInfo: document.getElementById('mapImageLightboxInfo'),
+  mapImageLightboxModeLabel: document.getElementById('mapImageLightboxModeLabel'),
   backToOffersBtn: document.getElementById('backToOffersBtn'),
   authButtons: document.getElementById('authButtons'),
   userMenu: document.getElementById('userMenu'),
@@ -823,6 +825,21 @@ function applyLightboxTheme(mode) {
   elements.mapImageLightbox.classList.toggle('image-lightbox--light', useLightTheme);
 }
 
+function setLightboxModeLabel(label) {
+  const info = elements.mapImageLightboxInfo;
+  const labelElement = elements.mapImageLightboxModeLabel;
+  if (!info || !labelElement) return;
+
+  const text = typeof label === 'string' ? label.trim() : '';
+  if (text) {
+    labelElement.textContent = `„${text}”`;
+    info.classList.remove('hidden');
+  } else {
+    labelElement.textContent = '';
+    info.classList.add('hidden');
+  }
+}
+
 function getAvailableLightboxModes() {
   return (elements.mapModeButtons || [])
     .map(btn => btn?.dataset?.mode)
@@ -878,6 +895,7 @@ function showLightboxImage(mode, options = {}) {
   elements.mapImageLightboxPicture.src = url;
   elements.mapImageLightboxPicture.alt = accessibleLabel;
 
+  setLightboxModeLabel(label);
   applyLightboxTheme(mode);
   setLightboxNavigationState();
   prepareLightboxZoom(preserveZoom);
@@ -961,6 +979,7 @@ function closeMapImageLightbox() {
     elements.mapImageLightboxPicture.src = '';
     elements.mapImageLightboxPicture.alt = '';
   }
+  setLightboxModeLabel('');
   document.body.classList.remove('lightbox-open');
   state.isLightboxOpen = false;
   state.lightboxImageModes = [];

--- a/assets/details.js
+++ b/assets/details.js
@@ -832,7 +832,7 @@ function setLightboxModeLabel(label) {
 
   const text = typeof label === 'string' ? label.trim() : '';
   if (text) {
-    labelElement.textContent = `„${text}”`;
+    labelElement.textContent = text;
     info.classList.remove('hidden');
   } else {
     labelElement.textContent = '';

--- a/details.html
+++ b/details.html
@@ -510,6 +510,9 @@
       >
         <i class="fas fa-chevron-right" aria-hidden="true"></i>
       </button>
+      <div class="image-lightbox__info hidden" id="mapImageLightboxInfo" aria-live="polite">
+        Zdjęcie pochodzi z zakładki <span id="mapImageLightboxModeLabel" class="image-lightbox__mode-label"></span>
+      </div>
     </div>
   </div>
 

--- a/details.html
+++ b/details.html
@@ -511,7 +511,8 @@
         <i class="fas fa-chevron-right" aria-hidden="true"></i>
       </button>
       <div class="image-lightbox__info hidden" id="mapImageLightboxInfo" aria-live="polite">
-        zakładka: <span id="mapImageLightboxModeLabel" class="image-lightbox__mode-label"></span>
+        <span class="image-lightbox__mode-prefix">Zakładka:</span>
+        <span id="mapImageLightboxModeLabel" class="image-lightbox__mode-label"></span>
       </div>
     </div>
   </div>

--- a/details.html
+++ b/details.html
@@ -511,7 +511,7 @@
         <i class="fas fa-chevron-right" aria-hidden="true"></i>
       </button>
       <div class="image-lightbox__info hidden" id="mapImageLightboxInfo" aria-live="polite">
-        Zdjęcie pochodzi z zakładki <span id="mapImageLightboxModeLabel" class="image-lightbox__mode-label"></span>
+        zakładka: <span id="mapImageLightboxModeLabel" class="image-lightbox__mode-label"></span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a description in the map lightbox that names the source tab of the displayed image
- style the new lightbox information pill and prepare stage cursor styles
- update lightbox logic to populate and reset the description text

## Testing
- not run (static front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68e2e1745f34832bb0dbfd80c8d31592