### PR TITLE
Adjust offer thumbnails and add mobile map scroll helper

### DIFF
--- a/assets/oferty.css
+++ b/assets/oferty.css
@@ -712,8 +712,9 @@
 }
 
 .offers-list .offer-card__media{
-  flex-basis:240px;
-  min-height:160px;
+  flex-basis:200px;
+  max-width:200px;
+  min-height:140px;
 }
 
 .offers-list .offer-card{align-items:stretch;}

--- a/oferty.html
+++ b/oferty.html
@@ -1902,6 +1902,23 @@ window.showConfirmModal = showConfirmModal;
     }
   }
 
+  function scrollMapIntoViewIfMobile() {
+    if (typeof window === 'undefined') return;
+    const isMobile = window.matchMedia
+      ? window.matchMedia('(max-width: 1024px)').matches
+      : window.innerWidth <= 1024;
+    if (!isMobile) return;
+
+    const container = document.querySelector('.map-container');
+    if (!container) return;
+
+    try {
+      container.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } catch (error) {
+      container.scrollIntoView();
+    }
+  }
+
   function focusOfferFromMapState() {
     if (!map || !pendingMapState || !pendingMapState.focusOfferId) return;
     const { focusOfferId } = pendingMapState;
@@ -1944,7 +1961,7 @@ window.showConfirmModal = showConfirmModal;
         plotIndex: Number.isInteger(match.index) ? match.index : null,
         skipMapStateUpdate: true
       });
-      document.querySelector('.map-container')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      scrollMapIntoViewIfMobile();
     }
 
     clearStoredMapState();
@@ -5177,6 +5194,7 @@ window.showConfirmModal = showConfirmModal;
           offerId: typeof o.id === 'string' ? o.id : null,
           plotIndex: Number.isInteger(o.index) ? o.index : null
         });
+        scrollMapIntoViewIfMobile();
       });
 
       listContainer.appendChild(card);
@@ -5215,7 +5233,7 @@ window.showConfirmModal = showConfirmModal;
       offerId: typeof match.id === 'string' ? match.id : null,
       plotIndex: Number.isInteger(match.index) ? match.index : null
     });
-    document.querySelector('.map-container')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    scrollMapIntoViewIfMobile();
   };
 
   // ładowanie Google Maps


### PR DESCRIPTION
## Summary
- shrink the offer list preview images for better readability
- scroll the map into view on mobile when focusing an offer card
- reuse the same mobile scroll helper for saved map state and My Offers links

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e399835d90832bac8a263940c4a4a9