### PR TITLE
Fix desktop filters panel overlap

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -368,9 +368,9 @@
   }
 
   .sidebar-stack {
-    position:sticky;
-    top:24px;
-    z-index:5;
+    position:static;
+    top:auto;
+    z-index:auto;
   }
 }
 

--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -31,6 +31,8 @@
   flex-direction:column;
   gap:22px;
   margin-bottom:24px;
+  position:relative;
+  z-index:0;
 }
 
 .voronoi-panel {
@@ -354,10 +356,18 @@
   gap:1.15rem;
   backdrop-filter:blur(14px);
   -webkit-backdrop-filter:blur(14px);
+  position:relative;
+  z-index:1;
 }
 
 .sidebar-stack .filters-panel {
   margin-bottom:0;
+}
+
+.sidebar-stack + .offers-section {
+  position:relative;
+  z-index:2;
+  margin-top:32px;
 }
 
 @media (min-width:993px){


### PR DESCRIPTION
## Summary
- stop using sticky positioning for the desktop filters sidebar so it no longer overlaps the "Moje Oferty" section

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e39482c684832ba3bd83e4524946e3